### PR TITLE
Update grammar for quoted triples and triple functions

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -10166,1150 +10166,1278 @@ _:x rdf:type xsd:decimal .
           <li>Only custom aggregate functions use the <code>DISTINCT</code> keyword
             in a <a href="#rFunctionCall">function call</a>.</li>
         </ol>
-        <div class="grammarTable">
-          <table>
-            <tbody>
-              <tr style="vertical-align: baseline">
-                <td><code>[1]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rQueryUnit">QueryUnit</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rQuery">Query</a> </code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[2]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rQuery">Query</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPrologue">Prologue</a><br>
-                    ( <a href="#rSelectQuery">SelectQuery</a> | <a href="#rConstructQuery">ConstructQuery</a> | <a href="#rDescribeQuery">DescribeQuery</a> | <a href="#rAskQuery">AskQuery</a> )<br>
-                    <a href="#rValuesClause">ValuesClause</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[3]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rUpdateUnit">UpdateUnit</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rUpdate">Update</a> </code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[4]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPrologue">Prologue</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>( <a href="#rBaseDecl">BaseDecl</a> | <a href="#rPrefixDecl">PrefixDecl</a> )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[5]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBaseDecl">BaseDecl</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'BASE'</span> <a href="#rIRIREF">IRIREF</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[6]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPrefixDecl">PrefixDecl</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'PREFIX'</span> <a href="#rPNAME_NS">PNAME_NS</a> <a href="#rIRIREF">IRIREF</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[7]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSelectQuery">SelectQuery</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rSelectClause">SelectClause</a> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[8]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSubSelect">SubSelect</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rSelectClause">SelectClause</a> <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a> <a href="#rValuesClause">ValuesClause</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[9]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSelectClause">SelectClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'SELECT'</span> ( <span class="token">'DISTINCT'</span> | <span class="token">'REDUCED'</span> )? ( ( <a href="#rVar">Var</a> | ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">'AS'</span> <a href="#rVar">Var</a> <span class="token">')'</span> ) )+ | <span class="token">'*'</span>
-                    )</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[10]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rConstructQuery">ConstructQuery</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'CONSTRUCT'</span> ( <a href="#rConstructTemplate">ConstructTemplate</a> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a> | <a href="#rDatasetClause">DatasetClause</a>* <span class="token">'WHERE'</span> <span class="token">'{'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? <span class="token">'}'</span> <a href="#rSolutionModifier">SolutionModifier</a> )</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[11]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDescribeQuery">DescribeQuery</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'DESCRIBE'</span> ( <a href="#rVarOrIri">VarOrIri</a>+ | <span class="token">'*'</span> ) <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a>? <a href="#rSolutionModifier">SolutionModifier</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[12]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rAskQuery">AskQuery</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'ASK'</span> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[13]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDatasetClause">DatasetClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'FROM'</span> ( <a href="#rDefaultGraphClause">DefaultGraphClause</a> | <a href="#rNamedGraphClause">NamedGraphClause</a> )</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[14]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDefaultGraphClause">DefaultGraphClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rSourceSelector">SourceSelector</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[15]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNamedGraphClause">NamedGraphClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'NAMED'</span> <a href="#rSourceSelector">SourceSelector</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[16]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSourceSelector">SourceSelector</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#riri">iri</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[17]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rWhereClause">WhereClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'WHERE'</span>? <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[18]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSolutionModifier">SolutionModifier</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rGroupClause">GroupClause</a>? <a href="#rHavingClause">HavingClause</a>? <a href="#rOrderClause">OrderClause</a>? <a href="#rLimitOffsetClauses">LimitOffsetClauses</a>?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[19]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGroupClause">GroupClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'GROUP'</span> <span class="token">'BY'</span> <a href="#rGroupCondition">GroupCondition</a>+</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[20]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGroupCondition">GroupCondition</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rBuiltInCall">BuiltInCall</a> | <a href="#rFunctionCall">FunctionCall</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">'AS'</span> <a href="#rVar">Var</a> )? <span class="token">')'</span> | <a href="#rVar">Var</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[21]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rHavingClause">HavingClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'HAVING'</span> <a href="#rHavingCondition">HavingCondition</a>+</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[22]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rHavingCondition">HavingCondition</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rConstraint">Constraint</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[23]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rOrderClause">OrderClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'ORDER'</span> <span class="token">'BY'</span> <a href="#rOrderCondition">OrderCondition</a>+</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[24]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rOrderCondition">OrderCondition</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>( ( <span class="token">'ASC'</span> | <span class="token">'DESC'</span> ) <a href="#rBrackettedExpression">BrackettedExpression</a> )<br>
-                    | ( <a href="#rConstraint">Constraint</a> | <a href="#rVar">Var</a> )</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[25]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rLimitOffsetClauses">LimitOffsetClauses</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rLimitClause">LimitClause</a> <a href="#rOffsetClause">OffsetClause</a>? | <a href="#rOffsetClause">OffsetClause</a> <a href="#rLimitClause">LimitClause</a>?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[26]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rLimitClause">LimitClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'LIMIT'</span> <a href="#rINTEGER">INTEGER</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[27]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rOffsetClause">OffsetClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'OFFSET'</span> <a href="#rINTEGER">INTEGER</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[28]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rValuesClause">ValuesClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>( <span class="token">'VALUES'</span> <a href="#rDataBlock">DataBlock</a> )?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[29]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rUpdate">Update</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPrologue">Prologue</a> ( <a href="#rUpdate1">Update1</a> ( <span class="token">';'</span> <a href="#rUpdate">Update</a> )? )?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[30]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rUpdate1">Update1</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rLoad">Load</a> | <a href="#rClear">Clear</a> | <a href="#rDrop">Drop</a> | <a href="#rAdd">Add</a> | <a href="#rMove">Move</a> | <a href="#rCopy">Copy</a> |
-                    <a href="#rCreate">Create</a> | <a href="#rInsertData">InsertData</a> | <a href="#rDeleteData">DeleteData</a> | <a href="#rDeleteWhere">DeleteWhere</a> | <a href="#rModify">Modify</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[31]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rLoad">Load</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'LOAD'</span> <span class="token">'SILENT'</span>? <a href="#riri">iri</a> ( <span class="token">'INTO'</span> <a href="#rGraphRef">GraphRef</a>
-                    )?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[32]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rClear">Clear</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'CLEAR'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRefAll">GraphRefAll</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[33]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDrop">Drop</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'DROP'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRefAll">GraphRefAll</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[34]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rCreate">Create</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'CREATE'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRef">GraphRef</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[35]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rAdd">Add</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'ADD'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[36]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rMove">Move</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'MOVE'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[37]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rCopy">Copy</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'COPY'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[38]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rInsertData">InsertData</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'INSERT DATA'</span> <a href="#rQuadData">QuadData</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[39]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDeleteData">DeleteData</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'DELETE DATA'</span> <a href="#rQuadData">QuadData</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[40]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDeleteWhere">DeleteWhere</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'DELETE WHERE'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[41]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rModify">Modify</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>( <span class="token">'WITH'</span> <a href="#riri">iri</a> )? ( <a href="#rDeleteClause">DeleteClause</a> <a href="#rInsertClause">InsertClause</a>? | <a href="#rInsertClause">InsertClause</a> ) <a href="#rUsingClause">UsingClause</a>* <span class="token">'WHERE'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[42]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDeleteClause">DeleteClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'DELETE'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[43]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rInsertClause">InsertClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'INSERT'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[44]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rUsingClause">UsingClause</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'USING'</span> ( <a href="#riri">iri</a> | <span class="token">'NAMED'</span> <a href="#riri">iri</a> )</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[45]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGraphOrDefault">GraphOrDefault</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'DEFAULT'</span> | <span class="token">'GRAPH'</span>? <a href="#riri">iri</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[46]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGraphRef">GraphRef</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'GRAPH'</span> <a href="#riri">iri</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[47]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGraphRefAll">GraphRefAll</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rGraphRef">GraphRef</a> | <span class="token">'DEFAULT'</span> | <span class="token">'NAMED'</span> | <span class="token">'ALL'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[48]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rQuadPattern">QuadPattern</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'{'</span> <a href="#rQuads">Quads</a> <span class="token">'}'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[49]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rQuadData">QuadData</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'{'</span> <a href="#rQuads">Quads</a> <span class="token">'}'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[50]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rQuads">Quads</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rTriplesTemplate">TriplesTemplate</a>? ( <a href="#rQuadsNotTriples">QuadsNotTriples</a> <span class="token">'.'</span>? <a href="#rTriplesTemplate">TriplesTemplate</a>? )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[51]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rQuadsNotTriples">QuadsNotTriples</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'GRAPH'</span> <a href="#rVarOrIri">VarOrIri</a> <span class="token">'{'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? <span class="token">'}'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[52]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesTemplate">TriplesTemplate</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rTriplesSameSubject">TriplesSameSubject</a> ( <span class="token">'.'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? )?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[53]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGroupGraphPattern">GroupGraphPattern</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'{'</span> ( <a href="#rSubSelect">SubSelect</a> | <a href="#rGroupGraphPatternSub">GroupGraphPatternSub</a> ) <span class="token">'}'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[54]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGroupGraphPatternSub">GroupGraphPatternSub</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rTriplesBlock">TriplesBlock</a>? ( <a href="#rGraphPatternNotTriples">GraphPatternNotTriples</a> <span class="token">'.'</span>? <a href="#rTriplesBlock">TriplesBlock</a>? )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[55]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesBlock">TriplesBlock</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rTriplesSameSubjectPath">TriplesSameSubjectPath</a> ( <span class="token">'.'</span> <a href="#rTriplesBlock">TriplesBlock</a>? )?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[56]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGraphPatternNotTriples">GraphPatternNotTriples</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rGroupOrUnionGraphPattern">GroupOrUnionGraphPattern</a> | <a href="#rOptionalGraphPattern">OptionalGraphPattern</a> | <a href="#rMinusGraphPattern">MinusGraphPattern</a> | <a href="#rGraphGraphPattern">GraphGraphPattern</a> | <a href="#rServiceGraphPattern">ServiceGraphPattern</a> | <a href="#rFilter">Filter</a> | <a href="#rBind">Bind</a> | <a href="#rInlineData">InlineData</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[57]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rOptionalGraphPattern">OptionalGraphPattern</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'OPTIONAL'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[58]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGraphGraphPattern">GraphGraphPattern</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'GRAPH'</span> <a href="#rVarOrIri">VarOrIri</a> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[59]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rServiceGraphPattern">ServiceGraphPattern</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'SERVICE'</span> <span class="token">'SILENT'</span>? <a href="#rVarOrIri">VarOrIri</a> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[60]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBind">Bind</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'BIND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">'AS'</span> <a href="#rVar">Var</a> <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[61]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rInlineData">InlineData</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'VALUES'</span> <a href="#rDataBlock">DataBlock</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[62]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDataBlock">DataBlock</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rInlineDataOneVar">InlineDataOneVar</a> | <a href="#rInlineDataFull">InlineDataFull</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[63]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rInlineDataOneVar">InlineDataOneVar</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rVar">Var</a> <span class="token">'{'</span> <a href="#rDataBlockValue">DataBlockValue</a>* <span class="token">'}'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[64]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rInlineDataFull">InlineDataFull</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>( <a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rVar">Var</a>* <span class="token">')'</span> ) <span class="token">'{'</span> ( <span class="token">'('</span> <a href="#rDataBlockValue">DataBlockValue</a>* <span class="token">')'</span> | <a href="#rNIL">NIL</a> )* <span class="token">'}'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[65]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDataBlockValue">DataBlockValue</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> |
-                    <span class="token">'UNDEF'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[66]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rMinusGraphPattern">MinusGraphPattern</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'MINUS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[67]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGroupOrUnionGraphPattern">GroupOrUnionGraphPattern</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rGroupGraphPattern">GroupGraphPattern</a> ( <span class="token">'UNION'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a> )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[68]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rFilter">Filter</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'FILTER'</span> <a href="#rConstraint">Constraint</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[69]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rConstraint">Constraint</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#rFunctionCall">FunctionCall</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[70]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rFunctionCall">FunctionCall</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#riri">iri</a> <a href="#rArgList">ArgList</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[71]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rArgList">ArgList</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rNIL">NIL</a> | <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> ( <span class="token">','</span>
-                    <a href="#rExpression">Expression</a> )* <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[72]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rExpressionList">ExpressionList</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )*
-                    <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[73]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rConstructTemplate">ConstructTemplate</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'{'</span> <a href="#rConstructTriples">ConstructTriples</a>? <span class="token">'}'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[74]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rConstructTriples">ConstructTriples</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rTriplesSameSubject">TriplesSameSubject</a> ( <span class="token">'.'</span> <a href="#rConstructTriples">ConstructTriples</a>? )?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[75]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesSameSubject">TriplesSameSubject</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> | <a href="#rTriplesNode">TriplesNode</a> <a href="#rPropertyList">PropertyList</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[76]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPropertyList">PropertyList</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a>?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[77]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPropertyListNotEmpty">PropertyListNotEmpty</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> ( <span class="token">';'</span> ( <a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> )?
-                    )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[78]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVerb">Verb</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rVarOrIri">VarOrIri</a> | <span class="token">'a'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[79]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rObjectList">ObjectList</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rObject">Object</a> ( <span class="token">','</span> <a href="#rObject">Object</a> )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[80]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rObject">Object</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rGraphNode">GraphNode</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[81]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesSameSubjectPath">TriplesSameSubjectPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> | <a href="#rTriplesNodePath">TriplesNodePath</a> <a href="#rPropertyListPath">PropertyListPath</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[82]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPropertyListPath">PropertyListPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a>?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[83]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPropertyListPathNotEmpty">PropertyListPathNotEmpty</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> ( <span class="token">';'</span> ( ( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> )? )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[84]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVerbPath">VerbPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPath">Path</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[85]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVerbSimple">VerbSimple</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rVar">Var</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[86]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rObjectListPath">ObjectListPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rObjectPath">ObjectPath</a> ( <span class="token">','</span> <a href="#rObjectPath">ObjectPath</a> )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[87]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rObjectPath">ObjectPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rGraphNodePath">GraphNodePath</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[88]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPath">Path</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPathAlternative">PathAlternative</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[89]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathAlternative">PathAlternative</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPathSequence">PathSequence</a> ( <span class="token">'|'</span> <a href="#rPathSequence">PathSequence</a> )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[90]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathSequence">PathSequence</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPathEltOrInverse">PathEltOrInverse</a> ( <span class="token">'/'</span> <a href="#rPathEltOrInverse">PathEltOrInverse</a> )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[91]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathElt">PathElt</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPathPrimary">PathPrimary</a> <a href="#rPathMod">PathMod</a>?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[92]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathEltOrInverse">PathEltOrInverse</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPathElt">PathElt</a> | <span class="token">'^'</span> <a href="#rPathElt">PathElt</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[93]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathMod">PathMod</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'?'</span> | <span class="token">'*'</span> | <span class="token">'+'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[94]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathPrimary">PathPrimary</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#riri">iri</a> | <span class="token">'a'</span> | <span class="token">'!'</span> <a href="#rPathNegatedPropertySet">PathNegatedPropertySet</a> | <span class="token">'('</span> <a href="#rPath">Path</a> <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[95]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathNegatedPropertySet">PathNegatedPropertySet</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPathOneInPropertySet">PathOneInPropertySet</a> | <span class="token">'('</span> ( <a href="#rPathOneInPropertySet">PathOneInPropertySet</a> ( <span class="token">'|'</span> <a href="#rPathOneInPropertySet">PathOneInPropertySet</a> )* )? <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[96]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathOneInPropertySet">PathOneInPropertySet</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#riri">iri</a> | <span class="token">'a'</span> | <span class="token">'^'</span> ( <a href="#riri">iri</a> | <span class="token">'a'</span> )</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[97]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rInteger">Integer</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rINTEGER">INTEGER</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[98]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesNode">TriplesNode</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rCollection">Collection</a> | <a href="#rBlankNodePropertyList">BlankNodePropertyList</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[99]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBlankNodePropertyList">BlankNodePropertyList</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'['</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">']'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[100]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesNodePath">TriplesNodePath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rCollectionPath">CollectionPath</a> | <a href="#rBlankNodePropertyListPath">BlankNodePropertyListPath</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[101]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBlankNodePropertyListPath">BlankNodePropertyListPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'['</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">']'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[102]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rCollection">Collection</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'('</span> <a href="#rGraphNode">GraphNode</a>+ <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[103]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rCollectionPath">CollectionPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'('</span> <a href="#rGraphNodePath">GraphNodePath</a>+ <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[104]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGraphNode">GraphNode</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rVarOrTerm">VarOrTerm</a> | <a href="#rTriplesNode">TriplesNode</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[105]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGraphNodePath">GraphNodePath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rVarOrTerm">VarOrTerm</a> | <a href="#rTriplesNodePath">TriplesNodePath</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[106]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVarOrTerm">VarOrTerm</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rVar">Var</a> | <a href="#rGraphTerm">GraphTerm</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[107]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVarOrIri">VarOrIri</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rVar">Var</a> | <a href="#riri">iri</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[108]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVar">Var</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rVAR1">VAR1</a> | <a href="#rVAR2">VAR2</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[109]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGraphTerm">GraphTerm</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rNIL">NIL</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[110]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rExpression">Expression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rConditionalOrExpression">ConditionalOrExpression</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[111]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rConditionalOrExpression">ConditionalOrExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rConditionalAndExpression">ConditionalAndExpression</a> ( <span class="token">'||'</span> <a href="#rConditionalAndExpression">ConditionalAndExpression</a>
-                    )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[112]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rConditionalAndExpression">ConditionalAndExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rValueLogical">ValueLogical</a> ( <span class="token">'&amp;&amp;'</span> <a href="#rValueLogical">ValueLogical</a> )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[113]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rValueLogical">ValueLogical</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rRelationalExpression">RelationalExpression</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[114]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRelationalExpression">RelationalExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rNumericExpression">NumericExpression</a> ( <span class="token">'='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'!='</span>
-                    <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;'</span>
-                    <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;='</span>
-                    <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> | <span class="token">'NOT'</span> <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> )?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[115]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericExpression">NumericExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rAdditiveExpression">AdditiveExpression</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[116]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rAdditiveExpression">AdditiveExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rMultiplicativeExpression">MultiplicativeExpression</a> ( <span class="token">'+'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> |
-                    <span class="token">'-'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | ( <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a> ) ( ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) | ( <span class="token">'/'</span>
-                    <a href="#rUnaryExpression">UnaryExpression</a> ) )* )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[117]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rMultiplicativeExpression">MultiplicativeExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rUnaryExpression">UnaryExpression</a> ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> | <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[118]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rUnaryExpression">UnaryExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>&nbsp;&nbsp;<span class="token">'!'</span> <a href="#rPrimaryExpression">PrimaryExpression</a><br>
-                    | <span class="token">'+'</span> <a href="#rPrimaryExpression">PrimaryExpression</a><br>
-                    | <span class="token">'-'</span> <a href="#rPrimaryExpression">PrimaryExpression</a><br>
-                    | <a href="#rPrimaryExpression">PrimaryExpression</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[119]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPrimaryExpression">PrimaryExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#ririOrFunction">iriOrFunction</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[120]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBrackettedExpression">BrackettedExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[121]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBuiltInCall">BuiltInCall</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>&nbsp;&nbsp;<a href="#rAggregate">Aggregate</a><br>
-                    | <span class="token">'STR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'LANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'LANGMATCHES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    <span class="token">')'</span><br>
-                    | <span class="token">'DATATYPE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'BOUND'</span> <span class="token">'('</span> <a href="#rVar">Var</a> <span class="token">')'</span><br>
-                    | <span class="token">'IRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'BNODE'</span> ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> | <a href="#rNIL">NIL</a> )<br>
-                    | <span class="token">'RAND'</span> <a href="#rNIL">NIL</a><br>
-                    | <span class="token">'ABS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'CEIL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'FLOOR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'ROUND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'CONCAT'</span> <a href="#rExpressionList">ExpressionList</a><br>
-                    | <a href="#rSubstringExpression">SubstringExpression</a><br>
-                    | <span class="token">'STRLEN'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <a href="#rStrReplaceExpression">StrReplaceExpression</a><br>
-                    | <span class="token">'UCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'LCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'ENCODE_FOR_URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'CONTAINS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    <span class="token">')'</span><br>
-                    | <span class="token">'STRSTARTS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    <span class="token">')'</span><br>
-                    | <span class="token">'STRENDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    <span class="token">')'</span><br>
-                    | <span class="token">'STRBEFORE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    <span class="token">')'</span><br>
-                    | <span class="token">'STRAFTER'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    <span class="token">')'</span><br>
-                    | <span class="token">'YEAR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'MONTH'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'DAY'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'HOURS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'MINUTES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'SECONDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'TIMEZONE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'TZ'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'NOW'</span> <a href="#rNIL">NIL</a><br>
-                    | <span class="token">'UUID'</span> <a href="#rNIL">NIL</a><br>
-                    | <span class="token">'STRUUID'</span> <a href="#rNIL">NIL</a><br>
-                    | <span class="token">'MD5'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'SHA1'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'SHA256'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'SHA384'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'SHA512'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'COALESCE'</span> <a href="#rExpressionList">ExpressionList</a><br>
-                    | <span class="token">'IF'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'STRLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    <span class="token">')'</span><br>
-                    | <span class="token">'STRDT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    <span class="token">')'</span><br>
-                    | <span class="token">'sameTerm'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    <span class="token">')'</span><br>
-                    | <span class="token">'isIRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'isURI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'isBLANK'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'isLITERAL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'isNUMERIC'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <a href="#rRegexExpression">RegexExpression</a><br>
-                    | <a href="#rExistsFunc">ExistsFunc</a><br>
-                    | <a href="#rNotExistsFunc">NotExistsFunc</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[122]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRegexExpression">RegexExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'REGEX'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[123]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSubstringExpression">SubstringExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'SUBSTR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a>
-                    ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[124]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rStrReplaceExpression">StrReplaceExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'REPLACE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )?
-                    <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[125]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rExistsFunc">ExistsFunc</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'EXISTS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[126]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNotExistsFunc">NotExistsFunc</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'NOT'</span> <span class="token">'EXISTS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[127]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rAggregate">Aggregate</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>&nbsp;&nbsp;<span class="token">'COUNT'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? ( <span class="token">'*'</span> | <a href="#rExpression">Expression</a> ) <span class="token">')'</span><br>
-                    | <span class="token">'SUM'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'MIN'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'MAX'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'AVG'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'SAMPLE'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span><br>
-                    | <span class="token">'GROUP_CONCAT'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> ( <span class="token">';'</span> <span class="token">'SEPARATOR'</span> <span class="token">'='</span> <a href="#rString">String</a> )? <span class="token">')'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[128]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="ririOrFunction">iriOrFunction</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#riri">iri</a> <a href="#rArgList">ArgList</a>?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[129]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRDFLiteral">RDFLiteral</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rString">String</a> ( <a href="#rLANGTAG">LANGTAG</a> | ( <span class="token">'^^'</span> <a href="#riri">iri</a> ) )?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[130]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericLiteral">NumericLiteral</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rNumericLiteralUnsigned">NumericLiteralUnsigned</a> | <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[131]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericLiteralUnsigned">NumericLiteralUnsigned</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rINTEGER">INTEGER</a> | <a href="#rDECIMAL">DECIMAL</a> | <a href="#rDOUBLE">DOUBLE</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[132]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericLiteralPositive">NumericLiteralPositive</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rINTEGER_POSITIVE">INTEGER_POSITIVE</a> | <a href="#rDECIMAL_POSITIVE">DECIMAL_POSITIVE</a> | <a href="#rDOUBLE_POSITIVE">DOUBLE_POSITIVE</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[133]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericLiteralNegative">NumericLiteralNegative</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rINTEGER_NEGATIVE">INTEGER_NEGATIVE</a> | <a href="#rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</a> | <a href="#rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[134]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBooleanLiteral">BooleanLiteral</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'true'</span> | <span class="token">'false'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[135]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rString">String</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a> | <a href="#rSTRING_LITERAL2">STRING_LITERAL2</a> | <a href="#rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</a> | <a href="#rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[136]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="riri">iri</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rIRIREF">IRIREF</a> | <a href="#rPrefixedName">PrefixedName</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[137]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPrefixedName">PrefixedName</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPNAME_LN">PNAME_LN</a> | <a href="#rPNAME_NS">PNAME_NS</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[138]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBlankNode">BlankNode</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rBLANK_NODE_LABEL">BLANK_NODE_LABEL</a> | <a href="#rANON">ANON</a></code></td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <p>Productions for terminals:</p>
-        <div class="grammarTable">
-          <table>
-            <tbody>
-              <tr style="vertical-align: baseline">
-                <td><code>[139]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rIRIREF">IRIREF</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'&lt;' ([^&lt;&gt;"{}|^`\]-[#x00-#x20])* '&gt;'</span></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[140]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPNAME_NS">PNAME_NS</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPN_PREFIX">PN_PREFIX</a>? ':'</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[141]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPNAME_LN">PNAME_LN</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPNAME_NS">PNAME_NS</a> <a href="#rPN_LOCAL">PN_LOCAL</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[142]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBLANK_NODE_LABEL">BLANK_NODE_LABEL</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>'_:' ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] ) ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[143]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVAR1">VAR1</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>'?' <a href="#rVARNAME">VARNAME</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[144]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVAR2">VAR2</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>'$' <a href="#rVARNAME">VARNAME</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[145]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rLANGTAG">LANGTAG</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[146]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rINTEGER">INTEGER</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>[0-9]+</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[147]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDECIMAL">DECIMAL</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>[0-9]* '.' [0-9]+</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[148]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDOUBLE">DOUBLE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>[0-9]+ '.' [0-9]* <a href="#rEXPONENT">EXPONENT</a> | '.' ([0-9])+ <a href="#rEXPONENT">EXPONENT</a> | ([0-9])+ <a href="#rEXPONENT">EXPONENT</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[149]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rINTEGER_POSITIVE">INTEGER_POSITIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'+'</span> <a href="#rINTEGER">INTEGER</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[150]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDECIMAL_POSITIVE">DECIMAL_POSITIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'+'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[151]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDOUBLE_POSITIVE">DOUBLE_POSITIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'+'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[152]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rINTEGER_NEGATIVE">INTEGER_NEGATIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'-'</span> <a href="#rINTEGER">INTEGER</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[153]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'-'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[154]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><span class="token">'-'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[155]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rEXPONENT">EXPONENT</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>[eE] [+-]? [0-9]+</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[156]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSTRING_LITERAL1">STRING_LITERAL1</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>"'" ( ([^#x27#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* "'"</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[157]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSTRING_LITERAL2">STRING_LITERAL2</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>'"' ( ([^#x22#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* '"'</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[158]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>"'''" ( ( "'" | "''" )? ( [^'\] | <a href="#rECHAR">ECHAR</a> ) )* "'''"</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[159]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>'"""' ( ( '"' | '""' )? ( [^"\] | <a href="#rECHAR">ECHAR</a> ) )* '"""'</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[160]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rECHAR">ECHAR</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>'\' [tbnrf\"']</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[161]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNIL">NIL</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>'(' <a href="#rWS">WS</a>* ')'</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[162]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rWS">WS</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>#x20 | #x9 | #xD | #xA</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[163]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rANON">ANON</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>'[' <a href="#rWS">WS</a>* ']'</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[164]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_CHARS_BASE">PN_CHARS_BASE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>[A-Z] | [a-z] | [#x00C0-#x00D6] | [#x00D8-#x00F6] | [#x00F8-#x02FF] | [#x0370-#x037D] | [#x037F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] |
-                    [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[165]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_CHARS_U">PN_CHARS_U</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> | '_'</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[166]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVARNAME">VARNAME</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] ) ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[167]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_CHARS">PN_CHARS</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPN_CHARS_U">PN_CHARS_U</a> | '-' | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040]</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[168]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_PREFIX">PN_PREFIX</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[169]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_LOCAL">PN_LOCAL</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>(<a href="#rPN_CHARS_U">PN_CHARS_U</a> | ':' | [0-9] | <a href="#rPLX">PLX</a> ) ((<a href="#rPN_CHARS">PN_CHARS</a> | '.' | ':' | <a href="#rPLX">PLX</a>)* (<a href="#rPN_CHARS">PN_CHARS</a> | ':' | <a href="#rPLX">PLX</a>) )?</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[170]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPLX">PLX</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code><a href="#rPERCENT">PERCENT</a> | <a href="#rPN_LOCAL_ESC">PN_LOCAL_ESC</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[171]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPERCENT">PERCENT</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>'%' <a href="#rHEX">HEX</a> <a href="#rHEX">HEX</a></code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[172]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rHEX">HEX</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>[0-9] | [A-F] | [a-f]</code></td>
-              </tr>
-              <tr style="vertical-align: baseline">
-                <td><code>[173]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_LOCAL_ESC">PN_LOCAL_ESC</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code>'\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )</code></td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <!-- GRAMMAR -->
+<div class="grammarTable">
+  <table><tbody>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[1]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rQueryUnit">QueryUnit</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rQuery">Query</a> <span class="token"></span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[2]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rQuery">Query</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPrologue">Prologue</a><br/>( <a href="#rSelectQuery">SelectQuery</a> | <a href="#rConstructQuery">ConstructQuery</a> | <a href="#rDescribeQuery">DescribeQuery</a> | <a href="#rAskQuery">AskQuery</a> )<br/><a href="#rValuesClause">ValuesClause</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[3]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rUpdateUnit">UpdateUnit</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rUpdate">Update</a> <span class="token"></span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[4]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPrologue">Prologue</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">( <a href="#rBaseDecl">BaseDecl</a> | <a href="#rPrefixDecl">PrefixDecl</a> )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[5]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rBaseDecl">BaseDecl</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'BASE'</span> <a href="#rIRIREF">IRIREF</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[6]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPrefixDecl">PrefixDecl</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'PREFIX'</span> <a href="#rPNAME_NS">PNAME_NS</a> <a href="#rIRIREF">IRIREF</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[7]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rSelectQuery">SelectQuery</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rSelectClause">SelectClause</a> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[8]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rSubSelect">SubSelect</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rSelectClause">SelectClause</a> <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a> <a href="#rValuesClause">ValuesClause</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[9]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rSelectClause">SelectClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'SELECT'</span> ( <span class="token">'DISTINCT'</span> | <span class="token">'REDUCED'</span> )? ( ( <a href="#rVar">Var</a> | ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">'AS'</span> <a href="#rVar">Var</a> <span class="token">')'</span> ) )+ | <span class="token">'*'</span> )</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[10]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rConstructQuery">ConstructQuery</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'CONSTRUCT'</span> ( <a href="#rConstructTemplate">ConstructTemplate</a> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a> | <a href="#rDatasetClause">DatasetClause</a>* <span class="token">'WHERE'</span> <span class="token">'{'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? <span class="token">'}'</span> <a href="#rSolutionModifier">SolutionModifier</a> )</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[11]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDescribeQuery">DescribeQuery</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'DESCRIBE'</span> ( <a href="#rVarOrIri">VarOrIri</a>+ | <span class="token">'*'</span> ) <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a>? <a href="#rSolutionModifier">SolutionModifier</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[12]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rAskQuery">AskQuery</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'ASK'</span> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[13]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDatasetClause">DatasetClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'FROM'</span> ( <a href="#rDefaultGraphClause">DefaultGraphClause</a> | <a href="#rNamedGraphClause">NamedGraphClause</a> )</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[14]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDefaultGraphClause">DefaultGraphClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rSourceSelector">SourceSelector</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[15]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rNamedGraphClause">NamedGraphClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'NAMED'</span> <a href="#rSourceSelector">SourceSelector</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[16]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rSourceSelector">SourceSelector</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#riri">iri</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[17]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rWhereClause">WhereClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'WHERE'</span>? <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[18]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rSolutionModifier">SolutionModifier</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rGroupClause">GroupClause</a>? <a href="#rHavingClause">HavingClause</a>? <a href="#rOrderClause">OrderClause</a>? <a href="#rLimitOffsetClauses">LimitOffsetClauses</a>?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[19]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGroupClause">GroupClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'GROUP'</span> <span class="token">'BY'</span> <a href="#rGroupCondition">GroupCondition</a>+</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[20]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGroupCondition">GroupCondition</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rBuiltInCall">BuiltInCall</a> | <a href="#rFunctionCall">FunctionCall</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">'AS'</span> <a href="#rVar">Var</a> )? <span class="token">')'</span> | <a href="#rVar">Var</a> </code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[21]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rHavingClause">HavingClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'HAVING'</span> <a href="#rHavingCondition">HavingCondition</a>+</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[22]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rHavingCondition">HavingCondition</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rConstraint">Constraint</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[23]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rOrderClause">OrderClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'ORDER'</span> <span class="token">'BY'</span> <a href="#rOrderCondition">OrderCondition</a>+</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[24]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rOrderCondition">OrderCondition</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">   ( ( <span class="token">'ASC'</span> | <span class="token">'DESC'</span> ) <a href="#rBrackettedExpression">BrackettedExpression</a> )<br/>| ( <a href="#rConstraint">Constraint</a> | <a href="#rVar">Var</a> ) </code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[25]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rLimitOffsetClauses">LimitOffsetClauses</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rLimitClause">LimitClause</a> <a href="#rOffsetClause">OffsetClause</a>? | <a href="#rOffsetClause">OffsetClause</a> <a href="#rLimitClause">LimitClause</a>? </code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[26]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rLimitClause">LimitClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'LIMIT'</span> <a href="#rINTEGER">INTEGER</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[27]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rOffsetClause">OffsetClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'OFFSET'</span> <a href="#rINTEGER">INTEGER</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[28]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rValuesClause">ValuesClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">( <span class="token">'VALUES'</span> <a href="#rDataBlock">DataBlock</a> )?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[29]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rUpdate">Update</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPrologue">Prologue</a> ( <a href="#rUpdate1">Update1</a> ( <span class="token">';'</span> <a href="#rUpdate">Update</a> )? )?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[30]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rUpdate1">Update1</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rLoad">Load</a> | <a href="#rClear">Clear</a> | <a href="#rDrop">Drop</a> | <a href="#rAdd">Add</a> | <a href="#rMove">Move</a> | <a href="#rCopy">Copy</a> | <a href="#rCreate">Create</a> | <a href="#rDeleteWhere">DeleteWhere</a> | <a href="#rModify">Modify</a> | <a href="#rInsertData">InsertData</a> | <a href="#rDeleteData">DeleteData</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[31]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rLoad">Load</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'LOAD'</span> <span class="token">'SILENT'</span>? <a href="#riri">iri</a> ( <span class="token">'INTO'</span> <a href="#rGraphRef">GraphRef</a> )?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[32]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rClear">Clear</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'CLEAR'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRefAll">GraphRefAll</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[33]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDrop">Drop</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'DROP'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRefAll">GraphRefAll</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[34]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rCreate">Create</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'CREATE'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRef">GraphRef</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[35]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rAdd">Add</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'ADD'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[36]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rMove">Move</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'MOVE'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[37]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rCopy">Copy</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'COPY'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[38]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rInsertData">InsertData</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'INSERT DATA'</span> <a href="#rQuadData">QuadData</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[39]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDeleteData">DeleteData</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'DELETE DATA'</span> <a href="#rQuadData">QuadData</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[40]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDeleteWhere">DeleteWhere</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'DELETE WHERE'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[41]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rModify">Modify</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">( <span class="token">'WITH'</span> <a href="#riri">iri</a> )? ( <a href="#rDeleteClause">DeleteClause</a> <a href="#rInsertClause">InsertClause</a>? | <a href="#rInsertClause">InsertClause</a> ) <a href="#rUsingClause">UsingClause</a>* <span class="token">'WHERE'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[42]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDeleteClause">DeleteClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'DELETE'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[43]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rInsertClause">InsertClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'INSERT'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[44]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rUsingClause">UsingClause</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'USING'</span> ( <a href="#riri">iri</a> | <span class="token">'NAMED'</span> <a href="#riri">iri</a> )</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[45]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGraphOrDefault">GraphOrDefault</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'DEFAULT'</span> | <span class="token">'GRAPH'</span>? <a href="#riri">iri</a> </code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[46]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGraphRef">GraphRef</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'GRAPH'</span> <a href="#riri">iri</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[47]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGraphRefAll">GraphRefAll</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rGraphRef">GraphRef</a> | <span class="token">'DEFAULT'</span> | <span class="token">'NAMED'</span> | <span class="token">'ALL'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[48]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rQuadPattern">QuadPattern</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rQuads">Quads</a> <span class="token">'}'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[49]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rQuadData">QuadData</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rQuads">Quads</a> <span class="token">'}'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[50]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rQuads">Quads</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rTriplesTemplate">TriplesTemplate</a>? ( <a href="#rQuadsNotTriples">QuadsNotTriples</a> <span class="token">'.'</span>? <a href="#rTriplesTemplate">TriplesTemplate</a>? )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[51]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rQuadsNotTriples">QuadsNotTriples</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'GRAPH'</span> <a href="#rVarOrIri">VarOrIri</a> <span class="token">'{'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? <span class="token">'}'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[52]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rTriplesTemplate">TriplesTemplate</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rTriplesSameSubject">TriplesSameSubject</a> ( <span class="token">'.'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? )?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[53]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGroupGraphPattern">GroupGraphPattern</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'{'</span> ( <a href="#rSubSelect">SubSelect</a> | <a href="#rGroupGraphPatternSub">GroupGraphPatternSub</a> ) <span class="token">'}'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[54]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGroupGraphPatternSub">GroupGraphPatternSub</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rTriplesBlock">TriplesBlock</a>? ( <a href="#rGraphPatternNotTriples">GraphPatternNotTriples</a> <span class="token">'.'</span>? <a href="#rTriplesBlock">TriplesBlock</a>? )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[55]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rTriplesBlock">TriplesBlock</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rTriplesSameSubjectPath">TriplesSameSubjectPath</a> ( <span class="token">'.'</span> <a href="#rTriplesBlock">TriplesBlock</a>? )?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[56]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGraphPatternNotTriples">GraphPatternNotTriples</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rGroupOrUnionGraphPattern">GroupOrUnionGraphPattern</a> | <a href="#rOptionalGraphPattern">OptionalGraphPattern</a> | <a href="#rMinusGraphPattern">MinusGraphPattern</a> | <a href="#rGraphGraphPattern">GraphGraphPattern</a> | <a href="#rServiceGraphPattern">ServiceGraphPattern</a> | <a href="#rFilter">Filter</a> | <a href="#rBind">Bind</a> | <a href="#rInlineData">InlineData</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[57]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rOptionalGraphPattern">OptionalGraphPattern</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'OPTIONAL'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[58]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGraphGraphPattern">GraphGraphPattern</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'GRAPH'</span> <a href="#rVarOrIri">VarOrIri</a> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[59]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rServiceGraphPattern">ServiceGraphPattern</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'SERVICE'</span> <span class="token">'SILENT'</span>? <a href="#rVarOrIri">VarOrIri</a> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[60]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rBind">Bind</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'BIND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">'AS'</span> <a href="#rVar">Var</a> <span class="token">')'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[61]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rInlineData">InlineData</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'VALUES'</span> <a href="#rDataBlock">DataBlock</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[62]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDataBlock">DataBlock</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rInlineDataOneVar">InlineDataOneVar</a> | <a href="#rInlineDataFull">InlineDataFull</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[63]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rInlineDataOneVar">InlineDataOneVar</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rVar">Var</a> <span class="token">'{'</span> <a href="#rDataBlockValue">DataBlockValue</a>* <span class="token">'}'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[64]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rInlineDataFull">InlineDataFull</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">( <a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rVar">Var</a>* <span class="token">')'</span> ) <span class="token">'{'</span> ( <span class="token">'('</span> <a href="#rDataBlockValue">DataBlockValue</a>* <span class="token">')'</span> | <a href="#rNIL">NIL</a> )* <span class="token">'}'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[65]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDataBlockValue">DataBlockValue</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#riri">iri</a> |	<a href="#rRDFLiteral">RDFLiteral</a> |	<a href="#rNumericLiteral">NumericLiteral</a> |	<a href="#rBooleanLiteral">BooleanLiteral</a> |	<span class="token">'UNDEF'</span> |	<a href="#rQuotedTripleData">QuotedTripleData</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[66]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rMinusGraphPattern">MinusGraphPattern</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'MINUS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[67]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGroupOrUnionGraphPattern">GroupOrUnionGraphPattern</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rGroupGraphPattern">GroupGraphPattern</a> ( <span class="token">'UNION'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a> )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[68]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rFilter">Filter</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'FILTER'</span> <a href="#rConstraint">Constraint</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[69]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rConstraint">Constraint</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#rFunctionCall">FunctionCall</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[70]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rFunctionCall">FunctionCall</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[71]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rArgList">ArgList</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[72]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rExpressionList">ExpressionList</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[73]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rConstructTemplate">ConstructTemplate</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rConstructTriples">ConstructTriples</a>? <span class="token">'}'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[74]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rConstructTriples">ConstructTriples</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rTriplesSameSubject">TriplesSameSubject</a> ( <span class="token">'.'</span> <a href="#rConstructTriples">ConstructTriples</a>? )?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[75]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rTriplesSameSubject">TriplesSameSubject</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> |	<a href="#rTriplesNode">TriplesNode</a> <a href="#rPropertyList">PropertyList</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[76]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPropertyList">PropertyList</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a>?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[77]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPropertyListNotEmpty">PropertyListNotEmpty</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> ( <span class="token">';'</span> ( <a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> )? )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[78]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rVerb">Verb</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rVarOrIri">VarOrIri</a> | <span class="token">'a'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[79]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rObjectList">ObjectList</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rObject">Object</a> ( <span class="token">','</span> <a href="#rObject">Object</a> )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[80]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rObject">Object</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rGraphNode">GraphNode</a> <a href="#rAnnotation">Annotation</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[81]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rTriplesSameSubjectPath">TriplesSameSubjectPath</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> |	<a href="#rTriplesNodePath">TriplesNodePath</a> <a href="#rPropertyListPath">PropertyListPath</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[82]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPropertyListPath">PropertyListPath</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a>?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[83]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPropertyListPathNotEmpty">PropertyListPathNotEmpty</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> ( <span class="token">';'</span> ( ( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> )? )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[84]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rVerbPath">VerbPath</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPath">Path</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[85]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rVerbSimple">VerbSimple</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rVar">Var</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[86]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rObjectListPath">ObjectListPath</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rObjectPath">ObjectPath</a> ( <span class="token">','</span> <a href="#rObjectPath">ObjectPath</a> )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[87]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rObjectPath">ObjectPath</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rGraphNodePath">GraphNodePath</a> <a href="#rAnnotationPath">AnnotationPath</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[88]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPath">Path</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPathAlternative">PathAlternative</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[89]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPathAlternative">PathAlternative</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPathSequence">PathSequence</a> ( <span class="token">'|'</span> <a href="#rPathSequence">PathSequence</a> )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[90]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPathSequence">PathSequence</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPathEltOrInverse">PathEltOrInverse</a> ( <span class="token">'/'</span> <a href="#rPathEltOrInverse">PathEltOrInverse</a> )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[91]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPathElt">PathElt</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPathPrimary">PathPrimary</a> <a href="#rPathMod">PathMod</a>?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[92]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPathEltOrInverse">PathEltOrInverse</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPathElt">PathElt</a> | <span class="token">'^'</span> <a href="#rPathElt">PathElt</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[93]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPathMod">PathMod</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'?'</span> | <span class="token">'*'</span> | <span class="token">'+'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[94]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPathPrimary">PathPrimary</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#riri">iri</a> | <span class="token">'a'</span> | <span class="token">'!'</span> <a href="#rPathNegatedPropertySet">PathNegatedPropertySet</a> | <span class="token">'('</span> <a href="#rPath">Path</a> <span class="token">')'</span> </code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[95]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPathNegatedPropertySet">PathNegatedPropertySet</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPathOneInPropertySet">PathOneInPropertySet</a> | <span class="token">'('</span> ( <a href="#rPathOneInPropertySet">PathOneInPropertySet</a> ( <span class="token">'|'</span> <a href="#rPathOneInPropertySet">PathOneInPropertySet</a> )* )? <span class="token">')'</span> </code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[96]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPathOneInPropertySet">PathOneInPropertySet</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#riri">iri</a> | <span class="token">'a'</span> | <span class="token">'^'</span> ( <a href="#riri">iri</a> | <span class="token">'a'</span> ) </code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[97]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rInteger">Integer</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rINTEGER">INTEGER</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[98]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rTriplesNode">TriplesNode</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rCollection">Collection</a> |	<a href="#rBlankNodePropertyList">BlankNodePropertyList</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[99]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rBlankNodePropertyList">BlankNodePropertyList</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">']'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[100]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rTriplesNodePath">TriplesNodePath</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rCollectionPath">CollectionPath</a> |	<a href="#rBlankNodePropertyListPath">BlankNodePropertyListPath</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[101]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rBlankNodePropertyListPath">BlankNodePropertyListPath</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">']'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[102]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rCollection">Collection</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNode">GraphNode</a>+ <span class="token">')'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[103]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rCollectionPath">CollectionPath</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNodePath">GraphNodePath</a>+ <span class="token">')'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[104]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rAnnotationPath">AnnotationPath</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">( <span class="token">'{|'</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">'|}'</span> )?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[105]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rAnnotation">Annotation</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">( <span class="token">'{|'</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">'|}'</span> )?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[106]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGraphNode">GraphNode</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> |	<a href="#rTriplesNode">TriplesNode</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[107]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGraphNodePath">GraphNodePath</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> |	<a href="#rTriplesNodePath">TriplesNodePath</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[108]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rVarOrTerm">VarOrTerm</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#rGraphTerm">GraphTerm</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[109]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rQuotedTriple">QuotedTriple</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rVarOrTerm">VarOrTerm</a> <a href="#rVerb">Verb</a> <a href="#rVarOrTerm">VarOrTerm</a> <span class="token">'&gt;&gt;'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[110]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rQuotedTripleData">QuotedTripleData</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rDataValueTerm">DataValueTerm</a> ( <a href="#riri">iri</a> | <span class="token">'a'</span> ) <a href="#rDataValueTerm">DataValueTerm</a> <span class="token">'&gt;&gt;'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[111]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDataValueTerm">DataValueTerm</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#riri">iri</a> |	<a href="#rRDFLiteral">RDFLiteral</a> |	<a href="#rNumericLiteral">NumericLiteral</a> |	<a href="#rBooleanLiteral">BooleanLiteral</a> |	<a href="#rQuotedTripleData">QuotedTripleData</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[112]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rVarOrIri">VarOrIri</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[113]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rVar">Var</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rVAR1">VAR1</a> | <a href="#rVAR2">VAR2</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[114]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rGraphTerm">GraphTerm</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#riri">iri</a> |	<a href="#rRDFLiteral">RDFLiteral</a> |	<a href="#rNumericLiteral">NumericLiteral</a> |	<a href="#rBooleanLiteral">BooleanLiteral</a> |	<a href="#rBlankNode">BlankNode</a> |	<a href="#rQuotedTriple">QuotedTriple</a> |	<a href="#rNIL">NIL</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[115]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rExpression">Expression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rConditionalOrExpression">ConditionalOrExpression</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[116]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rConditionalOrExpression">ConditionalOrExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rConditionalAndExpression">ConditionalAndExpression</a> ( <span class="token">'||'</span> <a href="#rConditionalAndExpression">ConditionalAndExpression</a> )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[117]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rConditionalAndExpression">ConditionalAndExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rValueLogical">ValueLogical</a> ( <span class="token">'&amp;&amp;'</span> <a href="#rValueLogical">ValueLogical</a> )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[118]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rValueLogical">ValueLogical</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rRelationalExpression">RelationalExpression</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[119]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rRelationalExpression">RelationalExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rNumericExpression">NumericExpression</a> ( <span class="token">'='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'!='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> | <span class="token">'NOT'</span> <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> )?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[120]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rNumericExpression">NumericExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rAdditiveExpression">AdditiveExpression</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[121]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rAdditiveExpression">AdditiveExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rMultiplicativeExpression">MultiplicativeExpression</a> ( <span class="token">'+'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | <span class="token">'-'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | ( <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a> ) ( ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) | ( <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) )* )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[122]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rMultiplicativeExpression">MultiplicativeExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rUnaryExpression">UnaryExpression</a> ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> | <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[123]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rUnaryExpression">UnaryExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'!'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'+'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'-'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<a href="#rPrimaryExpression">PrimaryExpression</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[124]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPrimaryExpression">PrimaryExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#ririOrFunction">iriOrFunction</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprQuotedTriple">ExprQuotedTriple</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[125]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rExprVarOrTerm">ExprVarOrTerm</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprQuotedTriple">ExprQuotedTriple</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[126]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rExprQuotedTriple">ExprQuotedTriple</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rExprVarOrTerm">ExprVarOrTerm</a> <a href="#rVerb">Verb</a> <a href="#rExprVarOrTerm">ExprVarOrTerm</a> <span class="token">'&gt;&gt;'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[127]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rBrackettedExpression">BrackettedExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[128]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rBuiltInCall">BuiltInCall</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">&nbsp;&nbsp;<a href="#rAggregate">Aggregate</a> <br/>|	<span class="token">'STR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANGMATCHES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DATATYPE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BOUND'</span> <span class="token">'('</span> <a href="#rVar">Var</a> <span class="token">')'</span> <br/>|	<span class="token">'IRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BNODE'</span> ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> | <a href="#rNIL">NIL</a> ) <br/>|	<span class="token">'RAND'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'ABS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CEIL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'FLOOR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ROUND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONCAT'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<a href="#rSubstringExpression">SubstringExpression</a> <br/>|	<span class="token">'STRLEN'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<a href="#rStrReplaceExpression">StrReplaceExpression</a> <br/>|	<span class="token">'UCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ENCODE_FOR_URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONTAINS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRSTARTS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRENDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRBEFORE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRAFTER'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'YEAR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MONTH'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DAY'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'HOURS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MINUTES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SECONDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TIMEZONE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TZ'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'NOW'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'UUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'STRUUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'MD5'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA1'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA256'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA384'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA512'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'COALESCE'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<span class="token">'IF'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRDT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'sameTerm'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isIRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isURI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isBLANK'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isLITERAL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isNUMERIC'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<a href="#rRegexExpression">RegexExpression</a> <br/>|	<a href="#rExistsFunc">ExistsFunc</a> <br/>|	<a href="#rNotExistsFunc">NotExistsFunc</a> <br/>|	<span class="token">'isTRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SUBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'PREDICATE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'OBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[129]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rRegexExpression">RegexExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'REGEX'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[130]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rSubstringExpression">SubstringExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'SUBSTR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[131]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rStrReplaceExpression">StrReplaceExpression</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'REPLACE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[132]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rExistsFunc">ExistsFunc</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'EXISTS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[133]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rNotExistsFunc">NotExistsFunc</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'NOT'</span> <span class="token">'EXISTS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[134]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rAggregate">Aggregate</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'COUNT'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? ( <span class="token">'*'</span> | <a href="#rExpression">Expression</a> ) <span class="token">')'</span> <br/>| <span class="token">'SUM'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MIN'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MAX'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'AVG'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SAMPLE'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'GROUP_CONCAT'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> ( <span class="token">';'</span> <span class="token">'SEPARATOR'</span> <span class="token">'='</span> <a href="#rString">String</a> )? <span class="token">')'</span> </code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[135]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="ririOrFunction">iriOrFunction</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a>?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[136]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rRDFLiteral">RDFLiteral</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rString">String</a> ( <a href="#rLANGTAG">LANGTAG</a> | ( <span class="token">'^^'</span> <a href="#riri">iri</a> ) )?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[137]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rNumericLiteral">NumericLiteral</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rNumericLiteralUnsigned">NumericLiteralUnsigned</a> | <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[138]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rNumericLiteralUnsigned">NumericLiteralUnsigned</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rINTEGER">INTEGER</a> |	<a href="#rDECIMAL">DECIMAL</a> |	<a href="#rDOUBLE">DOUBLE</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[139]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rNumericLiteralPositive">NumericLiteralPositive</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rINTEGER_POSITIVE">INTEGER_POSITIVE</a> |	<a href="#rDECIMAL_POSITIVE">DECIMAL_POSITIVE</a> |	<a href="#rDOUBLE_POSITIVE">DOUBLE_POSITIVE</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[140]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rNumericLiteralNegative">NumericLiteralNegative</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rINTEGER_NEGATIVE">INTEGER_NEGATIVE</a> |	<a href="#rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</a> |	<a href="#rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[141]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rBooleanLiteral">BooleanLiteral</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'true'</span> |	<span class="token">'false'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[142]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rString">String</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a> | <a href="#rSTRING_LITERAL2">STRING_LITERAL2</a> | <a href="#rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</a> | <a href="#rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[143]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="riri">iri</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rIRIREF">IRIREF</a> |	<a href="#rPrefixedName">PrefixedName</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[144]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPrefixedName">PrefixedName</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPNAME_LN">PNAME_LN</a> | <a href="#rPNAME_NS">PNAME_NS</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[145]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rBlankNode">BlankNode</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rBLANK_NODE_LABEL">BLANK_NODE_LABEL</a> |	<a href="#rANON">ANON</a></code></td>
+</tr>
+  </tbody></table>
+</div>
+<p>Productions for terminals:</p>
+<div class="grammarTable">
+  <table><tbody>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[146]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rIRIREF">IRIREF</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'&lt;' ([^&lt;&gt;"{}|^`\]-[#x00-#x20])* '&gt;'</span></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[147]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPNAME_NS">&lt;PNAME_NS&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPN_PREFIX">PN_PREFIX</a>? ':'</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[148]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPNAME_LN">&lt;PNAME_LN&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPNAME_NS">PNAME_NS</a> <a href="#rPN_LOCAL">PN_LOCAL</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[149]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rBLANK_NODE_LABEL">&lt;BLANK_NODE_LABEL&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">'_:' ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] ) ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[150]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rVAR1">&lt;VAR1&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">'?' <a href="#rVARNAME">VARNAME</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[151]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rVAR2">&lt;VAR2&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">'$' <a href="#rVARNAME">VARNAME</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[152]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rLANGTAG">&lt;LANGTAG&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[153]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rINTEGER">&lt;INTEGER&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">[0-9]+</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[154]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDECIMAL">&lt;DECIMAL&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">[0-9]* '.' [0-9]+</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[155]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDOUBLE">&lt;DOUBLE&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">[0-9]+ '.' [0-9]* <a href="#rEXPONENT">EXPONENT</a> | '.' ([0-9])+ <a href="#rEXPONENT">EXPONENT</a> | ([0-9])+ <a href="#rEXPONENT">EXPONENT</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[156]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rINTEGER_POSITIVE">&lt;INTEGER_POSITIVE&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rINTEGER">INTEGER</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[157]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDECIMAL_POSITIVE">&lt;DECIMAL_POSITIVE&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[158]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDOUBLE_POSITIVE">&lt;DOUBLE_POSITIVE&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[159]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rINTEGER_NEGATIVE">&lt;INTEGER_NEGATIVE&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rINTEGER">INTEGER</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[160]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDECIMAL_NEGATIVE">&lt;DECIMAL_NEGATIVE&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[161]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rDOUBLE_NEGATIVE">&lt;DOUBLE_NEGATIVE&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[162]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rEXPONENT">&lt;EXPONENT&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">[eE] [+-]? [0-9]+</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[163]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rSTRING_LITERAL1">&lt;STRING_LITERAL1&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">"'" ( ([^#x27#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* "'"</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[164]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rSTRING_LITERAL2">&lt;STRING_LITERAL2&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">'"' ( ([^#x22#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* '"'</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[165]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG1">&lt;STRING_LITERAL_LONG1&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">"'''" ( ( "'" | "''" )? ( [^'\] | <a href="#rECHAR">ECHAR</a> ) )* "'''"</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[166]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG2">&lt;STRING_LITERAL_LONG2&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">'"""' ( ( '"' | '""' )? ( [^"\] | <a href="#rECHAR">ECHAR</a> ) )* '"""'</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[167]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rECHAR">&lt;ECHAR&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">'\' [tbnrf\"']</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[168]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rNIL">&lt;NIL&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">'(' <a href="#rWS">WS</a>* ')'</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[169]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rWS">&lt;WS&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">#x20 | #x9 | #xD | #xA</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[170]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rANON">&lt;ANON&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">'['  <a href="#rWS">WS</a>* ']'</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[171]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPN_CHARS_BASE">&lt;PN_CHARS_BASE&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">[A-Z] | [a-z] | [#x00C0-#x00D6] | [#x00D8-#x00F6] | [#x00F8-#x02FF] | [#x0370-#x037D] | [#x037F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[172]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPN_CHARS_U">&lt;PN_CHARS_U&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> | '_'</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[173]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rVARNAME">&lt;VARNAME&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">( <a href="#rPN_CHARS_U">PN_CHARS_U</a>  | [0-9] ) ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[174]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPN_CHARS">&lt;PN_CHARS&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPN_CHARS_U">PN_CHARS_U</a> | '-' | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040]</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[175]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPN_PREFIX">&lt;PN_PREFIX&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[176]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPN_LOCAL">&lt;PN_LOCAL&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">(<a href="#rPN_CHARS_U">PN_CHARS_U</a> | ':' | [0-9] | <a href="#rPLX">PLX</a> ) ((<a href="#rPN_CHARS">PN_CHARS</a> | '.' | ':' | <a href="#rPLX">PLX</a>)* (<a href="#rPN_CHARS">PN_CHARS</a> | ':' | <a href="#rPLX">PLX</a>) )?</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[177]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPLX">&lt;PLX&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody"><a href="#rPERCENT">PERCENT</a> | <a href="#rPN_LOCAL_ESC">PN_LOCAL_ESC</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[178]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPERCENT">&lt;PERCENT&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">'%' <a href="#rHEX">HEX</a> <a href="#rHEX">HEX</a></code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[179]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rHEX">&lt;HEX&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">[0-9] | [A-F] | [a-f]</code></td>
+</tr>
+
+<tr  style="vertical-align: baseline">
+  <td><code>[180]&nbsp;&nbsp;</code></td>
+  <td><code><span class="doc-ref" id="rPN_LOCAL_ESC">&lt;PN_LOCAL_ESC&gt;</span></code></td>
+  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+  <td><code class="gRuleBody">'\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )</code></td>
+</tr>
+  </tbody></table>
+</div>
+
+        <!-- GRAMMAR -->
       </section>
     </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -10167,1276 +10167,1268 @@ _:x rdf:type xsd:decimal .
             in a <a href="#rFunctionCall">function call</a>.</li>
         </ol>
         <!-- GRAMMAR -->
-<div class="grammarTable">
-  <table><tbody>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[1]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rQueryUnit">QueryUnit</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rQuery">Query</a> <span class="token"></span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[2]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rQuery">Query</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPrologue">Prologue</a><br/>( <a href="#rSelectQuery">SelectQuery</a> | <a href="#rConstructQuery">ConstructQuery</a> | <a href="#rDescribeQuery">DescribeQuery</a> | <a href="#rAskQuery">AskQuery</a> )<br/><a href="#rValuesClause">ValuesClause</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[3]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rUpdateUnit">UpdateUnit</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rUpdate">Update</a> <span class="token"></span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[4]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPrologue">Prologue</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">( <a href="#rBaseDecl">BaseDecl</a> | <a href="#rPrefixDecl">PrefixDecl</a> )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[5]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rBaseDecl">BaseDecl</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'BASE'</span> <a href="#rIRIREF">IRIREF</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[6]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPrefixDecl">PrefixDecl</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'PREFIX'</span> <a href="#rPNAME_NS">PNAME_NS</a> <a href="#rIRIREF">IRIREF</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[7]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rSelectQuery">SelectQuery</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rSelectClause">SelectClause</a> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[8]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rSubSelect">SubSelect</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rSelectClause">SelectClause</a> <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a> <a href="#rValuesClause">ValuesClause</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[9]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rSelectClause">SelectClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'SELECT'</span> ( <span class="token">'DISTINCT'</span> | <span class="token">'REDUCED'</span> )? ( ( <a href="#rVar">Var</a> | ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">'AS'</span> <a href="#rVar">Var</a> <span class="token">')'</span> ) )+ | <span class="token">'*'</span> )</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[10]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rConstructQuery">ConstructQuery</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'CONSTRUCT'</span> ( <a href="#rConstructTemplate">ConstructTemplate</a> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a> | <a href="#rDatasetClause">DatasetClause</a>* <span class="token">'WHERE'</span> <span class="token">'{'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? <span class="token">'}'</span> <a href="#rSolutionModifier">SolutionModifier</a> )</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[11]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDescribeQuery">DescribeQuery</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'DESCRIBE'</span> ( <a href="#rVarOrIri">VarOrIri</a>+ | <span class="token">'*'</span> ) <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a>? <a href="#rSolutionModifier">SolutionModifier</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[12]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rAskQuery">AskQuery</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'ASK'</span> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[13]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDatasetClause">DatasetClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'FROM'</span> ( <a href="#rDefaultGraphClause">DefaultGraphClause</a> | <a href="#rNamedGraphClause">NamedGraphClause</a> )</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[14]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDefaultGraphClause">DefaultGraphClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rSourceSelector">SourceSelector</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[15]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rNamedGraphClause">NamedGraphClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'NAMED'</span> <a href="#rSourceSelector">SourceSelector</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[16]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rSourceSelector">SourceSelector</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#riri">iri</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[17]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rWhereClause">WhereClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'WHERE'</span>? <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[18]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rSolutionModifier">SolutionModifier</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rGroupClause">GroupClause</a>? <a href="#rHavingClause">HavingClause</a>? <a href="#rOrderClause">OrderClause</a>? <a href="#rLimitOffsetClauses">LimitOffsetClauses</a>?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[19]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGroupClause">GroupClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'GROUP'</span> <span class="token">'BY'</span> <a href="#rGroupCondition">GroupCondition</a>+</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[20]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGroupCondition">GroupCondition</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rBuiltInCall">BuiltInCall</a> | <a href="#rFunctionCall">FunctionCall</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">'AS'</span> <a href="#rVar">Var</a> )? <span class="token">')'</span> | <a href="#rVar">Var</a> </code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[21]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rHavingClause">HavingClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'HAVING'</span> <a href="#rHavingCondition">HavingCondition</a>+</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[22]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rHavingCondition">HavingCondition</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rConstraint">Constraint</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[23]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rOrderClause">OrderClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'ORDER'</span> <span class="token">'BY'</span> <a href="#rOrderCondition">OrderCondition</a>+</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[24]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rOrderCondition">OrderCondition</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">   ( ( <span class="token">'ASC'</span> | <span class="token">'DESC'</span> ) <a href="#rBrackettedExpression">BrackettedExpression</a> )<br/>| ( <a href="#rConstraint">Constraint</a> | <a href="#rVar">Var</a> ) </code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[25]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rLimitOffsetClauses">LimitOffsetClauses</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rLimitClause">LimitClause</a> <a href="#rOffsetClause">OffsetClause</a>? | <a href="#rOffsetClause">OffsetClause</a> <a href="#rLimitClause">LimitClause</a>? </code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[26]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rLimitClause">LimitClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'LIMIT'</span> <a href="#rINTEGER">INTEGER</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[27]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rOffsetClause">OffsetClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'OFFSET'</span> <a href="#rINTEGER">INTEGER</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[28]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rValuesClause">ValuesClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">( <span class="token">'VALUES'</span> <a href="#rDataBlock">DataBlock</a> )?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[29]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rUpdate">Update</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPrologue">Prologue</a> ( <a href="#rUpdate1">Update1</a> ( <span class="token">';'</span> <a href="#rUpdate">Update</a> )? )?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[30]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rUpdate1">Update1</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rLoad">Load</a> | <a href="#rClear">Clear</a> | <a href="#rDrop">Drop</a> | <a href="#rAdd">Add</a> | <a href="#rMove">Move</a> | <a href="#rCopy">Copy</a> | <a href="#rCreate">Create</a> | <a href="#rDeleteWhere">DeleteWhere</a> | <a href="#rModify">Modify</a> | <a href="#rInsertData">InsertData</a> | <a href="#rDeleteData">DeleteData</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[31]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rLoad">Load</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'LOAD'</span> <span class="token">'SILENT'</span>? <a href="#riri">iri</a> ( <span class="token">'INTO'</span> <a href="#rGraphRef">GraphRef</a> )?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[32]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rClear">Clear</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'CLEAR'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRefAll">GraphRefAll</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[33]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDrop">Drop</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'DROP'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRefAll">GraphRefAll</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[34]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rCreate">Create</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'CREATE'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRef">GraphRef</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[35]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rAdd">Add</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'ADD'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[36]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rMove">Move</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'MOVE'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[37]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rCopy">Copy</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'COPY'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[38]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rInsertData">InsertData</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'INSERT DATA'</span> <a href="#rQuadData">QuadData</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[39]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDeleteData">DeleteData</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'DELETE DATA'</span> <a href="#rQuadData">QuadData</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[40]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDeleteWhere">DeleteWhere</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'DELETE WHERE'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[41]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rModify">Modify</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">( <span class="token">'WITH'</span> <a href="#riri">iri</a> )? ( <a href="#rDeleteClause">DeleteClause</a> <a href="#rInsertClause">InsertClause</a>? | <a href="#rInsertClause">InsertClause</a> ) <a href="#rUsingClause">UsingClause</a>* <span class="token">'WHERE'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[42]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDeleteClause">DeleteClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'DELETE'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[43]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rInsertClause">InsertClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'INSERT'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[44]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rUsingClause">UsingClause</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'USING'</span> ( <a href="#riri">iri</a> | <span class="token">'NAMED'</span> <a href="#riri">iri</a> )</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[45]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGraphOrDefault">GraphOrDefault</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'DEFAULT'</span> | <span class="token">'GRAPH'</span>? <a href="#riri">iri</a> </code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[46]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGraphRef">GraphRef</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'GRAPH'</span> <a href="#riri">iri</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[47]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGraphRefAll">GraphRefAll</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rGraphRef">GraphRef</a> | <span class="token">'DEFAULT'</span> | <span class="token">'NAMED'</span> | <span class="token">'ALL'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[48]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rQuadPattern">QuadPattern</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rQuads">Quads</a> <span class="token">'}'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[49]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rQuadData">QuadData</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rQuads">Quads</a> <span class="token">'}'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[50]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rQuads">Quads</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rTriplesTemplate">TriplesTemplate</a>? ( <a href="#rQuadsNotTriples">QuadsNotTriples</a> <span class="token">'.'</span>? <a href="#rTriplesTemplate">TriplesTemplate</a>? )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[51]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rQuadsNotTriples">QuadsNotTriples</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'GRAPH'</span> <a href="#rVarOrIri">VarOrIri</a> <span class="token">'{'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? <span class="token">'}'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[52]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rTriplesTemplate">TriplesTemplate</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rTriplesSameSubject">TriplesSameSubject</a> ( <span class="token">'.'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? )?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[53]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGroupGraphPattern">GroupGraphPattern</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'{'</span> ( <a href="#rSubSelect">SubSelect</a> | <a href="#rGroupGraphPatternSub">GroupGraphPatternSub</a> ) <span class="token">'}'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[54]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGroupGraphPatternSub">GroupGraphPatternSub</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rTriplesBlock">TriplesBlock</a>? ( <a href="#rGraphPatternNotTriples">GraphPatternNotTriples</a> <span class="token">'.'</span>? <a href="#rTriplesBlock">TriplesBlock</a>? )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[55]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rTriplesBlock">TriplesBlock</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rTriplesSameSubjectPath">TriplesSameSubjectPath</a> ( <span class="token">'.'</span> <a href="#rTriplesBlock">TriplesBlock</a>? )?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[56]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGraphPatternNotTriples">GraphPatternNotTriples</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rGroupOrUnionGraphPattern">GroupOrUnionGraphPattern</a> | <a href="#rOptionalGraphPattern">OptionalGraphPattern</a> | <a href="#rMinusGraphPattern">MinusGraphPattern</a> | <a href="#rGraphGraphPattern">GraphGraphPattern</a> | <a href="#rServiceGraphPattern">ServiceGraphPattern</a> | <a href="#rFilter">Filter</a> | <a href="#rBind">Bind</a> | <a href="#rInlineData">InlineData</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[57]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rOptionalGraphPattern">OptionalGraphPattern</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'OPTIONAL'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[58]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGraphGraphPattern">GraphGraphPattern</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'GRAPH'</span> <a href="#rVarOrIri">VarOrIri</a> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[59]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rServiceGraphPattern">ServiceGraphPattern</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'SERVICE'</span> <span class="token">'SILENT'</span>? <a href="#rVarOrIri">VarOrIri</a> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[60]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rBind">Bind</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'BIND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">'AS'</span> <a href="#rVar">Var</a> <span class="token">')'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[61]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rInlineData">InlineData</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'VALUES'</span> <a href="#rDataBlock">DataBlock</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[62]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDataBlock">DataBlock</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rInlineDataOneVar">InlineDataOneVar</a> | <a href="#rInlineDataFull">InlineDataFull</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[63]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rInlineDataOneVar">InlineDataOneVar</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rVar">Var</a> <span class="token">'{'</span> <a href="#rDataBlockValue">DataBlockValue</a>* <span class="token">'}'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[64]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rInlineDataFull">InlineDataFull</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">( <a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rVar">Var</a>* <span class="token">')'</span> ) <span class="token">'{'</span> ( <span class="token">'('</span> <a href="#rDataBlockValue">DataBlockValue</a>* <span class="token">')'</span> | <a href="#rNIL">NIL</a> )* <span class="token">'}'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[65]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDataBlockValue">DataBlockValue</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#riri">iri</a> |	<a href="#rRDFLiteral">RDFLiteral</a> |	<a href="#rNumericLiteral">NumericLiteral</a> |	<a href="#rBooleanLiteral">BooleanLiteral</a> |	<span class="token">'UNDEF'</span> |	<a href="#rQuotedTripleData">QuotedTripleData</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[66]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rMinusGraphPattern">MinusGraphPattern</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'MINUS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[67]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGroupOrUnionGraphPattern">GroupOrUnionGraphPattern</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rGroupGraphPattern">GroupGraphPattern</a> ( <span class="token">'UNION'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a> )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[68]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rFilter">Filter</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'FILTER'</span> <a href="#rConstraint">Constraint</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[69]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rConstraint">Constraint</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#rFunctionCall">FunctionCall</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[70]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rFunctionCall">FunctionCall</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[71]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rArgList">ArgList</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[72]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rExpressionList">ExpressionList</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[73]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rConstructTemplate">ConstructTemplate</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rConstructTriples">ConstructTriples</a>? <span class="token">'}'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[74]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rConstructTriples">ConstructTriples</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rTriplesSameSubject">TriplesSameSubject</a> ( <span class="token">'.'</span> <a href="#rConstructTriples">ConstructTriples</a>? )?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[75]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rTriplesSameSubject">TriplesSameSubject</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> |	<a href="#rTriplesNode">TriplesNode</a> <a href="#rPropertyList">PropertyList</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[76]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPropertyList">PropertyList</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a>?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[77]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPropertyListNotEmpty">PropertyListNotEmpty</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> ( <span class="token">';'</span> ( <a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> )? )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[78]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rVerb">Verb</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rVarOrIri">VarOrIri</a> | <span class="token">'a'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[79]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rObjectList">ObjectList</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rObject">Object</a> ( <span class="token">','</span> <a href="#rObject">Object</a> )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[80]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rObject">Object</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rGraphNode">GraphNode</a> <a href="#rAnnotation">Annotation</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[81]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rTriplesSameSubjectPath">TriplesSameSubjectPath</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> |	<a href="#rTriplesNodePath">TriplesNodePath</a> <a href="#rPropertyListPath">PropertyListPath</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[82]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPropertyListPath">PropertyListPath</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a>?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[83]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPropertyListPathNotEmpty">PropertyListPathNotEmpty</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> ( <span class="token">';'</span> ( ( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> )? )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[84]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rVerbPath">VerbPath</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPath">Path</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[85]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rVerbSimple">VerbSimple</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rVar">Var</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[86]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rObjectListPath">ObjectListPath</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rObjectPath">ObjectPath</a> ( <span class="token">','</span> <a href="#rObjectPath">ObjectPath</a> )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[87]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rObjectPath">ObjectPath</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rGraphNodePath">GraphNodePath</a> <a href="#rAnnotationPath">AnnotationPath</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[88]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPath">Path</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPathAlternative">PathAlternative</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[89]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPathAlternative">PathAlternative</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPathSequence">PathSequence</a> ( <span class="token">'|'</span> <a href="#rPathSequence">PathSequence</a> )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[90]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPathSequence">PathSequence</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPathEltOrInverse">PathEltOrInverse</a> ( <span class="token">'/'</span> <a href="#rPathEltOrInverse">PathEltOrInverse</a> )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[91]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPathElt">PathElt</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPathPrimary">PathPrimary</a> <a href="#rPathMod">PathMod</a>?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[92]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPathEltOrInverse">PathEltOrInverse</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPathElt">PathElt</a> | <span class="token">'^'</span> <a href="#rPathElt">PathElt</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[93]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPathMod">PathMod</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'?'</span> | <span class="token">'*'</span> | <span class="token">'+'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[94]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPathPrimary">PathPrimary</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#riri">iri</a> | <span class="token">'a'</span> | <span class="token">'!'</span> <a href="#rPathNegatedPropertySet">PathNegatedPropertySet</a> | <span class="token">'('</span> <a href="#rPath">Path</a> <span class="token">')'</span> </code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[95]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPathNegatedPropertySet">PathNegatedPropertySet</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPathOneInPropertySet">PathOneInPropertySet</a> | <span class="token">'('</span> ( <a href="#rPathOneInPropertySet">PathOneInPropertySet</a> ( <span class="token">'|'</span> <a href="#rPathOneInPropertySet">PathOneInPropertySet</a> )* )? <span class="token">')'</span> </code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[96]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPathOneInPropertySet">PathOneInPropertySet</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#riri">iri</a> | <span class="token">'a'</span> | <span class="token">'^'</span> ( <a href="#riri">iri</a> | <span class="token">'a'</span> ) </code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[97]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rInteger">Integer</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rINTEGER">INTEGER</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[98]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rTriplesNode">TriplesNode</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rCollection">Collection</a> |	<a href="#rBlankNodePropertyList">BlankNodePropertyList</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[99]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rBlankNodePropertyList">BlankNodePropertyList</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">']'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[100]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rTriplesNodePath">TriplesNodePath</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rCollectionPath">CollectionPath</a> |	<a href="#rBlankNodePropertyListPath">BlankNodePropertyListPath</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[101]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rBlankNodePropertyListPath">BlankNodePropertyListPath</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">']'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[102]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rCollection">Collection</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNode">GraphNode</a>+ <span class="token">')'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[103]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rCollectionPath">CollectionPath</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNodePath">GraphNodePath</a>+ <span class="token">')'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[104]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rAnnotationPath">AnnotationPath</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">( <span class="token">'{|'</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">'|}'</span> )?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[105]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rAnnotation">Annotation</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">( <span class="token">'{|'</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">'|}'</span> )?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[106]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGraphNode">GraphNode</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> |	<a href="#rTriplesNode">TriplesNode</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[107]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGraphNodePath">GraphNodePath</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> |	<a href="#rTriplesNodePath">TriplesNodePath</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[108]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rVarOrTerm">VarOrTerm</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#rGraphTerm">GraphTerm</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[109]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rQuotedTriple">QuotedTriple</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rVarOrTerm">VarOrTerm</a> <a href="#rVerb">Verb</a> <a href="#rVarOrTerm">VarOrTerm</a> <span class="token">'&gt;&gt;'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[110]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rQuotedTripleData">QuotedTripleData</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rDataValueTerm">DataValueTerm</a> ( <a href="#riri">iri</a> | <span class="token">'a'</span> ) <a href="#rDataValueTerm">DataValueTerm</a> <span class="token">'&gt;&gt;'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[111]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDataValueTerm">DataValueTerm</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#riri">iri</a> |	<a href="#rRDFLiteral">RDFLiteral</a> |	<a href="#rNumericLiteral">NumericLiteral</a> |	<a href="#rBooleanLiteral">BooleanLiteral</a> |	<a href="#rQuotedTripleData">QuotedTripleData</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[112]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rVarOrIri">VarOrIri</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[113]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rVar">Var</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rVAR1">VAR1</a> | <a href="#rVAR2">VAR2</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[114]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rGraphTerm">GraphTerm</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#riri">iri</a> |	<a href="#rRDFLiteral">RDFLiteral</a> |	<a href="#rNumericLiteral">NumericLiteral</a> |	<a href="#rBooleanLiteral">BooleanLiteral</a> |	<a href="#rBlankNode">BlankNode</a> |	<a href="#rQuotedTriple">QuotedTriple</a> |	<a href="#rNIL">NIL</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[115]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rExpression">Expression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rConditionalOrExpression">ConditionalOrExpression</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[116]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rConditionalOrExpression">ConditionalOrExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rConditionalAndExpression">ConditionalAndExpression</a> ( <span class="token">'||'</span> <a href="#rConditionalAndExpression">ConditionalAndExpression</a> )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[117]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rConditionalAndExpression">ConditionalAndExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rValueLogical">ValueLogical</a> ( <span class="token">'&amp;&amp;'</span> <a href="#rValueLogical">ValueLogical</a> )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[118]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rValueLogical">ValueLogical</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rRelationalExpression">RelationalExpression</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[119]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rRelationalExpression">RelationalExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rNumericExpression">NumericExpression</a> ( <span class="token">'='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'!='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> | <span class="token">'NOT'</span> <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> )?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[120]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rNumericExpression">NumericExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rAdditiveExpression">AdditiveExpression</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[121]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rAdditiveExpression">AdditiveExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rMultiplicativeExpression">MultiplicativeExpression</a> ( <span class="token">'+'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | <span class="token">'-'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | ( <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a> ) ( ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) | ( <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) )* )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[122]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rMultiplicativeExpression">MultiplicativeExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rUnaryExpression">UnaryExpression</a> ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> | <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[123]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rUnaryExpression">UnaryExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'!'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'+'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'-'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<a href="#rPrimaryExpression">PrimaryExpression</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[124]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPrimaryExpression">PrimaryExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#ririOrFunction">iriOrFunction</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprQuotedTriple">ExprQuotedTriple</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[125]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rExprVarOrTerm">ExprVarOrTerm</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprQuotedTriple">ExprQuotedTriple</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[126]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rExprQuotedTriple">ExprQuotedTriple</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rExprVarOrTerm">ExprVarOrTerm</a> <a href="#rVerb">Verb</a> <a href="#rExprVarOrTerm">ExprVarOrTerm</a> <span class="token">'&gt;&gt;'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[127]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rBrackettedExpression">BrackettedExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[128]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rBuiltInCall">BuiltInCall</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">&nbsp;&nbsp;<a href="#rAggregate">Aggregate</a> <br/>|	<span class="token">'STR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANGMATCHES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DATATYPE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BOUND'</span> <span class="token">'('</span> <a href="#rVar">Var</a> <span class="token">')'</span> <br/>|	<span class="token">'IRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BNODE'</span> ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> | <a href="#rNIL">NIL</a> ) <br/>|	<span class="token">'RAND'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'ABS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CEIL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'FLOOR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ROUND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONCAT'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<a href="#rSubstringExpression">SubstringExpression</a> <br/>|	<span class="token">'STRLEN'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<a href="#rStrReplaceExpression">StrReplaceExpression</a> <br/>|	<span class="token">'UCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ENCODE_FOR_URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONTAINS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRSTARTS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRENDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRBEFORE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRAFTER'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'YEAR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MONTH'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DAY'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'HOURS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MINUTES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SECONDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TIMEZONE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TZ'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'NOW'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'UUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'STRUUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'MD5'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA1'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA256'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA384'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA512'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'COALESCE'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<span class="token">'IF'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRDT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'sameTerm'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isIRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isURI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isBLANK'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isLITERAL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isNUMERIC'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<a href="#rRegexExpression">RegexExpression</a> <br/>|	<a href="#rExistsFunc">ExistsFunc</a> <br/>|	<a href="#rNotExistsFunc">NotExistsFunc</a> <br/>|	<span class="token">'isTRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SUBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'PREDICATE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'OBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[129]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rRegexExpression">RegexExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'REGEX'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[130]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rSubstringExpression">SubstringExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'SUBSTR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[131]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rStrReplaceExpression">StrReplaceExpression</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'REPLACE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[132]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rExistsFunc">ExistsFunc</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'EXISTS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[133]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rNotExistsFunc">NotExistsFunc</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'NOT'</span> <span class="token">'EXISTS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[134]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rAggregate">Aggregate</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'COUNT'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? ( <span class="token">'*'</span> | <a href="#rExpression">Expression</a> ) <span class="token">')'</span> <br/>| <span class="token">'SUM'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MIN'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MAX'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'AVG'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SAMPLE'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'GROUP_CONCAT'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> ( <span class="token">';'</span> <span class="token">'SEPARATOR'</span> <span class="token">'='</span> <a href="#rString">String</a> )? <span class="token">')'</span> </code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[135]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="ririOrFunction">iriOrFunction</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a>?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[136]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rRDFLiteral">RDFLiteral</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rString">String</a> ( <a href="#rLANGTAG">LANGTAG</a> | ( <span class="token">'^^'</span> <a href="#riri">iri</a> ) )?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[137]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rNumericLiteral">NumericLiteral</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rNumericLiteralUnsigned">NumericLiteralUnsigned</a> | <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[138]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rNumericLiteralUnsigned">NumericLiteralUnsigned</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rINTEGER">INTEGER</a> |	<a href="#rDECIMAL">DECIMAL</a> |	<a href="#rDOUBLE">DOUBLE</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[139]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rNumericLiteralPositive">NumericLiteralPositive</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rINTEGER_POSITIVE">INTEGER_POSITIVE</a> |	<a href="#rDECIMAL_POSITIVE">DECIMAL_POSITIVE</a> |	<a href="#rDOUBLE_POSITIVE">DOUBLE_POSITIVE</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[140]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rNumericLiteralNegative">NumericLiteralNegative</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rINTEGER_NEGATIVE">INTEGER_NEGATIVE</a> |	<a href="#rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</a> |	<a href="#rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[141]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rBooleanLiteral">BooleanLiteral</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'true'</span> |	<span class="token">'false'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[142]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rString">String</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a> | <a href="#rSTRING_LITERAL2">STRING_LITERAL2</a> | <a href="#rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</a> | <a href="#rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[143]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="riri">iri</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rIRIREF">IRIREF</a> |	<a href="#rPrefixedName">PrefixedName</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[144]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPrefixedName">PrefixedName</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPNAME_LN">PNAME_LN</a> | <a href="#rPNAME_NS">PNAME_NS</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[145]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rBlankNode">BlankNode</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rBLANK_NODE_LABEL">BLANK_NODE_LABEL</a> |	<a href="#rANON">ANON</a></code></td>
-</tr>
-  </tbody></table>
-</div>
-<p>Productions for terminals:</p>
-<div class="grammarTable">
-  <table><tbody>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[146]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rIRIREF">IRIREF</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'&lt;' ([^&lt;&gt;"{}|^`\]-[#x00-#x20])* '&gt;'</span></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[147]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPNAME_NS">&lt;PNAME_NS&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPN_PREFIX">PN_PREFIX</a>? ':'</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[148]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPNAME_LN">&lt;PNAME_LN&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPNAME_NS">PNAME_NS</a> <a href="#rPN_LOCAL">PN_LOCAL</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[149]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rBLANK_NODE_LABEL">&lt;BLANK_NODE_LABEL&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">'_:' ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] ) ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[150]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rVAR1">&lt;VAR1&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">'?' <a href="#rVARNAME">VARNAME</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[151]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rVAR2">&lt;VAR2&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">'$' <a href="#rVARNAME">VARNAME</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[152]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rLANGTAG">&lt;LANGTAG&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[153]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rINTEGER">&lt;INTEGER&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">[0-9]+</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[154]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDECIMAL">&lt;DECIMAL&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">[0-9]* '.' [0-9]+</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[155]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDOUBLE">&lt;DOUBLE&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">[0-9]+ '.' [0-9]* <a href="#rEXPONENT">EXPONENT</a> | '.' ([0-9])+ <a href="#rEXPONENT">EXPONENT</a> | ([0-9])+ <a href="#rEXPONENT">EXPONENT</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[156]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rINTEGER_POSITIVE">&lt;INTEGER_POSITIVE&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rINTEGER">INTEGER</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[157]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDECIMAL_POSITIVE">&lt;DECIMAL_POSITIVE&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[158]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDOUBLE_POSITIVE">&lt;DOUBLE_POSITIVE&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[159]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rINTEGER_NEGATIVE">&lt;INTEGER_NEGATIVE&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rINTEGER">INTEGER</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[160]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDECIMAL_NEGATIVE">&lt;DECIMAL_NEGATIVE&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[161]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rDOUBLE_NEGATIVE">&lt;DOUBLE_NEGATIVE&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[162]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rEXPONENT">&lt;EXPONENT&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">[eE] [+-]? [0-9]+</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[163]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rSTRING_LITERAL1">&lt;STRING_LITERAL1&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">"'" ( ([^#x27#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* "'"</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[164]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rSTRING_LITERAL2">&lt;STRING_LITERAL2&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">'"' ( ([^#x22#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* '"'</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[165]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG1">&lt;STRING_LITERAL_LONG1&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">"'''" ( ( "'" | "''" )? ( [^'\] | <a href="#rECHAR">ECHAR</a> ) )* "'''"</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[166]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG2">&lt;STRING_LITERAL_LONG2&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">'"""' ( ( '"' | '""' )? ( [^"\] | <a href="#rECHAR">ECHAR</a> ) )* '"""'</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[167]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rECHAR">&lt;ECHAR&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">'\' [tbnrf\"']</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[168]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rNIL">&lt;NIL&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">'(' <a href="#rWS">WS</a>* ')'</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[169]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rWS">&lt;WS&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">#x20 | #x9 | #xD | #xA</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[170]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rANON">&lt;ANON&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">'['  <a href="#rWS">WS</a>* ']'</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[171]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPN_CHARS_BASE">&lt;PN_CHARS_BASE&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">[A-Z] | [a-z] | [#x00C0-#x00D6] | [#x00D8-#x00F6] | [#x00F8-#x02FF] | [#x0370-#x037D] | [#x037F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[172]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPN_CHARS_U">&lt;PN_CHARS_U&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> | '_'</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[173]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rVARNAME">&lt;VARNAME&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">( <a href="#rPN_CHARS_U">PN_CHARS_U</a>  | [0-9] ) ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[174]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPN_CHARS">&lt;PN_CHARS&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPN_CHARS_U">PN_CHARS_U</a> | '-' | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040]</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[175]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPN_PREFIX">&lt;PN_PREFIX&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[176]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPN_LOCAL">&lt;PN_LOCAL&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">(<a href="#rPN_CHARS_U">PN_CHARS_U</a> | ':' | [0-9] | <a href="#rPLX">PLX</a> ) ((<a href="#rPN_CHARS">PN_CHARS</a> | '.' | ':' | <a href="#rPLX">PLX</a>)* (<a href="#rPN_CHARS">PN_CHARS</a> | ':' | <a href="#rPLX">PLX</a>) )?</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[177]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPLX">&lt;PLX&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody"><a href="#rPERCENT">PERCENT</a> | <a href="#rPN_LOCAL_ESC">PN_LOCAL_ESC</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[178]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPERCENT">&lt;PERCENT&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">'%' <a href="#rHEX">HEX</a> <a href="#rHEX">HEX</a></code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[179]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rHEX">&lt;HEX&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">[0-9] | [A-F] | [a-f]</code></td>
-</tr>
-
-<tr  style="vertical-align: baseline">
-  <td><code>[180]&nbsp;&nbsp;</code></td>
-  <td><code><span class="doc-ref" id="rPN_LOCAL_ESC">&lt;PN_LOCAL_ESC&gt;</span></code></td>
-  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-  <td><code class="gRuleBody">'\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )</code></td>
-</tr>
-  </tbody></table>
-</div>
-
+        <div class="grammarTable">
+          <table><tbody>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[1]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rQueryUnit">QueryUnit</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rQuery">Query</a> <span class="token"></span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[2]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rQuery">Query</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPrologue">Prologue</a><br/>( <a href="#rSelectQuery">SelectQuery</a> | <a href="#rConstructQuery">ConstructQuery</a> | <a href="#rDescribeQuery">DescribeQuery</a> | <a href="#rAskQuery">AskQuery</a> )<br/><a href="#rValuesClause">ValuesClause</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[3]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rUpdateUnit">UpdateUnit</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rUpdate">Update</a> <span class="token"></span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[4]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPrologue">Prologue</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">( <a href="#rBaseDecl">BaseDecl</a> | <a href="#rPrefixDecl">PrefixDecl</a> )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[5]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rBaseDecl">BaseDecl</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'BASE'</span> <a href="#rIRIREF">IRIREF</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[6]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPrefixDecl">PrefixDecl</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'PREFIX'</span> <a href="#rPNAME_NS">PNAME_NS</a> <a href="#rIRIREF">IRIREF</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[7]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rSelectQuery">SelectQuery</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rSelectClause">SelectClause</a> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[8]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rSubSelect">SubSelect</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rSelectClause">SelectClause</a> <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a> <a href="#rValuesClause">ValuesClause</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[9]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rSelectClause">SelectClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'SELECT'</span> ( <span class="token">'DISTINCT'</span> | <span class="token">'REDUCED'</span> )? ( ( <a href="#rVar">Var</a> | ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">'AS'</span> <a href="#rVar">Var</a> <span class="token">')'</span> ) )+ | <span class="token">'*'</span> )</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[10]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rConstructQuery">ConstructQuery</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'CONSTRUCT'</span> ( <a href="#rConstructTemplate">ConstructTemplate</a> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a> | <a href="#rDatasetClause">DatasetClause</a>* <span class="token">'WHERE'</span> <span class="token">'{'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? <span class="token">'}'</span> <a href="#rSolutionModifier">SolutionModifier</a> )</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[11]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDescribeQuery">DescribeQuery</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'DESCRIBE'</span> ( <a href="#rVarOrIri">VarOrIri</a>+ | <span class="token">'*'</span> ) <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a>? <a href="#rSolutionModifier">SolutionModifier</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[12]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rAskQuery">AskQuery</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'ASK'</span> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[13]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDatasetClause">DatasetClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'FROM'</span> ( <a href="#rDefaultGraphClause">DefaultGraphClause</a> | <a href="#rNamedGraphClause">NamedGraphClause</a> )</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[14]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDefaultGraphClause">DefaultGraphClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rSourceSelector">SourceSelector</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[15]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rNamedGraphClause">NamedGraphClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'NAMED'</span> <a href="#rSourceSelector">SourceSelector</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[16]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rSourceSelector">SourceSelector</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#riri">iri</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[17]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rWhereClause">WhereClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'WHERE'</span>? <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[18]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rSolutionModifier">SolutionModifier</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rGroupClause">GroupClause</a>? <a href="#rHavingClause">HavingClause</a>? <a href="#rOrderClause">OrderClause</a>? <a href="#rLimitOffsetClauses">LimitOffsetClauses</a>?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[19]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGroupClause">GroupClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'GROUP'</span> <span class="token">'BY'</span> <a href="#rGroupCondition">GroupCondition</a>+</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[20]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGroupCondition">GroupCondition</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rBuiltInCall">BuiltInCall</a> | <a href="#rFunctionCall">FunctionCall</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">'AS'</span> <a href="#rVar">Var</a> )? <span class="token">')'</span> | <a href="#rVar">Var</a> </code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[21]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rHavingClause">HavingClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'HAVING'</span> <a href="#rHavingCondition">HavingCondition</a>+</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[22]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rHavingCondition">HavingCondition</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rConstraint">Constraint</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[23]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rOrderClause">OrderClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'ORDER'</span> <span class="token">'BY'</span> <a href="#rOrderCondition">OrderCondition</a>+</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[24]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rOrderCondition">OrderCondition</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">   ( ( <span class="token">'ASC'</span> | <span class="token">'DESC'</span> ) <a href="#rBrackettedExpression">BrackettedExpression</a> )<br/>| ( <a href="#rConstraint">Constraint</a> | <a href="#rVar">Var</a> ) </code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[25]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rLimitOffsetClauses">LimitOffsetClauses</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rLimitClause">LimitClause</a> <a href="#rOffsetClause">OffsetClause</a>? | <a href="#rOffsetClause">OffsetClause</a> <a href="#rLimitClause">LimitClause</a>? </code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[26]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rLimitClause">LimitClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'LIMIT'</span> <a href="#rINTEGER">INTEGER</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[27]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rOffsetClause">OffsetClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'OFFSET'</span> <a href="#rINTEGER">INTEGER</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[28]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rValuesClause">ValuesClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">( <span class="token">'VALUES'</span> <a href="#rDataBlock">DataBlock</a> )?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[29]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rUpdate">Update</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPrologue">Prologue</a> ( <a href="#rUpdate1">Update1</a> ( <span class="token">';'</span> <a href="#rUpdate">Update</a> )? )?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[30]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rUpdate1">Update1</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rLoad">Load</a> | <a href="#rClear">Clear</a> | <a href="#rDrop">Drop</a> | <a href="#rAdd">Add</a> | <a href="#rMove">Move</a> | <a href="#rCopy">Copy</a> | <a href="#rCreate">Create</a> | <a href="#rDeleteWhere">DeleteWhere</a> | <a href="#rModify">Modify</a> | <a href="#rInsertData">InsertData</a> | <a href="#rDeleteData">DeleteData</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[31]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rLoad">Load</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'LOAD'</span> <span class="token">'SILENT'</span>? <a href="#riri">iri</a> ( <span class="token">'INTO'</span> <a href="#rGraphRef">GraphRef</a> )?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[32]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rClear">Clear</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'CLEAR'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRefAll">GraphRefAll</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[33]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDrop">Drop</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'DROP'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRefAll">GraphRefAll</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[34]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rCreate">Create</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'CREATE'</span> <span class="token">'SILENT'</span>? <a href="#rGraphRef">GraphRef</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[35]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rAdd">Add</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'ADD'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[36]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rMove">Move</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'MOVE'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[37]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rCopy">Copy</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'COPY'</span> <span class="token">'SILENT'</span>? <a href="#rGraphOrDefault">GraphOrDefault</a> <span class="token">'TO'</span> <a href="#rGraphOrDefault">GraphOrDefault</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[38]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rInsertData">InsertData</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'INSERT DATA'</span> <a href="#rQuadData">QuadData</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[39]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDeleteData">DeleteData</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'DELETE DATA'</span> <a href="#rQuadData">QuadData</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[40]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDeleteWhere">DeleteWhere</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'DELETE WHERE'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[41]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rModify">Modify</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">( <span class="token">'WITH'</span> <a href="#riri">iri</a> )? ( <a href="#rDeleteClause">DeleteClause</a> <a href="#rInsertClause">InsertClause</a>? | <a href="#rInsertClause">InsertClause</a> ) <a href="#rUsingClause">UsingClause</a>* <span class="token">'WHERE'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[42]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDeleteClause">DeleteClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'DELETE'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[43]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rInsertClause">InsertClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'INSERT'</span> <a href="#rQuadPattern">QuadPattern</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[44]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rUsingClause">UsingClause</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'USING'</span> ( <a href="#riri">iri</a> | <span class="token">'NAMED'</span> <a href="#riri">iri</a> )</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[45]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGraphOrDefault">GraphOrDefault</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'DEFAULT'</span> | <span class="token">'GRAPH'</span>? <a href="#riri">iri</a> </code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[46]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGraphRef">GraphRef</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'GRAPH'</span> <a href="#riri">iri</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[47]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGraphRefAll">GraphRefAll</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rGraphRef">GraphRef</a> | <span class="token">'DEFAULT'</span> | <span class="token">'NAMED'</span> | <span class="token">'ALL'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[48]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rQuadPattern">QuadPattern</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rQuads">Quads</a> <span class="token">'}'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[49]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rQuadData">QuadData</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rQuads">Quads</a> <span class="token">'}'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[50]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rQuads">Quads</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rTriplesTemplate">TriplesTemplate</a>? ( <a href="#rQuadsNotTriples">QuadsNotTriples</a> <span class="token">'.'</span>? <a href="#rTriplesTemplate">TriplesTemplate</a>? )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[51]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rQuadsNotTriples">QuadsNotTriples</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'GRAPH'</span> <a href="#rVarOrIri">VarOrIri</a> <span class="token">'{'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? <span class="token">'}'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[52]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rTriplesTemplate">TriplesTemplate</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rTriplesSameSubject">TriplesSameSubject</a> ( <span class="token">'.'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? )?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[53]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGroupGraphPattern">GroupGraphPattern</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'{'</span> ( <a href="#rSubSelect">SubSelect</a> | <a href="#rGroupGraphPatternSub">GroupGraphPatternSub</a> ) <span class="token">'}'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[54]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGroupGraphPatternSub">GroupGraphPatternSub</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rTriplesBlock">TriplesBlock</a>? ( <a href="#rGraphPatternNotTriples">GraphPatternNotTriples</a> <span class="token">'.'</span>? <a href="#rTriplesBlock">TriplesBlock</a>? )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[55]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rTriplesBlock">TriplesBlock</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rTriplesSameSubjectPath">TriplesSameSubjectPath</a> ( <span class="token">'.'</span> <a href="#rTriplesBlock">TriplesBlock</a>? )?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[56]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGraphPatternNotTriples">GraphPatternNotTriples</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rGroupOrUnionGraphPattern">GroupOrUnionGraphPattern</a> | <a href="#rOptionalGraphPattern">OptionalGraphPattern</a> | <a href="#rMinusGraphPattern">MinusGraphPattern</a> | <a href="#rGraphGraphPattern">GraphGraphPattern</a> | <a href="#rServiceGraphPattern">ServiceGraphPattern</a> | <a href="#rFilter">Filter</a> | <a href="#rBind">Bind</a> | <a href="#rInlineData">InlineData</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[57]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rOptionalGraphPattern">OptionalGraphPattern</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'OPTIONAL'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[58]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGraphGraphPattern">GraphGraphPattern</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'GRAPH'</span> <a href="#rVarOrIri">VarOrIri</a> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[59]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rServiceGraphPattern">ServiceGraphPattern</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'SERVICE'</span> <span class="token">'SILENT'</span>? <a href="#rVarOrIri">VarOrIri</a> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[60]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rBind">Bind</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'BIND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">'AS'</span> <a href="#rVar">Var</a> <span class="token">')'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[61]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rInlineData">InlineData</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'VALUES'</span> <a href="#rDataBlock">DataBlock</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[62]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDataBlock">DataBlock</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rInlineDataOneVar">InlineDataOneVar</a> | <a href="#rInlineDataFull">InlineDataFull</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[63]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rInlineDataOneVar">InlineDataOneVar</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVar">Var</a> <span class="token">'{'</span> <a href="#rDataBlockValue">DataBlockValue</a>* <span class="token">'}'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[64]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rInlineDataFull">InlineDataFull</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">( <a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rVar">Var</a>* <span class="token">')'</span> ) <span class="token">'{'</span> ( <span class="token">'('</span> <a href="#rDataBlockValue">DataBlockValue</a>* <span class="token">')'</span> | <a href="#rNIL">NIL</a> )* <span class="token">'}'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[65]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDataBlockValue">DataBlockValue</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#riri">iri</a> |	<a href="#rRDFLiteral">RDFLiteral</a> |	<a href="#rNumericLiteral">NumericLiteral</a> |	<a href="#rBooleanLiteral">BooleanLiteral</a> |	<span class="token">'UNDEF'</span> |	<a href="#rQuotedTripleData">QuotedTripleData</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[66]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rMinusGraphPattern">MinusGraphPattern</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'MINUS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[67]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGroupOrUnionGraphPattern">GroupOrUnionGraphPattern</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rGroupGraphPattern">GroupGraphPattern</a> ( <span class="token">'UNION'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a> )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[68]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rFilter">Filter</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'FILTER'</span> <a href="#rConstraint">Constraint</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[69]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rConstraint">Constraint</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#rFunctionCall">FunctionCall</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[70]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rFunctionCall">FunctionCall</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[71]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rArgList">ArgList</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[72]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rExpressionList">ExpressionList</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[73]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rConstructTemplate">ConstructTemplate</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rConstructTriples">ConstructTriples</a>? <span class="token">'}'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[74]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rConstructTriples">ConstructTriples</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rTriplesSameSubject">TriplesSameSubject</a> ( <span class="token">'.'</span> <a href="#rConstructTriples">ConstructTriples</a>? )?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[75]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rTriplesSameSubject">TriplesSameSubject</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> |	<a href="#rTriplesNode">TriplesNode</a> <a href="#rPropertyList">PropertyList</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[76]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPropertyList">PropertyList</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a>?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[77]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPropertyListNotEmpty">PropertyListNotEmpty</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> ( <span class="token">';'</span> ( <a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> )? )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[78]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rVerb">Verb</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVarOrIri">VarOrIri</a> | <span class="token">'a'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[79]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rObjectList">ObjectList</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rObject">Object</a> ( <span class="token">','</span> <a href="#rObject">Object</a> )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[80]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rObject">Object</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rGraphNode">GraphNode</a> <a href="#rAnnotation">Annotation</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[81]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rTriplesSameSubjectPath">TriplesSameSubjectPath</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> |	<a href="#rTriplesNodePath">TriplesNodePath</a> <a href="#rPropertyListPath">PropertyListPath</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[82]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPropertyListPath">PropertyListPath</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a>?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[83]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPropertyListPathNotEmpty">PropertyListPathNotEmpty</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> ( <span class="token">';'</span> ( ( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> )? )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[84]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rVerbPath">VerbPath</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPath">Path</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[85]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rVerbSimple">VerbSimple</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVar">Var</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[86]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rObjectListPath">ObjectListPath</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rObjectPath">ObjectPath</a> ( <span class="token">','</span> <a href="#rObjectPath">ObjectPath</a> )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[87]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rObjectPath">ObjectPath</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rGraphNodePath">GraphNodePath</a> <a href="#rAnnotationPath">AnnotationPath</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[88]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPath">Path</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPathAlternative">PathAlternative</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[89]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPathAlternative">PathAlternative</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPathSequence">PathSequence</a> ( <span class="token">'|'</span> <a href="#rPathSequence">PathSequence</a> )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[90]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPathSequence">PathSequence</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPathEltOrInverse">PathEltOrInverse</a> ( <span class="token">'/'</span> <a href="#rPathEltOrInverse">PathEltOrInverse</a> )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[91]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPathElt">PathElt</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPathPrimary">PathPrimary</a> <a href="#rPathMod">PathMod</a>?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[92]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPathEltOrInverse">PathEltOrInverse</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPathElt">PathElt</a> | <span class="token">'^'</span> <a href="#rPathElt">PathElt</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[93]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPathMod">PathMod</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'?'</span> | <span class="token">'*'</span> | <span class="token">'+'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[94]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPathPrimary">PathPrimary</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#riri">iri</a> | <span class="token">'a'</span> | <span class="token">'!'</span> <a href="#rPathNegatedPropertySet">PathNegatedPropertySet</a> | <span class="token">'('</span> <a href="#rPath">Path</a> <span class="token">')'</span> </code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[95]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPathNegatedPropertySet">PathNegatedPropertySet</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPathOneInPropertySet">PathOneInPropertySet</a> | <span class="token">'('</span> ( <a href="#rPathOneInPropertySet">PathOneInPropertySet</a> ( <span class="token">'|'</span> <a href="#rPathOneInPropertySet">PathOneInPropertySet</a> )* )? <span class="token">')'</span> </code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[96]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPathOneInPropertySet">PathOneInPropertySet</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#riri">iri</a> | <span class="token">'a'</span> | <span class="token">'^'</span> ( <a href="#riri">iri</a> | <span class="token">'a'</span> ) </code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[97]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rInteger">Integer</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rINTEGER">INTEGER</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[98]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rTriplesNode">TriplesNode</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rCollection">Collection</a> |	<a href="#rBlankNodePropertyList">BlankNodePropertyList</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[99]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rBlankNodePropertyList">BlankNodePropertyList</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">']'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[100]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rTriplesNodePath">TriplesNodePath</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rCollectionPath">CollectionPath</a> |	<a href="#rBlankNodePropertyListPath">BlankNodePropertyListPath</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[101]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rBlankNodePropertyListPath">BlankNodePropertyListPath</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">']'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[102]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rCollection">Collection</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNode">GraphNode</a>+ <span class="token">')'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[103]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rCollectionPath">CollectionPath</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNodePath">GraphNodePath</a>+ <span class="token">')'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[104]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rAnnotationPath">AnnotationPath</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">( <span class="token">'{|'</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">'|}'</span> )?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[105]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rAnnotation">Annotation</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">( <span class="token">'{|'</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">'|}'</span> )?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[106]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGraphNode">GraphNode</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> |	<a href="#rTriplesNode">TriplesNode</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[107]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rGraphNodePath">GraphNodePath</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> |	<a href="#rTriplesNodePath">TriplesNodePath</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[108]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rVarOrTerm">VarOrTerm</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rNIL">NIL</a> | <a href="#rQuotedTriple">QuotedTriple</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[109]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rQuotedTriple">QuotedTriple</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rVarOrTerm">VarOrTerm</a> <a href="#rVerb">Verb</a> <a href="#rVarOrTerm">VarOrTerm</a> <span class="token">'&gt;&gt;'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[110]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rQuotedTripleData">QuotedTripleData</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rDataValueTerm">DataValueTerm</a> ( <a href="#riri">iri</a> | <span class="token">'a'</span> ) <a href="#rDataValueTerm">DataValueTerm</a> <span class="token">'&gt;&gt;'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[111]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDataValueTerm">DataValueTerm</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#riri">iri</a> |	<a href="#rRDFLiteral">RDFLiteral</a> |	<a href="#rNumericLiteral">NumericLiteral</a> |	<a href="#rBooleanLiteral">BooleanLiteral</a> |	<a href="#rQuotedTripleData">QuotedTripleData</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[112]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rVarOrIri">VarOrIri</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[113]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rVar">Var</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVAR1">VAR1</a> | <a href="#rVAR2">VAR2</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[114]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rExpression">Expression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rConditionalOrExpression">ConditionalOrExpression</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[115]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rConditionalOrExpression">ConditionalOrExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rConditionalAndExpression">ConditionalAndExpression</a> ( <span class="token">'||'</span> <a href="#rConditionalAndExpression">ConditionalAndExpression</a> )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[116]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rConditionalAndExpression">ConditionalAndExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rValueLogical">ValueLogical</a> ( <span class="token">'&amp;&amp;'</span> <a href="#rValueLogical">ValueLogical</a> )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[117]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rValueLogical">ValueLogical</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rRelationalExpression">RelationalExpression</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[118]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rRelationalExpression">RelationalExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rNumericExpression">NumericExpression</a> ( <span class="token">'='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'!='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> | <span class="token">'NOT'</span> <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> )?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[119]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rNumericExpression">NumericExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rAdditiveExpression">AdditiveExpression</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[120]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rAdditiveExpression">AdditiveExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rMultiplicativeExpression">MultiplicativeExpression</a> ( <span class="token">'+'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | <span class="token">'-'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | ( <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a> ) ( ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) | ( <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) )* )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[121]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rMultiplicativeExpression">MultiplicativeExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rUnaryExpression">UnaryExpression</a> ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> | <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[122]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rUnaryExpression">UnaryExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'!'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'+'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'-'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<a href="#rPrimaryExpression">PrimaryExpression</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[123]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPrimaryExpression">PrimaryExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#ririOrFunction">iriOrFunction</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprQuotedTriple">ExprQuotedTriple</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[124]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rExprVarOrTerm">ExprVarOrTerm</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprQuotedTriple">ExprQuotedTriple</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[125]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rExprQuotedTriple">ExprQuotedTriple</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rExprVarOrTerm">ExprVarOrTerm</a> <a href="#rVerb">Verb</a> <a href="#rExprVarOrTerm">ExprVarOrTerm</a> <span class="token">'&gt;&gt;'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[126]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rBrackettedExpression">BrackettedExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[127]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rBuiltInCall">BuiltInCall</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">&nbsp;&nbsp;<a href="#rAggregate">Aggregate</a> <br/>|	<span class="token">'STR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANGMATCHES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DATATYPE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BOUND'</span> <span class="token">'('</span> <a href="#rVar">Var</a> <span class="token">')'</span> <br/>|	<span class="token">'IRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BNODE'</span> ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> | <a href="#rNIL">NIL</a> ) <br/>|	<span class="token">'RAND'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'ABS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CEIL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'FLOOR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ROUND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONCAT'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<a href="#rSubstringExpression">SubstringExpression</a> <br/>|	<span class="token">'STRLEN'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<a href="#rStrReplaceExpression">StrReplaceExpression</a> <br/>|	<span class="token">'UCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ENCODE_FOR_URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONTAINS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRSTARTS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRENDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRBEFORE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRAFTER'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'YEAR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MONTH'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DAY'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'HOURS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MINUTES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SECONDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TIMEZONE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TZ'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'NOW'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'UUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'STRUUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'MD5'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA1'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA256'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA384'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA512'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'COALESCE'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<span class="token">'IF'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRDT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'sameTerm'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isIRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isURI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isBLANK'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isLITERAL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isNUMERIC'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<a href="#rRegexExpression">RegexExpression</a> <br/>|	<a href="#rExistsFunc">ExistsFunc</a> <br/>|	<a href="#rNotExistsFunc">NotExistsFunc</a> <br/>|	<span class="token">'isTRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SUBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'PREDICATE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'OBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[128]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rRegexExpression">RegexExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'REGEX'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[129]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rSubstringExpression">SubstringExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'SUBSTR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[130]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rStrReplaceExpression">StrReplaceExpression</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'REPLACE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[131]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rExistsFunc">ExistsFunc</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'EXISTS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[132]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rNotExistsFunc">NotExistsFunc</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'NOT'</span> <span class="token">'EXISTS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[133]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rAggregate">Aggregate</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'COUNT'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? ( <span class="token">'*'</span> | <a href="#rExpression">Expression</a> ) <span class="token">')'</span> <br/>| <span class="token">'SUM'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MIN'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MAX'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'AVG'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SAMPLE'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'GROUP_CONCAT'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> ( <span class="token">';'</span> <span class="token">'SEPARATOR'</span> <span class="token">'='</span> <a href="#rString">String</a> )? <span class="token">')'</span> </code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[134]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="ririOrFunction">iriOrFunction</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a>?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[135]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rRDFLiteral">RDFLiteral</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rString">String</a> ( <a href="#rLANGTAG">LANGTAG</a> | ( <span class="token">'^^'</span> <a href="#riri">iri</a> ) )?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[136]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rNumericLiteral">NumericLiteral</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rNumericLiteralUnsigned">NumericLiteralUnsigned</a> | <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[137]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rNumericLiteralUnsigned">NumericLiteralUnsigned</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rINTEGER">INTEGER</a> |	<a href="#rDECIMAL">DECIMAL</a> |	<a href="#rDOUBLE">DOUBLE</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[138]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rNumericLiteralPositive">NumericLiteralPositive</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rINTEGER_POSITIVE">INTEGER_POSITIVE</a> |	<a href="#rDECIMAL_POSITIVE">DECIMAL_POSITIVE</a> |	<a href="#rDOUBLE_POSITIVE">DOUBLE_POSITIVE</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[139]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rNumericLiteralNegative">NumericLiteralNegative</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rINTEGER_NEGATIVE">INTEGER_NEGATIVE</a> |	<a href="#rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</a> |	<a href="#rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[140]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rBooleanLiteral">BooleanLiteral</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'true'</span> |	<span class="token">'false'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[141]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rString">String</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a> | <a href="#rSTRING_LITERAL2">STRING_LITERAL2</a> | <a href="#rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</a> | <a href="#rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[142]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="riri">iri</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rIRIREF">IRIREF</a> |	<a href="#rPrefixedName">PrefixedName</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[143]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPrefixedName">PrefixedName</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPNAME_LN">PNAME_LN</a> | <a href="#rPNAME_NS">PNAME_NS</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[144]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rBlankNode">BlankNode</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rBLANK_NODE_LABEL">BLANK_NODE_LABEL</a> |	<a href="#rANON">ANON</a></code></td>
+              </tr>
+          </tbody></table>
+        </div>
+        <p>Productions for terminals:</p>
+        <div class="grammarTable">
+          <table><tbody>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[145]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rIRIREF">IRIREF</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'&lt;' ([^&lt;&gt;"{}|^`\]-[#x00-#x20])* '&gt;'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[146]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPNAME_NS">PNAME_NS</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPN_PREFIX">PN_PREFIX</a>? ':'</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[147]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPNAME_LN">PNAME_LN</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPNAME_NS">PNAME_NS</a> <a href="#rPN_LOCAL">PN_LOCAL</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[148]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rBLANK_NODE_LABEL">BLANK_NODE_LABEL</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">'_:' ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] ) ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[149]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rVAR1">VAR1</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">'?' <a href="#rVARNAME">VARNAME</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[150]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rVAR2">VAR2</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">'$' <a href="#rVARNAME">VARNAME</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[151]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rLANGTAG">LANGTAG</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[152]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rINTEGER">INTEGER</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">[0-9]+</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[153]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDECIMAL">DECIMAL</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">[0-9]* '.' [0-9]+</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[154]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDOUBLE">DOUBLE</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">[0-9]+ '.' [0-9]* <a href="#rEXPONENT">EXPONENT</a> | '.' ([0-9])+ <a href="#rEXPONENT">EXPONENT</a> | ([0-9])+ <a href="#rEXPONENT">EXPONENT</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[155]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rINTEGER_POSITIVE">INTEGER_POSITIVE</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rINTEGER">INTEGER</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[156]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDECIMAL_POSITIVE">DECIMAL_POSITIVE</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[157]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDOUBLE_POSITIVE">DOUBLE_POSITIVE</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[158]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rINTEGER_NEGATIVE">INTEGER_NEGATIVE</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rINTEGER">INTEGER</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[159]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[160]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[161]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rEXPONENT">EXPONENT</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">[eE] [+-]? [0-9]+</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[162]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rSTRING_LITERAL1">STRING_LITERAL1</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">"'" ( ([^#x27#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* "'"</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[163]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rSTRING_LITERAL2">STRING_LITERAL2</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">'"' ( ([^#x22#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* '"'</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[164]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">"'''" ( ( "'" | "''" )? ( [^'\] | <a href="#rECHAR">ECHAR</a> ) )* "'''"</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[165]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">'"""' ( ( '"' | '""' )? ( [^"\] | <a href="#rECHAR">ECHAR</a> ) )* '"""'</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[166]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rECHAR">ECHAR</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">'\' [tbnrf\"']</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[167]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rNIL">NIL</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">'(' <a href="#rWS">WS</a>* ')'</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[168]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rWS">WS</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">#x20 | #x9 | #xD | #xA</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[169]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rANON">ANON</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">'['  <a href="#rWS">WS</a>* ']'</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[170]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPN_CHARS_BASE">PN_CHARS_BASE</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">[A-Z] | [a-z] | [#x00C0-#x00D6] | [#x00D8-#x00F6] | [#x00F8-#x02FF] | [#x0370-#x037D] | [#x037F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[171]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPN_CHARS_U">PN_CHARS_U</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> | '_'</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[172]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rVARNAME">VARNAME</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">( <a href="#rPN_CHARS_U">PN_CHARS_U</a>  | [0-9] ) ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[173]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPN_CHARS">PN_CHARS</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPN_CHARS_U">PN_CHARS_U</a> | '-' | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040]</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[174]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPN_PREFIX">PN_PREFIX</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[175]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPN_LOCAL">PN_LOCAL</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">(<a href="#rPN_CHARS_U">PN_CHARS_U</a> | ':' | [0-9] | <a href="#rPLX">PLX</a> ) ((<a href="#rPN_CHARS">PN_CHARS</a> | '.' | ':' | <a href="#rPLX">PLX</a>)* (<a href="#rPN_CHARS">PN_CHARS</a> | ':' | <a href="#rPLX">PLX</a>) )?</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[176]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPLX">PLX</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPERCENT">PERCENT</a> | <a href="#rPN_LOCAL_ESC">PN_LOCAL_ESC</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[177]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPERCENT">PERCENT</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">'%' <a href="#rHEX">HEX</a> <a href="#rHEX">HEX</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[178]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rHEX">HEX</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">[0-9] | [A-F] | [a-f]</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[179]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPN_LOCAL_ESC">PN_LOCAL_ESC</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">'\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )</code></td>
+              </tr>
+          </tbody></table>
+        </div>
         <!-- GRAMMAR -->
       </section>
     </section>


### PR DESCRIPTION
Part of issue #53 (Incorporate RFD-star CG report)

This is the SPARQL Grammar changes, and only those changes, to replace the table in [section 19.8](https://w3c.github.io/sparql-query/spec/index.html#sparqlGrammar).

This is not directly the content from the CG report because the complete SPARQL grammar in the report has various errors and omissions. The fragment earlier in the report is closer.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/78.html" title="Last updated on May 25, 2023, 5:11 PM UTC (a484316)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/78/57924ae...a484316.html" title="Last updated on May 25, 2023, 5:11 PM UTC (a484316)">Diff</a>