### PR TITLE
GH-7: clarification-query-2

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -5220,8 +5220,8 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
           <h4>Operator Extensibility</h4>
           <p>SPARQL language extensions may provide additional associations between operators and
             operator functions; this amounts to adding rows to the table above. No additional operator
-            may yield a result that replaces any result other than a type error in the semantics
-            defined above. The consequence of this rule is that SPARQL <code>FILTER</code>s will
+            may yield a result that replaces any result other than a type error.
+            The consequence of this rule is that SPARQL <code>FILTER</code>s will
             produce <em>at least</em> the same intermediate bindings after applying a
             <code>FILTER</code> as an unextended implementation.</p>
           <p>Additional mappings of the '&lt;' operator are expected to control the relative ordering


### PR DESCRIPTION
The reason for this change is in the email thread at: 

https://lists.w3.org/Archives/Public/public-rdf-dawg-comments/2013Jul/0004.html

Summary: a processor can use the fact two value spaces are distinct to provide the result of `!=` where otherwise it would be an an error.

Thanks to Rob Vesse for the analysis.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/16.html" title="Last updated on Feb 26, 2023, 6:05 PM UTC (d45e1ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/16/b64a563...d45e1ac.html" title="Last updated on Feb 26, 2023, 6:05 PM UTC (d45e1ac)">Diff</a>