### PR TITLE
errata-query-12

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9421,9 +9421,11 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             expression. We define:</p>
           <p>Diff(Ω<sub>1</sub>, Ω<sub>2</sub>, expr) = { μ | μ in Ω<sub>1</sub> such that ∀ μ′ in
             Ω<sub>2</sub>, either μ and μ′ are not compatible or μ and μ' are compatible and
-            expr(merge(μ, μ')) has an effective boolean value of false }</p>
+            expr(merge(μ, μ')) does not have an effective boolean value of true }</p>
           <p>card[Diff(Ω<sub>1</sub>, Ω<sub>2</sub>, expr)](μ) = card[Ω<sub>1</sub>](μ)</p>
         </div>
+        <p>The evaluation of expr(merge(μ, μ')) does not have an effective boolean
+          value of true if it evaluates to false or if it raises an error.</p>
         <p>Diff is used internally for the definition of LeftJoin.</p>
         <div class="defn">
           <p><b>Definition:</b></p>


### PR DESCRIPTION
https://www.w3.org/2013/sparql-errata#errata-query-12

Discussion:
https://lists.w3.org/Archives/Public/public-rdf-dawg-comments/2015Jun/0004


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/36.html" title="Last updated on Mar 25, 2023, 8:14 AM UTC (eb46e8a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/36/7144771...eb46e8a.html" title="Last updated on Mar 25, 2023, 8:14 AM UTC (eb46e8a)">Diff</a>