### PR TITLE
Rename section to pass specStatus

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -11636,7 +11636,7 @@ _:x rdf:type xsd:decimal .
     </section>
 
     <section id="security">
-      <h2>Security Considerations (Informative)</h2>
+      <h2>Security Considerations</h2>
       <p>SPARQL queries using FROM, FROM NAMED, or GRAPH may cause the specified URI to be
           dereferenced. This may cause additional use of network, disk or CPU resources along with
           associated secondary issues such as denial of service. The security issues of [[[RFC3986]]]


### PR DESCRIPTION
Makes `?specStatus=FPWD&pubDate=2023-04-01` as per WG editors guide.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/38.html" title="Last updated on Mar 26, 2023, 3:55 PM UTC (e3f30c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/38/7144771...e3f30c4.html" title="Last updated on Mar 26, 2023, 3:55 PM UTC (e3f30c4)">Diff</a>