### PR TITLE
errata-query-4: CONCAT and COALESCE

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -6443,7 +6443,7 @@ WHERE {
                 syntactic shorthand for <code>"abc"^^xsd:string</code>.
               </p>
             </section>
-            <section id="idp1915512">
+            <section id="string-literal-return-type">
               <h6>String Literal Return Type</h6>
               <p>Functions that return a string literal do so with the string literal of the same
                 kind as the first argument (literal with datatype <code>xsd:string</code>, literal with the same language tag).
@@ -6847,12 +6847,16 @@ WHERE {
           <section id="func-concat">
             <h5>CONCAT</h5>
             <pre class="prototype nohighlight"><span class="return">string literal</span>  <span class="operator">CONCAT</span>(<span class="type">string literal</span> <span>ltrl<sub>1</sub></span> ... <span class="type">string literal</span> <span>ltrl<sub>n</sub></span>)</pre>
-            <p>The <code>CONCAT</code> function corresponds to the XPath <a data-cite="XPATH-FUNCTIONS#func-concat">fn:concat</a> function. The function accepts string
-              literals as arguments.</p>
-            <p>The lexical form of the returned literal is obtained by concatenating the lexical
-              forms of its inputs. If all input literals are literals with identical language
-              tags, then the returned literal is a literal with the same language tag, in all
-              other cases, the returned literal is a literal with datatype <code>xsd:string</code>.</p>
+            <p>The <code>CONCAT</code> function returns a string literal following the 
+              <a href="#string-literal-return-type">string literal return type</a> rule.
+              The <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a> of the
+              returned string literal is obtained by concatenating the lexical
+              forms of the arguments of the function. 
+              If zero arguments are given, the result is an empty string literal without language tag.
+              If all input literals are literals with identical language tag,
+              then the returned literal is a literal with that language tag.
+              Otherwise, the returned literal is a literal with datatype <code>xsd:string</code>.
+            </p>
             <div class="result">
               <table>
                 <tbody>
@@ -6873,8 +6877,20 @@ WHERE {
                     <td>"foobar"</td>
                   </tr>
                   <tr>
-                    <td><code>concat("foo"@en, "bar")</code></td>
+                    <td><code>concat("foo"@en, "bar"@es)</code></td>
                     <td>"foobar"</td>
+                  </tr>
+                  <tr>
+                    <td><code>concat("abc")</code></td>
+                    <td>"abc"</td>
+                  </tr>
+                  <tr>
+                    <td><code>concat("abc"@en)</code></td>
+                    <td>"abc"@en</td>
+                  </tr>
+                  <tr>
+                    <td><code>concat()</code></td>
+                    <td>""</td>
                   </tr>
                 </tbody>
               </table>

--- a/spec/index.html
+++ b/spec/index.html
@@ -6847,10 +6847,9 @@ WHERE {
           <section id="func-concat">
             <h5>CONCAT</h5>
             <pre class="prototype nohighlight"><span class="return">string literal</span>  <span class="operator">CONCAT</span>(<span class="type">string literal</span> <span>ltrl<sub>1</sub></span>, ..., <span class="type">string literal</span> <span>ltrl<sub>n</sub></span>)</pre>
-            <p>The <code>CONCAT</code> function returns a string literal following the 
-              <a href="#string-literal-return-type">string literal return type</a> rule.
-              The <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a> of the
-              returned string literal is obtained by concatenating the lexical
+            <p>The <code>CONCAT</code> function returns a string literal such that
+              the <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a> of
+              this literal is obtained by concatenating the lexical
               forms of the arguments of the function. 
               If zero arguments are given, the result is an empty string literal without language tag.
               If all input literals are literals with identical language tag,

--- a/spec/index.html
+++ b/spec/index.html
@@ -6846,7 +6846,7 @@ WHERE {
           </section>
           <section id="func-concat">
             <h5>CONCAT</h5>
-            <pre class="prototype nohighlight"><span class="return">string literal</span>  <span class="operator">CONCAT</span>(<span class="type">string literal</span> <span>ltrl<sub>1</sub></span> ... <span class="type">string literal</span> <span>ltrl<sub>n</sub></span>)</pre>
+            <pre class="prototype nohighlight"><span class="return">string literal</span>  <span class="operator">CONCAT</span>(<span class="type">string literal</span> <span>ltrl<sub>1</sub></span>, ..., <span class="type">string literal</span> <span>ltrl<sub>n</sub></span>)</pre>
             <p>The <code>CONCAT</code> function returns a string literal following the 
               <a href="#string-literal-return-type">string literal return type</a> rule.
               The <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a> of the

--- a/spec/index.html
+++ b/spec/index.html
@@ -861,7 +861,7 @@ WHERE  { ?x foaf:name ?name }
         <h3>Creating Values with Expressions</h3>
         <p>SPARQL 1.2 allows values to be created from complex expressions. The queries below show how
           the <a href="#func-concat">CONCAT</a> function can be used to concatenate first names and
-          last names from foaf data, then assign the value using an 
+          last names from FOAF data, then assign the value using an 
           <a href="#selectExpressions">expression in the <code>SELECT</code> clause</a> and also assign the
           value by using the <a href="#bind">BIND</a> form.</p>
         <div class="exampleGroup">
@@ -6847,15 +6847,26 @@ WHERE {
           <section id="func-concat">
             <h5>CONCAT</h5>
             <pre class="prototype nohighlight"><span class="return">string literal</span>  <span class="operator">CONCAT</span>(<span class="type">string literal</span> <span>ltrl<sub>1</sub></span>, ..., <span class="type">string literal</span> <span>ltrl<sub>n</sub></span>)</pre>
-            <p>The <code>CONCAT</code> function returns a string literal such that
-              the <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a> of
-              this literal is obtained by concatenating the lexical
-              forms of the arguments of the function. 
-              If zero arguments are given, the result is an empty string literal without language tag.
-              If all input literals are literals with identical language tag,
-              then the returned literal is a literal with that language tag.
-              Otherwise, the returned literal is a literal with datatype <code>xsd:string</code>
-              (and no language tag).
+
+            <p>The <code>CONCAT</code> function takes zero or more arguments.</p>
+            <p>
+              If zero arguments are given, the result is an empty string literal
+              without language tag.
+            </p>
+            <p>
+              If one argument is given, the result is that argument value.
+            </p>
+            <p>
+              If two or more arguments are given, the function returns a string
+              literal such that the
+              <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a> 
+              of the resulting string literal is obtained by concatenating the
+              lexical forms of the arguments of the function using the
+              <a data-cite="XPATH-FUNCTIONS#func-concat">fn:concat</a> function.
+              If all input literals are literals with the same language tag,
+              then the returned string literal is a literal with that language
+              tag.  Otherwise, the returned literal is a literal with
+              datatype <code>xsd:string</code> and no language tag.
             </p>
             <div class="result">
               <table>

--- a/spec/index.html
+++ b/spec/index.html
@@ -5430,11 +5430,17 @@ WHERE {
               <span class="return">rdfTerm</span> <span class="operator">COALESCE</span>(<span
 class="expression">expression, ....</span>)
             </pre>
-            <p>The <code>COALESCE</code> function form returns the RDF term value of the first
-              expression that evaluates without error. In SPARQL, evaluating an unbound variable raises
-              an error.</p>
-            <p>If none of the arguments evaluates to an RDF term, an error is raised. If no
-              expressions are evaluated without error, an error is raised.</p>
+            <p>
+              The <code>COALESCE</code> function form returns the RDF term value of the first
+              expression that evaluates without error.
+              In SPARQL, evaluating an unbound variable raises an error.
+            </p>
+            <p>
+              If none of the expressions evaluate without error, an error is raised.
+            </p>
+            <p>
+              If there are zero expressions, an error is raised.
+            </p>
             <p>Examples: Suppose ?x = 2 and ?y is not bound in some query solution:</p>
             <div class="result">
               <table>
@@ -5458,6 +5464,10 @@ class="expression">expression, ....</span>)
                   <tr>
                     <td><code>COALESCE(?y)</code></td>
                     <td>raises an error because <code>y</code> is not bound.</td>
+                  </tr>
+                  <tr>
+                    <td><code>COALESCE()</code></td>
+                    <td>raises an error because there are zero arguments.</td>
                   </tr>
                 </tbody>
               </table>

--- a/spec/index.html
+++ b/spec/index.html
@@ -6846,7 +6846,7 @@ WHERE {
           </section>
           <section id="func-concat">
             <h5>CONCAT</h5>
-            <pre class="prototype nohighlight"><span class="return">string literal</span>  <span class="operator">CONCAT</span>(<span class="type">string literal</span> <span>ltrl<sub>1</sub></span>, ..., <span class="type">string literal</span> <span>ltrl<sub>n</sub></span>)</pre>
+            <pre class="prototype nohighlight"><span class="return">string literal</span>  <span class="operator">CONCAT</span>(<span class="type">string literal</span>, ..., <span class="type">string literal</span>)</pre>
 
             <p>The <code>CONCAT</code> function takes zero or more arguments.</p>
             <p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -6855,7 +6855,8 @@ WHERE {
               If zero arguments are given, the result is an empty string literal without language tag.
               If all input literals are literals with identical language tag,
               then the returned literal is a literal with that language tag.
-              Otherwise, the returned literal is a literal with datatype <code>xsd:string</code>.
+              Otherwise, the returned literal is a literal with datatype <code>xsd:string</code>
+              (and no language tag).
             </p>
             <div class="result">
               <table>


### PR DESCRIPTION
This addresses [sparql-errata#errata-query-4](https://www.w3.org/2013/sparql-errata#errata-query-4).

This is part of #8.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/70.html" title="Last updated on May 14, 2023, 7:18 PM UTC (e5e7387)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/70/b279bac...e5e7387.html" title="Last updated on May 14, 2023, 7:18 PM UTC (e5e7387)">Diff</a>