### PR TITLE
Address link checker report

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4663,42 +4663,40 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
                                                                       "type numeric">numeric</span> arguments:</p>
         <ul>
           <li>
-            <a data-cite=
-               "XMLSCHEMA-2-2#dt-nonPositiveInteger"><code>xsd:nonPositiveInteger</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-nonPositiveInteger"><code>xsd:nonPositiveInteger</code></a>
           </li>
           <li>
-            <a data-cite="XMLSCHEMA-2-2#dt-negativeInteger"><code>xsd:negativeInteger</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-negativeInteger"><code>xsd:negativeInteger</code></a>
           </li>
           <li>
-            <a data-cite="XMLSCHEMA-2-2#dt-long"><code>xsd:long</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-long"><code>xsd:long</code></a>
           </li>
           <li>
-            <a data-cite="XMLSCHEMA-2-2#dt-int"><code>xsd:int</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-int"><code>xsd:int</code></a>
           </li>
           <li>
-            <a data-cite="XMLSCHEMA-2-2#dt-short"><code>xsd:short</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-short"><code>xsd:short</code></a>
           </li>
           <li>
-            <a data-cite="XMLSCHEMA-2-2#dt-byte"><code>xsd:byte</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-byte"><code>xsd:byte</code></a>
           </li>
           <li>
-            <a data-cite=
-               "XMLSCHEMA-2-2#dt-nonNegativeInteger"><code>xsd:nonNegativeInteger</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-nonNegativeInteger"><code>xsd:nonNegativeInteger</code></a>
           </li>
           <li>
-            <a data-cite="XMLSCHEMA-2-2#dt-unsignedLong"><code>xsd:unsignedLong</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-unsignedLong"><code>xsd:unsignedLong</code></a>
           </li>
           <li>
-            <a data-cite="XMLSCHEMA-2-2#dt-unsignedInt"><code>xsd:unsignedInt</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-unsignedInt"><code>xsd:unsignedInt</code></a>
           </li>
           <li>
-            <a data-cite="XMLSCHEMA-2-2#dt-unsignedShort"><code>xsd:unsignedShort</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-unsignedShort"><code>xsd:unsignedShort</code></a>
           </li>
           <li>
-            <a data-cite="XMLSCHEMA-2-2#dt-unsignedByte"><code>xsd:unsignedByte</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-unsignedByte"><code>xsd:unsignedByte</code></a>
           </li>
           <li>
-            <a data-cite="XMLSCHEMA-2-2#dt-positiveInteger"><code>xsd:positiveInteger</code></a>
+            <a data-cite="XMLSCHEMA-2#dt-positiveInteger"><code>xsd:positiveInteger</code></a>
           </li>
         </ul>
         <p>SPARQL language extensions may treat additional types as being derived from XML schema

--- a/spec/index.html
+++ b/spec/index.html
@@ -4578,7 +4578,7 @@ foaf:mbox_sha1sum  rdf:type  owl:InverseFunctionalProperty .
         solutions that, when substituted into the expression, either result in an effective boolean
         value of <code>false</code> or produce an error. Effective boolean values are defined in
         section <a href="#ebv">17.2.2 <em>Effective Boolean Value</em></a> and errors are defined in
-        [[[XQUERY]]] [[XQUERY]] section <a data-cite="XQUERY#dt-type-error">2.3.1, <em>Kinds of
+        [[[XQUERY-31]]] [[XQUERY-31]] section <a data-cite="XQUERY-31#dt-type-error">2.3.1, <em>Kinds of
             Errors</em></a>. These errors have no effect outside of <code>FILTER</code> evaluation.</p>
       <div class="exampleGroup">
         <p>RDF literals may have a</p>
@@ -4705,8 +4705,8 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
       <section id="evaluation">
         <h3>Filter Evaluation</h3>
         <p>SPARQL provides a subset of the functions and operators defined by XQuery <a data-cite=
-                                                                                        "XQUERY#mapping">Operator Mapping</a>. XQuery 1.0 section <a data-cite=
-                                                                                                                                                     "XQUERY#id-expression-processing">2.2.3 Expression Processing</a> describes the invocation of
+                                                                                        "XQUERY-31#mapping">Operator Mapping</a>. XQuery 1.0 section <a data-cite=
+                                                                                                                                                     "XQUERY-31#id-expression-processing">2.2.3 Expression Processing</a> describes the invocation of
           XPath functions. The following rules accommodate the differences in the data and execution
           models between XQuery and SPARQL:</p>
         <ul>
@@ -4714,7 +4714,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
             the semantics of XPath functions, assume that each argument is a sequence of a single
             node.</li>
           <li>Functions invoked with an argument of the wrong type will produce a <a data-cite=
-                                                                                     "XQUERY#dt-type-error">type error</a>. Effective boolean value arguments (labeled
+                                                                                     "XQUERY-31#dt-type-error">type error</a>. Effective boolean value arguments (labeled
             "xsd:boolean (EBV)" in the operator mapping table below), are coerced to
             <code>xsd:boolean</code> using the <a href="#ebv">EBV rules</a> in section 17.2.2.
           </li>
@@ -4833,7 +4833,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
             <a href="#func-logical-and">logical-and</a>, <a href="#func-logical-or">logical-or</a>, and
             <a data-cite="XPATH-FUNCTIONS#func-not">fn:not</a>, as well as evaluate the result of a
             <code>FILTER</code> expression.</p>
-          <p>The XQuery <a data-cite="XQUERY#id-ebv">Effective Boolean Value</a> rules rely on the
+          <p>The XQuery <a data-cite="XQUERY-31#id-ebv">Effective Boolean Value</a> rules rely on the
             definition of XPath's <a data-cite="XPATH-FUNCTIONS#func-boolean">fn:boolean</a>. The following
             rules reflect the rules for <code>fn:boolean</code> applied to the argument types present
             in SPARQL queries:</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -3168,7 +3168,7 @@ _:a foaf:mbox &lt;mailto:alice@work.example.org&gt; .
           graphs. The triples in the named graphs are not visible in the default graph in this
           example.</p>
         <p id="ex_2"><b>Example 2:</b></p>
-        <p>RDF data can be combined by the <a data-cite="RDF12-SEMANTICS#graphdefs">RDF merge</a>
+        <p>RDF data can be combined by the <a data-cite="RDF12-SEMANTICS#dfn-merge">RDF merge</a>
           [[RDF12-SEMANTICS]] of graphs. One possible arrangement of graphs in an RDF Dataset is to have the
           default graph be the RDF merge of some or all of the information in the named graphs.</p>
         <p>In this next example, the named graphs contain the same triples as before. The RDF dataset
@@ -3263,7 +3263,7 @@ WHERE   { ?x foaf:name ?name }
           </div>
           <p>If a query provides more than one <code>FROM</code> clause, providing more than one IRI
             to indicate the default graph, then the default graph is the 
-            <a data-cite="RDF12-SEMANTICS#graphdefs">RDF merge</a> of the graphs obtained from representations of the
+            <a data-cite="RDF12-SEMANTICS#dfn-merge">RDF merge</a> of the graphs obtained from representations of the
             resources identified by the given IRIs.</p>
         </section>
         <section id="namedGraphs">
@@ -8125,7 +8125,7 @@ WHERE {
             <p>Write N1 for { &lt;u1<sub>j</sub>&gt; j = 1 to n }<br>
               Write N2 for { &lt;u2<sub>j</sub>&gt; j = 1 to m }<br></p>
             <ul>
-              <li>G is the <a data-cite="RDF12-SEMANTICS#defmerge">merge</a> of G1 and G2
+              <li>G is the <a data-cite="RDF12-SEMANTICS#dfn-merge">merge</a> of G1 and G2
               </li>
               <li>(&lt;u<sub>i</sub>&gt;, G<sub>i</sub>) where &lt;u<sub>i</sub>&gt; is in N1 but not
                 in N2</li>
@@ -8133,7 +8133,7 @@ WHERE {
                 in N1</li>
               <li>(&lt;u<sub>i</sub>&gt;, G<sub>i</sub>) where &lt;u<sub>i</sub>&gt; is equal to
                 &lt;u<sub>j</sub>&gt; in N1 and equal to &lt;u<sub>k</sub>&gt; in N2 and G<sub>i</sub>
-                is the <a data-cite="RDF12-SEMANTICS#defmerge">merge</a> of G1<sub>j</sub> and G2<sub>k</sub>
+                is the <a data-cite="RDF12-SEMANTICS#dfn-merge">merge</a> of G1<sub>j</sub> and G2<sub>k</sub>
               </li>
             </ul>
           </div>
@@ -9302,7 +9302,7 @@ The set PV is used later for projection.
           <p>A basic graph pattern is matched against the active graph for that part of the query.
             Basic graph patterns can be instantiated by replacing both variables and blank nodes by
             terms, giving two notions of instance. Blank nodes are replaced using an <a data-cite=
-                                                                                        "RDF12-SEMANTICS#definst">RDF instance mapping</a>, &nbsp;σ, from blank nodes to RDF terms;
+                                                                                        "RDF12-SEMANTICS#dfn-instance">RDF instance mapping</a>, &nbsp;σ, from blank nodes to RDF terms;
             variables are replaced by a solution mapping from query variables to RDF terms.</p>
           <div class="defn">
             <p><b>Definition: <span id="defn_PatternInstanceMapping">Pattern Instance Mapping</span></b></p>
@@ -9345,7 +9345,7 @@ The set PV is used later for projection.
             the basic graph pattern to a subset of the active graph.</p>
           <p>This is optimized for ease of computation rather than redundancy elimination. It allows
             query results to contain redundancies even when the active graph of the dataset is
-            <a data-cite="RDF12-SEMANTICS#deflean">lean</a>, and it allows logically equivalent datasets to
+            <a data-cite="RDF12-SEMANTICS#def-lean">lean</a>, and it allows logically equivalent datasets to
             yield different query results.</p>
         </section>
       </section>
@@ -10237,7 +10237,7 @@ _:x rdf:type xsd:decimal .
             <p>SG union μ<sub>1</sub>(BGP<sub>1</sub>) union ... union
               μ<sub>n</sub>(BGP<sub>n</sub>)</p>
             <p>has an instance which is a subgraph of SG, so is simply entailed by SG by the
-              <a data-cite="RDF12-SEMANTICS#interplemmaprf">RDF interpolation lemma</a> [[RDF12-SEMANTICS]].</p>
+              <a data-cite="RDF12-SEMANTICS#dfn-interpolation">RDF interpolation lemma</a> [[RDF12-SEMANTICS]].</p>
           </section>
         </section>
       </section>


### PR DESCRIPTION
This fixed the external links from link checker report for XQuery, XML Schema, and RDF MT.

RDF Semantics (1.1) did not preserve the fragments of RDF MT (1.0)

[TR/XQuery ](https://www.w3.org/TR/xquery/) is now an informational redirection page.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/48.html" title="Last updated on Apr 2, 2023, 9:49 AM UTC (cbb417a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/48/882acc7...cbb417a.html" title="Last updated on Apr 2, 2023, 9:49 AM UTC (cbb417a)">Diff</a>