### PR TITLE
GH-7: clarification-query-1

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -5709,10 +5709,10 @@ WHERE {
             <p>Errors in comparisons cause the <code>IN</code> expression to raise an error if the
               RDF term being tested is not found elsewhere in the list of terms.</p>
             <p>The <code>IN</code> operator is equivalent to the SPARQL expression:</p>
-            <pre>(rdfterm = expression1) || (rdfterm = expression2) || ...</pre>
+            <pre>(rdfTerm = expression1) || (rdfTerm = expression2) || ...</pre>
             <p>
               If <code>IN</code> is used with an expression to produce the
-              <code>rdfterm</code> then that expression is evaluated only once, 
+              <code>rdfTerm</code> then that expression is evaluated only once, 
               before evaluating the <code>IN</code> expression.
             </p>
             <p>Examples:</p>
@@ -5761,10 +5761,10 @@ WHERE {
               the RDF term being tested is not found to be elsewhere in the list of
               terms.</p>
             <p>The <code>NOT IN</code> operator is equivalent to the SPARQL expression:</p>
-            <pre>(rdfterm != expression1) &amp;& (rdfterm != expression2) &amp;& ...</pre>
+            <pre>(rdfTerm != expression1) &amp;& (rdfTerm != expression2) &amp;& ...</pre>
             <p>
               If <code>NOT IN</code> is used with an expression to produce the
-              <code>rdfterm</code>, then that expression is evaluated only once, 
+              <code>rdfTerm</code>, then that expression is evaluated only once, 
               before evaluating the <code>NOT IN</code> expression.
             </p>
             <p><code>NOT IN (...)</code> is equivalent to <code>!(IN (...))</code>.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -5754,7 +5754,7 @@ WHERE {
 </pre>
             <p>The <code>NOT IN</code> operator tests whether the RDF term on the left-hand side is
               not found in the values of list of the expressions on the right-hand side. The test is done
-              with "!=" operator, which tests for being not the same value, as determined by the 
+              with "!=" operator, which tests that two values are not the same value, as determined by the 
               <a href="#OperatorMapping">operator mapping</a>.</p>
             <p>A list of zero terms on the right-hand side is legal.</p>
             <p>Errors in comparisons cause the <code>NOT IN</code> expression to raise an error if

--- a/spec/index.html
+++ b/spec/index.html
@@ -5758,7 +5758,7 @@ WHERE {
               <a href="#OperatorMapping">operator mapping</a>.</p>
             <p>A list of zero terms on the right-hand side is legal.</p>
             <p>Errors in comparisons cause the <code>NOT IN</code> expression to raise an error if
-              the RDF term being tested is not found to be in the list elsewhere in the list of
+              the RDF term being tested is not found to be elsewhere in the list of
               terms.</p>
             <p>The <code>NOT IN</code> operator is equivalent to the SPARQL expression:</p>
             <pre>(rdfterm != expression1) &amp;& (rdfterm != expression2) &amp;& ...</pre>

--- a/spec/index.html
+++ b/spec/index.html
@@ -5702,14 +5702,19 @@ WHERE {
 <span class="return">boolean</span>  rdfTerm <span class="operator">IN</span> (<span class="expression">expression</span>, <span class="expression">...</span>)
             </pre>
             <p>The <code>IN</code> operator tests whether the RDF term on the left-hand side is found
-              in the values of list of expressions on the right-hand side. The test is done with "="
+              in the list of values of the expressions on the right-hand side. The test is done with "="
               operator, which tests for the same value, as determined by the 
               <a href="#OperatorMapping">operator mapping</a>.</p>
             <p>A list of zero terms on the right-hand side is legal.</p>
             <p>Errors in comparisons cause the <code>IN</code> expression to raise an error if the
               RDF term being tested is not found elsewhere in the list of terms.</p>
             <p>The <code>IN</code> operator is equivalent to the SPARQL expression:</p>
-            <pre>(lhs = expression1) || (lhs = expression2) || ...</pre>
+            <pre>(rdfterm = expression1) || (rdfterm = expression2) || ...</pre>
+            <p>
+              If <code>IN</code> is used with an expression to produce the
+              <code>rdfterm</code> then that expression is evaluated only once, 
+              before evaluating the <code>IN</code> expression.
+            </p>
             <p>Examples:</p>
             <div class="result">
               <table>
@@ -5748,15 +5753,20 @@ WHERE {
 <span class="return">boolean</span>  rdfTerm <span class="operator">NOT IN</span> (<span class="expression">expression</span>, <span class="expression">...</span>)
 </pre>
             <p>The <code>NOT IN</code> operator tests whether the RDF term on the left-hand side is
-              not found in the values of list of expressions on the right-hand side. The test is done
-              with "!=" operator, which tests for not the same value, as determined by the <a href=
-                                                                                              "#OperatorMapping">operator mapping</a>.</p>
+              not found in the values of list of the expressions on the right-hand side. The test is done
+              with "!=" operator, which tests for being not the same value, as determined by the 
+              <a href="#OperatorMapping">operator mapping</a>.</p>
             <p>A list of zero terms on the right-hand side is legal.</p>
             <p>Errors in comparisons cause the <code>NOT IN</code> expression to raise an error if
               the RDF term being tested is not found to be in the list elsewhere in the list of
               terms.</p>
             <p>The <code>NOT IN</code> operator is equivalent to the SPARQL expression:</p>
-            <pre>(lhs != expression1) &amp;& (lhs != expression2) &amp;& ...</pre>
+            <pre>(rdfterm != expression1) &amp;& (rdfterm != expression2) &amp;& ...</pre>
+            <p>
+              If <code>NOT IN</code> is used with an expression to produce the
+              <code>rdfterm</code> then that expression is evaluated only once, 
+              before evaluating the <code>NOT IN</code> expression.
+            </p>
             <p><code>NOT IN (...)</code> is equivalent to <code>!(IN (...))</code>.</p>
             <p>Examples:</p>
             <div class="result">

--- a/spec/index.html
+++ b/spec/index.html
@@ -5764,7 +5764,7 @@ WHERE {
             <pre>(rdfterm != expression1) &amp;& (rdfterm != expression2) &amp;& ...</pre>
             <p>
               If <code>NOT IN</code> is used with an expression to produce the
-              <code>rdfterm</code> then that expression is evaluated only once, 
+              <code>rdfterm</code>, then that expression is evaluated only once, 
               before evaluating the <code>NOT IN</code> expression.
             </p>
             <p><code>NOT IN (...)</code> is equivalent to <code>!(IN (...))</code>.</p>


### PR DESCRIPTION
#7 clarification-query-1

There is no substantive change here because the rules of function evaluation apply.

It is correcting the explanation of the `IN` operator as noted by the original errata report. It also applies to `NOT IN`.

***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/15.html" title="Last updated on Feb 24, 2023, 11:52 AM UTC (49cc904)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/15/b64a563...49cc904.html" title="Last updated on Feb 24, 2023, 11:52 AM UTC (49cc904)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/15.html" title="Last updated on Feb 26, 2023, 9:48 AM UTC (78f0670)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/15/b64a563...78f0670.html" title="Last updated on Feb 26, 2023, 9:48 AM UTC (78f0670)">Diff</a>