### PR TITLE
errata-query-7,7a (#29)

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9438,21 +9438,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             Join(Ω<sub>1</sub>, Ω<sub>2</sub>))](μ) + card[Diff(Ω<sub>1</sub>, Ω<sub>2</sub>,
             expr)](μ)</p>
         </div>
-        <p>Written in full that is:</p>
-        <p>LeftJoin(Ω<sub>1</sub>, Ω<sub>2</sub>, expr) =<br>
-          &nbsp;&nbsp;&nbsp; { merge(μ<sub>1,</sub> μ<sub>2</sub>) | μ<sub>1</sub> in Ω<sub>1</sub>
-          and μ<sub>2</sub> in Ω<sub>2</sub>, μ<sub>1</sub> and μ<sub>2</sub> are compatible and
-          expr(merge(μ<sub>1</sub>, μ<sub>2</sub>)) is true }<br>
-          ∪<br>
-          &nbsp;&nbsp;&nbsp; { μ<sub>1</sub> | μ<sub>1</sub> in Ω<sub>1</sub>, ∀ μ<sub>2</sub> in
-          Ω<sub>2</sub>, μ<sub>1</sub> and μ<sub>2</sub> are not compatible, or Ω<sub>2</sub> is
-          empty }<br>
-          ∪<br>
-          &nbsp;&nbsp;&nbsp; { μ<sub>1</sub> | μ<sub>1</sub> in Ω<sub>1</sub>, ∃ μ<sub>2</sub> in
-          Ω<sub>2</sub>, μ<sub>1</sub> and μ<sub>2</sub> are compatible and expr(merge(μ<sub>1</sub>,
-          μ<sub>2</sub>)) is false. }</p>
-        <p>As these are distinct, the cardinality of LeftJoin is cardinality of these individual
-          components of the definition.</p>
+
         <div class="defn">
           <p><b>Definition:</b></p>
           <div id="defn_algUnion">


### PR DESCRIPTION
See the email [public-rdf-dawg-comments/2015Jun/0000.html](https://lists.w3.org/Archives/Public/public-rdf-dawg-comments/2015Jun/0000.html).

It is not possible to expand the logical "or" condition in the definition of diff into a union because of the ∀ μ′ / ∀ μ2.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/29.html" title="Last updated on Mar 22, 2023, 9:07 PM UTC (7a7216d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/29/7144771...7a7216d.html" title="Last updated on Mar 22, 2023, 9:07 PM UTC (7a7216d)">Diff</a>