### PR TITLE
errata-query-9 (#30)

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -8798,13 +8798,13 @@ Replace join(A, Z) by A
               &nbsp;&nbsp; Join( <br>
               &nbsp;&nbsp;&nbsp;&nbsp; Join( {}, BGP(?s :p ?v)),<br>
               &nbsp;&nbsp;&nbsp;&nbsp; {}),<br>
-              &nbsp;&nbsp; ?v2, 2*?v)<br>
+              &nbsp;&nbsp; ?v2, 2*?v<br>
               )
             </div>
             <div class="algExample2">
               Extend(<br>
               &nbsp;&nbsp; BGP(?s :p ?v) ,<br>
-              &nbsp;&nbsp; ?v2, 2*?v)<br>
+              &nbsp;&nbsp; ?v2, 2*?v<br>
             )
             </div>
           </div>

--- a/spec/index.html
+++ b/spec/index.html
@@ -8787,16 +8787,25 @@ Replace join(A, Z) by A
               &nbsp;&nbsp; BGP(?s :p1 ?v2) )
             </div>
           </div>
-          <p>Example: Pattern involving BIND:</p>
+          <p>Example: Pattern involving BIND, with a 
+            <a href="#sparqlSimplification">simplification</a> step:</p>
           <div class="algExample">
             <div class="algExample1">
               { ?s :p ?v . {} BIND (2*?v AS ?v2) }
             </div>
             <div class="algExample2">
-              Join(<br>
-              &nbsp;&nbsp; BGP(?s :p ?v), ?v2, 2*?v) ,<br>
-              &nbsp;&nbsp; Extend({}, ?v2, 2*?v)<br>
+              Extend(<br>
+              &nbsp;&nbsp; Join( <br>
+              &nbsp;&nbsp;&nbsp;&nbsp; Join( {}, BGP(?s :p ?v)),<br>
+              &nbsp;&nbsp;&nbsp;&nbsp; {},<br>
+              &nbsp;&nbsp; ?v2, 2*?v)<br>
               )
+            </div>
+            <div class="algExample2">
+              Extend(<br>
+              &nbsp;&nbsp; BGP(?s :p ?v) ,<br>
+              &nbsp;&nbsp; ?v2, 2*?v)<br>
+            )
             </div>
           </div>
           <p>Example: Pattern involving MINUS:</p>
@@ -8807,7 +8816,8 @@ Replace join(A, Z) by A
             <div class="algExample2">
               Minus(<br>
               &nbsp;&nbsp; BGP(?s :p ?v)<br>
-              &nbsp;&nbsp; BGP(?s :p1 ?v2))
+              &nbsp;&nbsp; BGP(?s :p1 ?v2)<br>
+              )
             </div>
           </div>
           <p>Example: Pattern involving a subquery:</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -8797,7 +8797,7 @@ Replace join(A, Z) by A
               Extend(<br>
               &nbsp;&nbsp; Join( <br>
               &nbsp;&nbsp;&nbsp;&nbsp; Join( {}, BGP(?s :p ?v)),<br>
-              &nbsp;&nbsp;&nbsp;&nbsp; {},<br>
+              &nbsp;&nbsp;&nbsp;&nbsp; {}),<br>
               &nbsp;&nbsp; ?v2, 2*?v)<br>
               )
             </div>


### PR DESCRIPTION
Fix an example.

See [public-sparql-dev/2014OctDec/0005](https://lists.w3.org/Archives/Public/public-sparql-dev/2014OctDec/0005.html).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/30.html" title="Last updated on Mar 27, 2023, 1:37 PM UTC (69aef3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/30/7144771...69aef3c.html" title="Last updated on Mar 27, 2023, 1:37 PM UTC (69aef3c)">Diff</a>