### PR TITLE
errata-query-3

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -10905,7 +10905,7 @@ _:x rdf:type xsd:decimal .
                 <td><code><span class="doc-ref" id="rPropertyListPathNotEmpty">PropertyListPathNotEmpty</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code>( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> ( <span class="token">';'</span> ( ( <a href=
-                                                                                                                                                                                              "#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectList">ObjectList</a> )? )*</code></td>
+                                                                                                                                                                                              "#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> )? )*</code></td>
               </tr>
               <tr style="vertical-align: baseline">
                 <td><code>[84]&nbsp;&nbsp;</code></td>


### PR DESCRIPTION
https://www.w3.org/2013/sparql-errata#errata-query-3

This fixes an obvious mistake in the grammar.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/20.html" title="Last updated on Mar 6, 2023, 7:13 PM UTC (b75d98f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/20/7de93fb...b75d98f.html" title="Last updated on Mar 6, 2023, 7:13 PM UTC (b75d98f)">Diff</a>