### PR TITLE
Resolve clarification-query-3, #7

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -5462,29 +5462,33 @@ class="expression">expression, ....</span>)
                                                                                    "type">RDF term</span> <span class="name">term1</span> <span class=
                                                                                                                                                 "operator">=</span> <span class="type">RDF term</span> <span class=
                                                                                                                                                                                                              "name">term2</span></pre>
-            <p>Returns TRUE if <code>term1</code> and <code>term2</code> are the same RDF term as
-              defined in [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]; produces a type error if the
-              arguments are both literal but are not the same RDF term <sup><a href=
-                                                                               "#func-RDFterm-equal-foot1" class="footnote">*</a></sup>; returns FALSE otherwise.
-              <code>term1</code> and <code>term2</code> are the same if any of the following is
+            <p>Returns TRUE if <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms as defined below;
+              produces a type error if the arguments are both literals with the same datatype that is unsupported by the implementation but are not the same RDF term <sup><a href="#func-RDFterm-equal-foot1" class="footnote">*</a></sup>;
+              returns FALSE otherwise.</p>
+            <p>
+              <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms if any of the following is
               true:</p>
             <ul>
               <li>
-                <span class="name">term1</span> and <span class="name">term2</span> are equivalent
+                <span class="name">term1</span> and <span class="name">term2</span> are equal
                 <span class="IRI type">IRIs</span> as defined in <a data-cite=
-                                                                    "RDF12-CONCEPTS#section-Graph-URIref">6.4 RDF URI References</a> of
+                                                                    "RDF12-CONCEPTS#dfn-iri-equality">IRI quality</a> of
                 [[RDF12-CONCEPTS]].
               </li>
               <li>
-                <span class="name">term1</span> and <span class="name">term2</span> are equivalent
+                <span class="name">term1</span> and <span class="name">term2</span> are equal
                 <span class="literal type">literals</span> as defined in <a data-cite=
-                                                                            "RDF12-CONCEPTS#section-Literal-Equality">6.5.1 Literal Equality</a> of
+                                                                            "RDF12-CONCEPTS#dfn-term-equal">Literal term equality</a> of
                 [[RDF12-CONCEPTS]].
+              </li>
+              <li>
+                <span class="name">term1</span> and <span class="name">term2</span> are
+                <span class="literal type">literals</span> with equivalent values according to their datatypes.
               </li>
               <li>
                 <span class="name">term1</span> and <span class="name">term2</span> are the same
                 <span class="bnode type">blank node</span> as described in <a data-cite=
-                                                                              "RDF12-CONCEPTS#section-blank-nodes">6.6 Blank Nodes</a> of [[RDF12-CONCEPTS]].
+                                                                              "RDF12-CONCEPTS#section-blank-nodes">Blank Nodes</a> of [[RDF12-CONCEPTS]].
               </li>
             </ul>
             <div class="exampleGroup">
@@ -5532,7 +5536,7 @@ WHERE {
             </div>
             <p>In this query for documents that were annotated at a specific date and time (New
               Year's Day 2005, measures in timezone +00:00), the RDF terms are not the same, but have
-              equivalent values:</p>
+              equivalent values according to their datatype:</p>
             <div class="exampleGroup">
               <pre class="data">
 @prefix a:          &lt;http://www.w3.org/2000/10/annotation-ns#&gt; .

--- a/spec/index.html
+++ b/spec/index.html
@@ -5470,8 +5470,8 @@ class="expression">expression, ....</span>)
               true:</p>
             <ul>
               <li>
-                <span class="name">term1</span> and <span class="name">term2</span> are equal
-                <span class="IRI type">IRIs</span> as defined in <a data-cite=
+                <span class="name">term1</span> is an <span class="IRI type">IRI</span> and <span class="name">term2</span> is an <span class="IRI type">IRI</span>
+                such that these two <span class="IRI type">IRIs</span> are equal as per the notion of <a data-cite=
                                                                     "RDF12-CONCEPTS#dfn-iri-equality">IRI quality</a> of
                 [[RDF12-CONCEPTS]].
               </li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -5462,12 +5462,14 @@ class="expression">expression, ....</span>)
                                                                                    "type">RDF term</span> <span class="name">term1</span> <span class=
                                                                                                                                                 "operator">=</span> <span class="type">RDF term</span> <span class=
                                                                                                                                                                                                              "name">term2</span></pre>
-            <p>Returns TRUE if <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms as defined below;
-              produces a type error if <code>term1</code> and <code>term2</code> are both literals that have the
+            <p>The behavior of this operator is defined as follows:</p>
+            <ul>
+                <li>Returns TRUE if <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms, as defined below.</li>
+                <li>Produces a type error if <code>term1</code> and <code>term2</code> are both literals that have the
               same <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>, this datatype IRI is <em>not</em> in the
-              set of <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>, and
-              the two literals are <em>not</em> the same RDF term;
-              returns FALSE otherwise.</p>
+              set of <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>.</li>
+                <li>Returns FALSE otherwise.</li>
+            </ul>
             <p id="func-RDFterm-equal-note1" class="note">
               An extended implementation may have support for additional datatypes. An
               implementation processing a query that tests for equivalence on non-recognized datatypes

--- a/spec/index.html
+++ b/spec/index.html
@@ -5502,10 +5502,10 @@ class="expression">expression, ....</span>)
               </li>
             </ul>
             <p id="func-RDFterm-equal-note1" class="note">
-              An extended implementation may have support for additional datatypes. An
-              implementation processing a query that tests for equivalence on non-recognized datatypes
+              An extended implementation may support additional datatypes for literals. An
+              implementation processing a query that tests for equivalence of literals with non-recognized datatypes
               (and non-identical lexical form and datatype IRI) returns an error, indicating that it
-              was unable to determine whether or not the values are equivalent. For example, an
+              is unable to determine whether or not the values of the compared literals are equivalent. For example, an
               unextended implementation will produce an error when testing either <span class=
                                                                                         "queryExcerpt"><code>"iiii"^^my:romanNumeral =
                   "iv"^^my:romanNumeral</code></span> or <span class=

--- a/spec/index.html
+++ b/spec/index.html
@@ -5466,8 +5466,18 @@ class="expression">expression, ....</span>)
               produces a type error if <code>term1</code> and <code>term2</code> are both literals that have the
               same <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>, this datatype IRI is <em>not</em> in the
               set of <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>, and
-              the two literals are <em>not</em> the same RDF term <sup><a href="#func-RDFterm-equal-foot1" class="footnote">*</a></sup>;
+              the two literals are <em>not</em> the same RDF term;
               returns FALSE otherwise.</p>
+            <p id="func-RDFterm-equal-note1" class="note">
+              An extended implementation may have support for additional datatypes. An
+              implementation processing a query that tests for equivalence on non-recognized datatypes
+              (and non-identical lexical form and datatype IRI) returns an error, indicating that it
+              was unable to determine whether or not the values are equivalent. For example, an
+              unextended implementation will produce an error when testing either <span class=
+                                                                                        "queryExcerpt"><code>"iiii"^^my:romanNumeral =
+                  "iv"^^my:romanNumeral</code></span> or <span class=
+                                                               "queryExcerpt"><code>"iiii"^^my:romanNumeral !=
+                  "iv"^^my:romanNumeral</code></span>.</p>
             <p>
               <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms if any of the following is
               true:</p>
@@ -5578,18 +5588,6 @@ WHERE {
                   </table>
                 </div>
               </div>
-            </div>
-            <div id="func-RDFterm-equal-foot1" class="footnote">
-              <p><sup>*</sup> Invoking RDFterm-equal on two typed literals tests for equivalent
-                values. An extended implementation may have support for additional datatypes. An
-                implementation processing a query that tests for equivalence on unsupported datatypes
-                (and non-identical lexical form and datatype IRI) returns an error, indicating that it
-                was unable to determine whether or not the values are equivalent. For example, an
-                unextended implementation will produce an error when testing either <span class=
-                                                                                          "queryExcerpt"><code>"iiii"^^my:romanNumeral =
-                    "iv"^^my:romanNumeral</code></span> or <span class=
-                                                                 "queryExcerpt"><code>"iiii"^^my:romanNumeral !=
-                    "iv"^^my:romanNumeral</code></span>.</p>
             </div>
           </section>
           <section id="func-sameTerm">

--- a/spec/index.html
+++ b/spec/index.html
@@ -5476,8 +5476,9 @@ class="expression">expression, ....</span>)
                 [[RDF12-CONCEPTS]].
               </li>
               <li>
-                <span class="name">term1</span> and <span class="name">term2</span> are equal
-                <span class="literal type">literals</span> as defined in <a data-cite=
+                <span class="name">term1</span> is a <span class="literal type">literal</span> and
+                <span class="name">term2</span> is a <span class="literal type">literal</span> such that
+                these two <span class="literal type">literals</span> are equal as per the notion of <a data-cite=
                                                                             "RDF12-CONCEPTS#dfn-term-equal">Literal term equality</a> of
                 [[RDF12-CONCEPTS]].
               </li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -5470,16 +5470,6 @@ class="expression">expression, ....</span>)
               set of <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>.</li>
                 <li>Returns FALSE otherwise.</li>
             </ul>
-            <p id="func-RDFterm-equal-note1" class="note">
-              An extended implementation may have support for additional datatypes. An
-              implementation processing a query that tests for equivalence on non-recognized datatypes
-              (and non-identical lexical form and datatype IRI) returns an error, indicating that it
-              was unable to determine whether or not the values are equivalent. For example, an
-              unextended implementation will produce an error when testing either <span class=
-                                                                                        "queryExcerpt"><code>"iiii"^^my:romanNumeral =
-                  "iv"^^my:romanNumeral</code></span> or <span class=
-                                                               "queryExcerpt"><code>"iiii"^^my:romanNumeral !=
-                  "iv"^^my:romanNumeral</code></span>.</p>
             <p>
               <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms if any of the following is
               true:</p>
@@ -5511,6 +5501,16 @@ class="expression">expression, ....</span>)
                 <span class="bnode type">blank node</span>.
               </li>
             </ul>
+            <p id="func-RDFterm-equal-note1" class="note">
+              An extended implementation may have support for additional datatypes. An
+              implementation processing a query that tests for equivalence on non-recognized datatypes
+              (and non-identical lexical form and datatype IRI) returns an error, indicating that it
+              was unable to determine whether or not the values are equivalent. For example, an
+              unextended implementation will produce an error when testing either <span class=
+                                                                                        "queryExcerpt"><code>"iiii"^^my:romanNumeral =
+                  "iv"^^my:romanNumeral</code></span> or <span class=
+                                                               "queryExcerpt"><code>"iiii"^^my:romanNumeral !=
+                  "iv"^^my:romanNumeral</code></span>.</p>
             <div class="exampleGroup">
               <pre class="data">
 @prefix foaf:       &lt;http://xmlns.com/foaf/0.1/&gt; .

--- a/spec/index.html
+++ b/spec/index.html
@@ -5462,7 +5462,7 @@ class="expression">expression, ....</span>)
                                                                                    "type">RDF term</span> <span class="name">term1</span> <span class=
                                                                                                                                                 "operator">=</span> <span class="type">RDF term</span> <span class=
                                                                                                                                                                                                              "name">term2</span></pre>
-            <p>The behavior of this operator is defined as follows:</p>
+            <p>This function is defined as follows:</p>
             <ul>
                 <li>Returns TRUE if <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms, as defined below.</li>
                 <li>Produces a type error if <code>term1</code> and <code>term2</code> are both literals that have the

--- a/spec/index.html
+++ b/spec/index.html
@@ -5482,8 +5482,13 @@ class="expression">expression, ....</span>)
                 [[RDF12-CONCEPTS]].
               </li>
               <li>
-                <span class="name">term1</span> and <span class="name">term2</span> are
-                <span class="literal type">literals</span> with equivalent values according to their datatypes.
+                <span class="name">term1</span> is a <span class="literal type">literal</span> and
+                <span class="name">term2</span> is a <span class="literal type">literal</span>
+                such that the <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>
+                of these two literals is the same, this IRI is in the set of
+                <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>,
+                and the <a data-cite="RDF12-CONCEPTS#dfn-literal-value">literal value</a>
+                associated with both literals is the same.
               </li>
               <li>
                 <span class="name">term1</span> and <span class="name">term2</span> are the same

--- a/spec/index.html
+++ b/spec/index.html
@@ -5463,7 +5463,10 @@ class="expression">expression, ....</span>)
                                                                                                                                                 "operator">=</span> <span class="type">RDF term</span> <span class=
                                                                                                                                                                                                              "name">term2</span></pre>
             <p>Returns TRUE if <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms as defined below;
-              produces a type error if the arguments are both literals with the same datatype that is unsupported by the implementation but are not the same RDF term <sup><a href="#func-RDFterm-equal-foot1" class="footnote">*</a></sup>;
+              produces a type error if <code>term1</code> and <code>term2</code> are both literals that have the
+              same <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>, this datatype IRI is <em>not</em> in the
+              set of <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>, and
+              the two literals are <em>not</em> the same RDF term <sup><a href="#func-RDFterm-equal-foot1" class="footnote">*</a></sup>;
               returns FALSE otherwise.</p>
             <p>
               <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms if any of the following is

--- a/spec/index.html
+++ b/spec/index.html
@@ -5494,7 +5494,7 @@ class="expression">expression, ....</span>)
                 such that the <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>
                 of each of these two literals is in the set of
                 <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>
-                and both literals have the <a data-cite="RDF12-CONCEPTS#dfn-literal-value">literal value</a>.
+                and both literals have the same <a data-cite="RDF12-CONCEPTS#dfn-literal-value">literal value</a>.
               </li>
               <li>
                 <span class="name">term1</span> and <span class="name">term2</span> are the same

--- a/spec/index.html
+++ b/spec/index.html
@@ -5492,7 +5492,7 @@ class="expression">expression, ....</span>)
                 of these two literals is the same, this IRI is in the set of
                 <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>,
                 and the <a data-cite="RDF12-CONCEPTS#dfn-literal-value">literal values</a>
-                associated with both literals is the same.
+                associated with both literals are the same value.
               </li>
               <li>
                 <span class="name">term1</span> and <span class="name">term2</span> are the same

--- a/spec/index.html
+++ b/spec/index.html
@@ -5493,9 +5493,8 @@ class="expression">expression, ....</span>)
                 <span class="name">term2</span> is a <span class="literal type">literal</span>
                 such that the <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>
                 of each of these two literals is in the set of
-                <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>,
-                and the <a data-cite="RDF12-CONCEPTS#dfn-literal-value">literal values</a>
-                associated with both literals are the same value.
+                <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>
+                and both literals have the <a data-cite="RDF12-CONCEPTS#dfn-literal-value">literal value</a>.
               </li>
               <li>
                 <span class="name">term1</span> and <span class="name">term2</span> are the same

--- a/spec/index.html
+++ b/spec/index.html
@@ -5491,7 +5491,7 @@ class="expression">expression, ....</span>)
                 such that the <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>
                 of these two literals is the same, this IRI is in the set of
                 <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>,
-                and the <a data-cite="RDF12-CONCEPTS#dfn-literal-value">literal value</a>
+                and the <a data-cite="RDF12-CONCEPTS#dfn-literal-value">literal values</a>
                 associated with both literals is the same.
               </li>
               <li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -5465,9 +5465,10 @@ class="expression">expression, ....</span>)
             <p>This function is defined as follows:</p>
             <ul>
                 <li>Returns TRUE if <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms, as defined below.</li>
-                <li>Produces a type error if <code>term1</code> and <code>term2</code> are both literals that have the
+                <li>Produces a type error if <code>term1</code> and <code>term2</code> are both literals such that these two literals have the
               same <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>, this datatype IRI is <em>not</em> in the
-              set of <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>.</li>
+              set of <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>, and the
+              <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical forms</a> of the two literals are different from one another.</li>
                 <li>Returns FALSE otherwise.</li>
             </ul>
             <p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -5492,7 +5492,7 @@ class="expression">expression, ....</span>)
                 <span class="name">term1</span> is a <span class="literal type">literal</span> and
                 <span class="name">term2</span> is a <span class="literal type">literal</span>
                 such that the <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>
-                of these two literals is the same, this IRI is in the set of
+                of each of these two literals is in the set of
                 <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>,
                 and the <a data-cite="RDF12-CONCEPTS#dfn-literal-value">literal values</a>
                 associated with both literals are the same value.

--- a/spec/index.html
+++ b/spec/index.html
@@ -5472,7 +5472,7 @@ class="expression">expression, ....</span>)
               <li>
                 <span class="name">term1</span> is an <span class="IRI type">IRI</span> and <span class="name">term2</span> is an <span class="IRI type">IRI</span>
                 such that these two <span class="IRI type">IRIs</span> are equal as per the notion of <a data-cite=
-                                                                    "RDF12-CONCEPTS#dfn-iri-equality">IRI quality</a> of
+                                                                    "RDF12-CONCEPTS#dfn-iri-equality">IRI equality</a> of
                 [[RDF12-CONCEPTS]].
               </li>
               <li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -5493,8 +5493,7 @@ class="expression">expression, ....</span>)
               </li>
               <li>
                 <span class="name">term1</span> and <span class="name">term2</span> are the same
-                <span class="bnode type">blank node</span> as described in <a data-cite=
-                                                                              "RDF12-CONCEPTS#section-blank-nodes">Blank Nodes</a> of [[RDF12-CONCEPTS]].
+                <span class="bnode type">blank node</span>.
               </li>
             </ul>
             <div class="exampleGroup">

--- a/spec/index.html
+++ b/spec/index.html
@@ -5465,9 +5465,9 @@ class="expression">expression, ....</span>)
             <p>This function is defined as follows:</p>
             <ul>
                 <li>Returns TRUE if <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms, as defined below.</li>
-                <li>Produces a type error if <code>term1</code> and <code>term2</code> are both literals such that these two literals have the
-              same <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>, this datatype IRI is <em>not</em> in the
-              set of <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>, and the
+                <li>Produces a type error if <code>term1</code> and <code>term2</code> are both literals having the
+              same <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>; this datatype IRI is <em>not</em> in the
+              set of <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>; and the
               <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical forms</a> of the two literals are different from one another.</li>
                 <li>Returns FALSE otherwise.</li>
             </ul>


### PR DESCRIPTION
This PR resolves [clarification-query-3](https://www.w3.org/2013/sparql-errata#clarification-query-3) by rephrasing the equality definition.
I also had to update some of the references, as they were pointing to outdated specs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/17.html" title="Last updated on Mar 15, 2023, 6:10 PM UTC (31a68e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/17/7de93fb...31a68e6.html" title="Last updated on Mar 15, 2023, 6:10 PM UTC (31a68e6)">Diff</a>