### PR TITLE
errata-query-5: Aggregate functions can not be nested

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -10074,6 +10074,7 @@ _:x rdf:type xsd:decimal .
               call</a>. Aggregate functions may only be used in 
             <a href="#rSelectClause">SELECT</a>, <a href="#rHavingClause">HAVING</a>
             and <a href="#rOrderClause">ORDER BY</a> clauses.</li>
+          <li>The expression argument of an aggregate function can not contain an aggregate function.</li>
           <li>Only custom aggregate functions use the <code>DISTINCT</code> keyword
             in a <a href="#rFunctionCall">function call</a>.</li>
         </ol>


### PR DESCRIPTION
This addresses [sparql-errata#errata-query-5](https://www.w3.org/2013/sparql-errata#errata-query-5).

This is part of #8.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/77.html" title="Last updated on May 14, 2023, 7:20 PM UTC (2d6f428)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/77/ed41ca1...2d6f428.html" title="Last updated on May 14, 2023, 7:20 PM UTC (2d6f428)">Diff</a>