### PR TITLE
Defines 'RDFterm-equal' using an actual function signature, same for …

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -5437,7 +5437,7 @@ class="expression">expression, ....</span>)
             <pre class="prototype">
               <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">logical-or</span> (<span class="type">xsd:boolean</span> <span class="name">left</span>, <span class="type">xsd:boolean</span> <span class="name">right</span>)
             </pre>
-            <p>This function cannot be used directly in expressions. Instead, the purpose of this function is to define the semantics of the "<code>||</code>" operator.</p>
+            <p>This function cannot be used directly in expressions. The purpose of this function is to define the semantics of the "<code>||</code>" operator.</p>
             <p>The function returns a logical <code>OR</code> of <code>left</code> and <code>right</code>. Note
               that <span class="SPARQLoperator">logical-or</span> operates on the <a href=
                                                                                      "#ebv">effective boolean value</a> of its arguments.</p>
@@ -5449,7 +5449,7 @@ class="expression">expression, ....</span>)
             <pre class="prototype">
               <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">logical-and</span> (<span class="type">xsd:boolean</span> <span class="name">left</span>, <span class="type">xsd:boolean</span> <span class="name">right</span>)
             </pre>
-            <p>This function cannot be used directly in expressions. Instead, the purpose of this function is to define the semantics of the "<code>&amp;&amp;</code>" operator.</p>
+            <p>This function cannot be used directly in expressions. The purpose of this function is to define the semantics of the "<code>&amp;&amp;</code>" operator.</p>
             <p>The function returns a logical <code>AND</code> of <code>left</code> and <code>right</code>. Note
               that <span class="SPARQLoperator">logical-and</span> operates on the <a href=
                                                                                       "#ebv">effective boolean value</a> of its arguments.</p>
@@ -5461,7 +5461,7 @@ class="expression">expression, ....</span>)
             <pre class="prototype">
               <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">RDFterm-equal</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)
             </pre>
-            <p>This function cannot be used directly in expressions. Instead, the purpose of this function is to define the semantics of the "=" operator when applied to two RDF terms that do not fall into any of the other, more concrete cases covered in the operator mapping table in Section&nbsp;<a href="#OperatorMapping" class="sectionRef"></a>.</p>
+            <p>This function cannot be used directly in expressions. The purpose of this function is to define the semantics of the "=" operator when applied to two RDF terms that do not fall into any of the other, more concrete cases covered in the operator mapping table in Section&nbsp;<a href="#OperatorMapping" class="sectionRef"></a>.</p>
             <p>The function is defined as follows:</p>
             <ul>
                 <li>Returns TRUE if <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms, as defined below.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -5434,11 +5434,11 @@ class="expression">expression, ....</span>)
           </section>
           <section id="func-logical-or">
             <h5>logical-or</h5>
-            <pre class="prototype"> <span class="return">xsd:boolean</span>  <span class=
-                                                                                   "type">xsd:boolean</span> <span class="name">left</span> <span class=
-                                                                                                                                                  "operator">||</span> <span class="type">xsd:boolean</span> <span class=
-                                                                                                                                                                                                                   "name">right</span></pre>
-            <p>Returns a logical <code>OR</code> of <code>left</code> and <code>right</code>. Note
+            <pre class="prototype">
+              <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">logical-or</span> (<span class="type">xsd:boolean</span> <span class="name">left</span>, <span class="type">xsd:boolean</span> <span class="name">right</span>)
+            </pre>
+            <p>This function cannot be used directly in expressions. Instead, the purpose of this function is to define the semantics of the "<code>||</code>" operator.</p>
+            <p>The function returns a logical <code>OR</code> of <code>left</code> and <code>right</code>. Note
               that <span class="SPARQLoperator">logical-or</span> operates on the <a href=
                                                                                      "#ebv">effective boolean value</a> of its arguments.</p>
             <p>Note: see section 17.2, <a href="#evaluation">Filter Evaluation</a>, for the
@@ -5446,11 +5446,11 @@ class="expression">expression, ....</span>)
           </section>
           <section id="func-logical-and">
             <h5>logical-and</h5>
-            <pre class="prototype"> <span class="return">xsd:boolean</span>  <span class=
-                                                                                   "type">xsd:boolean</span> <span class="name">left</span> <span class=
-                                                                                                                                                  "operator">&amp;&</span> <span class="type">xsd:boolean</span> <span class=
-                                                                                                                                                                                                                       "name">right</span></pre>
-            <p>Returns a logical <code>AND</code> of <code>left</code> and <code>right</code>. Note
+            <pre class="prototype">
+              <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">logical-and</span> (<span class="type">xsd:boolean</span> <span class="name">left</span>, <span class="type">xsd:boolean</span> <span class="name">right</span>)
+            </pre>
+            <p>This function cannot be used directly in expressions. Instead, the purpose of this function is to define the semantics of the "<code>&amp;&</code>" operator.</p>
+            <p>The function returns a logical <code>AND</code> of <code>left</code> and <code>right</code>. Note
               that <span class="SPARQLoperator">logical-and</span> operates on the <a href=
                                                                                       "#ebv">effective boolean value</a> of its arguments.</p>
             <p>Note: see section 17.2, <a href="#evaluation">Filter Evaluation</a>, for the
@@ -5458,11 +5458,11 @@ class="expression">expression, ....</span>)
           </section>
           <section id="func-RDFterm-equal">
             <h5>RDFterm-equal</h5>
-            <pre class="prototype"> <span class="return">xsd:boolean</span>  <span class=
-                                                                                   "type">RDF term</span> <span class="name">term1</span> <span class=
-                                                                                                                                                "operator">=</span> <span class="type">RDF term</span> <span class=
-                                                                                                                                                                                                             "name">term2</span></pre>
-            <p>This function is defined as follows:</p>
+            <pre class="prototype">
+              <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">RDFterm-equal</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)
+            </pre>
+            <p>This function cannot be used directly in expressions. Instead, the purpose of this function is to define the semantics of the "=" operator when applied to two RDF terms that do not fall into any of the other, more concrete cases covered in the operator mapping table in Section&nbsp;<a href="#OperatorMapping" class="sectionRef"></a>.</p>
+            <p>The function is defined as follows:</p>
             <ul>
                 <li>Returns TRUE if <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms, as defined below.</li>
                 <li>Produces a type error if <code>term1</code> and <code>term2</code> are both literals having the

--- a/spec/index.html
+++ b/spec/index.html
@@ -5449,7 +5449,7 @@ class="expression">expression, ....</span>)
             <pre class="prototype">
               <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">logical-and</span> (<span class="type">xsd:boolean</span> <span class="name">left</span>, <span class="type">xsd:boolean</span> <span class="name">right</span>)
             </pre>
-            <p>This function cannot be used directly in expressions. Instead, the purpose of this function is to define the semantics of the "<code>&amp;&</code>" operator.</p>
+            <p>This function cannot be used directly in expressions. Instead, the purpose of this function is to define the semantics of the "<code>&amp;&amp;</code>" operator.</p>
             <p>The function returns a logical <code>AND</code> of <code>left</code> and <code>right</code>. Note
               that <span class="SPARQLoperator">logical-and</span> operates on the <a href=
                                                                                       "#ebv">effective boolean value</a> of its arguments.</p>


### PR DESCRIPTION
…'logical-or' and 'logical-and', as described in #18.

Note that I have also included statements that these functions are not meant to be used directly in expressions.

Closes #18


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/42.html" title="Last updated on Mar 29, 2023, 1:58 PM UTC (9074518)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/42/d327262...9074518.html" title="Last updated on Mar 29, 2023, 1:58 PM UTC (9074518)">Diff</a>