### PR TITLE
Use RDF 1.2 terminology

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -545,13 +545,9 @@ span.cancast:hover { background-color: #ffa;
           <p>The following terms are defined in [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]] and used in
             SPARQL:</p>
 
-          <p class="note">
-            IRI : align to RDF Concept2 -- "RDF URI reference" is RDF 1.0 terminology.
-          </p>
           <ul>
             <li>
               <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>
-              (corresponds to the Concepts and Abstract Syntax term "<code>RDF URI reference</code>")
             </li>
             <li>
               <a data-cite="RDF12-CONCEPTS#dfn-literal">literal</a>
@@ -563,8 +559,7 @@ span.cancast:hover { background-color: #ffa;
               <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
             </li>
             <li>
-              <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">datatype IRI</a>
-              (corresponds to the Concepts and Abstract Syntax term "<code>recognized datatype URI</code>")
+              <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>
             </li>
             <li>
               <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1110,12 +1110,6 @@ WHERE   {
             '&lt;' and '&gt;' delimiters do not form part of the IRI reference. Relative IRIs match the
             <code>irelative-ref</code> reference in section 2.2 ABNF for IRI References and IRIs in
             [[RFC3987]] and are resolved to IRIs as described below.</p>
-          <p>The set of RDF terms defined in [[[RDF12-CONCEPTS]]] includes RDF URI references while
-            SPARQL terms include IRIs. RDF URI references containing "<code>&lt;</code>",
-            "<code>&gt;</code>", '<code>"</code>' (double quote), space, "<code>{</code>",
-            "<code>}</code>", "<code>|</code>", "<code>\</code>", "<code>^</code>", and
-            "<code>`</code>" are not IRIs. The behavior of a SPARQL query against RDF statements
-            composed of such RDF URI references is not defined.</p>
           <section id="prefNames">
             <h5>Prefixed Names</h5>
             <p>The <code>PREFIX</code> keyword associates a prefix label with an IRI. A prefixed name

--- a/spec/index.html
+++ b/spec/index.html
@@ -537,7 +537,7 @@ span.cancast:hover { background-color: #ffa;
         </section>
         <section id="docTerminology">
           <h4>Terminology</h4>
-          <p>The SPARQL language includes IRIs, a subset of RDF URI References that omits spaces.
+          <p>The SPARQL language includes IRIs.
             Note that all IRIs in SPARQL queries are absolute; they may or may not include a fragment
             identifier [[RFC3987], section 3.1. IRIs include URIs [[RFC3986]] and URLs. The abbreviated
             forms (<a href="#QSynIRI">relative IRIs and prefixed names</a>) in the SPARQL syntax are


### PR DESCRIPTION
* Remove "RDF URI Reference" : use IRI.
* Revert to "datatype IRI"
* Remove "corresponds" text because the terminology is now the same (at SPARQL 1.1, "RDF URI Reference" was on its way out and replaced by IRI, as per RDF 1.1 WG).
* Remove text referring to related from SPARQL 1.1 about RDF URI References (when RDF 1.1 had not yet published). 

Text about  "RDF URI Reference" mentions RDF Concepts which does not have "RDF URI Reference". This then get confusing because we do have "IRI Reference".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/61.html" title="Last updated on May 1, 2023, 7:48 AM UTC (6e48cc9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/61/f17baf2...6e48cc9.html" title="Last updated on May 1, 2023, 7:48 AM UTC (6e48cc9)">Diff</a>