### PR TITLE
Move RDFterm-equal and sameTerm to term functions section

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -5554,6 +5554,246 @@ class="expression">expression, ....</span>)
             <p>Note: see section 17.2, <a href="#evaluation">Filter Evaluation</a>, for the
               <code>&amp;&</code> operator's treatment of errors.</p>
           </section>
+          <section id="func-in">
+            <h5>IN</h5>
+            <pre class="prototype nohighlight">
+<span class="return">boolean</span>  rdfTerm <span class="operator">IN</span> (<span class="expression">expression</span>, <span class="expression">...</span>)
+            </pre>
+            <p>
+              The <code>IN</code> operator tests whether the RDF term on the
+              left-hand side is found in the list of values of the expressions
+              on the right-hand side. The test is done with the "=" operator,
+              which tests for the same value, as determined by the
+              <a href="#OperatorMapping">operator mapping</a>.
+            </p>
+            <p>
+              A list of zero terms on the right-hand side is legal and evaluates
+              to <code>false</code>.
+            </p>
+            <p>
+              Errors in comparisons cause the <code>IN</code> expression to
+              raise an error if the RDF term being tested is not found elsewhere
+              in the list of terms.
+            </p>
+            <p>
+              If <code>IN</code> is used with an expression to produce the
+              <code>rdfTerm</code>, then that expression is evaluated only once, 
+              before evaluating the <code>IN</code> expression.
+            </p>
+            <p>
+              The <code>IN</code> operator is equivalent to the 
+              SPARQL expression:
+            </p>
+            <pre>(rdfTerm = value of expression1) || (rdfTerm = value of expression2) || ...</pre>
+            <p>Examples:</p>
+            <div class="result">
+              <table>
+                <tbody>
+                  <tr>
+                    <td><code>2 IN (1, 2, 3)</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>2 IN ()</code></td>
+                    <td>false</td>
+                  </tr>
+                  <tr>
+                    <td><code>2 IN (&lt;http://example/iri&gt;, "str", 2.0)</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>2 IN (1/0, 2)</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>2 IN (2, 1/0)</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>2 IN (3, 1/0)</code></td>
+                    <td>raises an error</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+          <section id="func-not-in">
+            <h5>NOT IN</h5>
+            <pre class="prototype nohighlight">
+<span class="return">boolean</span>  rdfTerm <span class="operator">NOT IN</span> (<span class="expression">expression</span>, <span class="expression">...</span>)
+</pre>
+            <p>
+              The <code>NOT IN</code> operator tests whether the RDF term on
+              the left-hand side is not found in the values of list of the
+              expressions on the right-hand side. The test is done with the "!="
+              operator, which tests that two values are not the same value, as
+              determined by the
+              <a href="#OperatorMapping">operator mapping</a>.
+            </p>
+            <p>
+              A list of zero terms on the right-hand side is legal and evaluates
+              to <code>true</code>.
+            </p>
+            <p>
+              If <code>NOT IN</code> is used with an expression to produce the
+              <code>rdfTerm</code>, then that expression is evaluated only once, 
+              before evaluating the <code>NOT IN</code> expression.
+            </p>
+            <p>Errors in comparisons cause the <code>NOT IN</code> expression to raise an error if
+              the RDF term being tested is not found elsewhere in the list of
+              terms.</p>
+            <p>
+              The <code>NOT IN</code> operator is equivalent to the
+              SPARQL expression: 
+            </p>
+            <pre>(rdfTerm != value of expression1) &amp;&amp; (rdfTerm != value of expression2) &amp;&amp; ...</pre>
+            <p><code>NOT IN (...)</code> is equivalent to <code>!(IN (...))</code>.</p>
+
+            <p>Examples:</p>
+            <div class="result">
+              <table>
+                <tbody>
+                  <tr>
+                    <td><code>2 NOT IN (1, 2, 3)</code></td>
+                    <td>false</td>
+                  </tr>
+                  <tr>
+                    <td><code>2 NOT IN ()</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>2 NOT IN (&lt;http://example/iri&gt;, "str", 2.0)</code></td>
+                    <td>false</td>
+                  </tr>
+                  <tr>
+                    <td><code>2 NOT IN (1/0, 2)</code></td>
+                    <td>false</td>
+                  </tr>
+                  <tr>
+                    <td><code>2 NOT IN (2, 1/0)</code></td>
+                    <td>false</td>
+                  </tr>
+                  <tr>
+                    <td><code>2 NOT IN (3, 1/0)</code></td>
+                    <td>raises an error</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </section>
+        <section id="func-rdfTerms">
+          <h4>Functions on RDF Terms</h4>
+          <section id="func-sameTerm">
+            <h5>sameTerm</h5>
+            <pre class="prototype nohighlight"> <span class="return">xsd:boolean</span>  <span class="operator">sameTerm</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)</pre>
+            <p>Returns TRUE if <code>term1</code> and <code>term2</code> are the same RDF term as
+              defined in [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]; returns FALSE otherwise.</p>
+            <div class="exampleGroup">
+              <pre class="data nohighlight">
+@prefix foaf:       &lt;http://xmlns.com/foaf/0.1/&gt; .
+
+_:a  foaf:name       "Alice".
+_:a  foaf:mbox       &lt;mailto:alice@work.example&gt; .
+
+_:b  foaf:name       "Ms A.".
+_:b  foaf:mbox       &lt;mailto:alice@work.example&gt; .
+              </pre>
+              <div class="queryGroup">
+                <p>This query finds the people who have multiple <code>foaf:name</code> triples:</p>
+                <pre class="query nohighlight">
+PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+SELECT ?name1 ?name2
+WHERE {
+    ?x foaf:name  ?name1 ;
+       foaf:mbox  ?mbox1 .
+    ?y foaf:name  ?name2 ;
+       foaf:mbox  ?mbox2 .
+    FILTER (sameTerm(?mbox1, ?mbox2) &amp;& !sameTerm(?name1, ?name2))
+}
+                </pre>
+                <p>Query result:</p>
+                <div class="result">
+                  <table class="resultTable">
+                    <tbody>
+                      <tr>
+                        <th>name1</th>
+                        <th>name2</th>
+                      </tr>
+                      <tr>
+                        <td>"Alice"</td>
+                        <td>"Ms A."</td>
+                      </tr>
+                      <tr>
+                        <td>"Ms A."</td>
+                        <td>"Alice"</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+            <p>Unlike <span class="operator">RDFterm-equal</span>, <span class="operator">sameTerm</span> can be used to test for non-equivalent <span class="type typedLiteral">typed literals</span> with unsupported datatypes:</p>
+            <div class="exampleGroup">
+              <pre class="data nohighlight">
+@prefix :          &lt;http://example.org/WMterms#&gt; .
+@prefix t:         &lt;http://example.org/types#&gt; .
+
+_:c1  :label        "Container 1" .
+_:c1  :weight       "100"^^t:kilos .
+_:c1  :displacement  "100"^^t:liters .
+
+_:c2  :label        "Container 2" .
+_:c2  :weight       "100"^^t:kilos .
+_:c2  :displacement  "85"^^t:liters .
+
+_:c3  :label        "Container 3" .
+_:c3  :weight       "85"^^t:kilos .
+_:c3  :displacement  "85"^^t:liters .
+              </pre>
+              <div class="queryGroup">
+                <pre class="query nohighlight">
+PREFIX  :      &lt;http://example.org/WMterms#&gt;
+PREFIX  t:     &lt;http://example.org/types#&gt;
+
+SELECT ?aLabel1 ?bLabel
+WHERE { 
+   ?a  :label        ?aLabel .
+   ?a  :weight       ?aWeight .
+   ?a  :displacement ?aDisp .
+
+   ?b  :label        ?bLabel .
+   ?b  :weight       ?bWeight .
+   ?b  :displacement ?bDisp .
+
+   FILTER ( sameTerm(?aWeight, ?bWeight) &amp;& !sameTerm(?aDisp, ?bDisp)) 
+}
+                </pre>
+                <div class="result">
+                  <table class="resultTable">
+                    <tbody>
+                      <tr>
+                        <th>aLabel</th>
+                        <th>bLabel</th>
+                      </tr>
+                      <tr>
+                        <td>"Container 1"</td>
+                        <td>"Container 2"</td>
+                      </tr>
+                      <tr>
+                        <td>"Container 2"</td>
+                        <td>"Container 1"</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+            <p>The test for boxes with the same weight may also be done with the '=' operator
+              (<a href="#func-RDFterm-equal" class="SPARQLoperator">RDFterm-equal</a>) as the test for
+              <code>"100"^^t:kilos = "85"^^t:kilos</code> will result in an error, eliminating that
+              potential solution.</p>
+          </section>
           <section id="func-RDFterm-equal">
             <h5>RDFterm-equal</h5>
             <pre class="prototype nohighlight">
@@ -5686,246 +5926,6 @@ WHERE {
               </div>
             </div>
           </section>
-          <section id="func-sameTerm">
-            <h5>sameTerm</h5>
-            <pre class="prototype nohighlight"> <span class="return">xsd:boolean</span>  <span class="operator">sameTerm</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)</pre>
-            <p>Returns TRUE if <code>term1</code> and <code>term2</code> are the same RDF term as
-              defined in [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]; returns FALSE otherwise.</p>
-            <div class="exampleGroup">
-              <pre class="data nohighlight">
-@prefix foaf:       &lt;http://xmlns.com/foaf/0.1/&gt; .
-
-_:a  foaf:name       "Alice".
-_:a  foaf:mbox       &lt;mailto:alice@work.example&gt; .
-
-_:b  foaf:name       "Ms A.".
-_:b  foaf:mbox       &lt;mailto:alice@work.example&gt; .
-              </pre>
-              <div class="queryGroup">
-                <p>This query finds the people who have multiple <code>foaf:name</code> triples:</p>
-                <pre class="query nohighlight">
-PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
-SELECT ?name1 ?name2
-WHERE {
-    ?x foaf:name  ?name1 ;
-       foaf:mbox  ?mbox1 .
-    ?y foaf:name  ?name2 ;
-       foaf:mbox  ?mbox2 .
-    FILTER (sameTerm(?mbox1, ?mbox2) &amp;& !sameTerm(?name1, ?name2))
-}
-                </pre>
-                <p>Query result:</p>
-                <div class="result">
-                  <table class="resultTable">
-                    <tbody>
-                      <tr>
-                        <th>name1</th>
-                        <th>name2</th>
-                      </tr>
-                      <tr>
-                        <td>"Alice"</td>
-                        <td>"Ms A."</td>
-                      </tr>
-                      <tr>
-                        <td>"Ms A."</td>
-                        <td>"Alice"</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
-            <p>Unlike <span class="operator">RDFterm-equal</span>, <span class="operator">sameTerm</span> can be used to test for non-equivalent <span class="type typedLiteral">typed literals</span> with unsupported datatypes:</p>
-            <div class="exampleGroup">
-              <pre class="data nohighlight">
-@prefix :          &lt;http://example.org/WMterms#&gt; .
-@prefix t:         &lt;http://example.org/types#&gt; .
-
-_:c1  :label        "Container 1" .
-_:c1  :weight       "100"^^t:kilos .
-_:c1  :displacement  "100"^^t:liters .
-
-_:c2  :label        "Container 2" .
-_:c2  :weight       "100"^^t:kilos .
-_:c2  :displacement  "85"^^t:liters .
-
-_:c3  :label        "Container 3" .
-_:c3  :weight       "85"^^t:kilos .
-_:c3  :displacement  "85"^^t:liters .
-              </pre>
-              <div class="queryGroup">
-                <pre class="query nohighlight">
-PREFIX  :      &lt;http://example.org/WMterms#&gt;
-PREFIX  t:     &lt;http://example.org/types#&gt;
-
-SELECT ?aLabel1 ?bLabel
-WHERE { 
-   ?a  :label        ?aLabel .
-   ?a  :weight       ?aWeight .
-   ?a  :displacement ?aDisp .
-
-   ?b  :label        ?bLabel .
-   ?b  :weight       ?bWeight .
-   ?b  :displacement ?bDisp .
-
-   FILTER ( sameTerm(?aWeight, ?bWeight) &amp;& !sameTerm(?aDisp, ?bDisp)) 
-}
-                </pre>
-                <div class="result">
-                  <table class="resultTable">
-                    <tbody>
-                      <tr>
-                        <th>aLabel</th>
-                        <th>bLabel</th>
-                      </tr>
-                      <tr>
-                        <td>"Container 1"</td>
-                        <td>"Container 2"</td>
-                      </tr>
-                      <tr>
-                        <td>"Container 2"</td>
-                        <td>"Container 1"</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
-            <p>The test for boxes with the same weight may also be done with the '=' operator
-              (<a href="#func-RDFterm-equal" class="SPARQLoperator">RDFterm-equal</a>) as the test for
-              <code>"100"^^t:kilos = "85"^^t:kilos</code> will result in an error, eliminating that
-              potential solution.</p>
-          </section>
-          <section id="func-in">
-            <h5>IN</h5>
-            <pre class="prototype nohighlight">
-<span class="return">boolean</span>  rdfTerm <span class="operator">IN</span> (<span class="expression">expression</span>, <span class="expression">...</span>)
-            </pre>
-            <p>
-              The <code>IN</code> operator tests whether the RDF term on the
-              left-hand side is found in the list of values of the expressions
-              on the right-hand side. The test is done with the "=" operator,
-              which tests for the same value, as determined by the
-              <a href="#OperatorMapping">operator mapping</a>.
-            </p>
-            <p>
-              A list of zero terms on the right-hand side is legal and evaluates
-              to <code>false</code>.
-            </p>
-            <p>
-              Errors in comparisons cause the <code>IN</code> expression to
-              raise an error if the RDF term being tested is not found elsewhere
-              in the list of terms.
-            </p>
-            <p>
-              If <code>IN</code> is used with an expression to produce the
-              <code>rdfTerm</code>, then that expression is evaluated only once, 
-              before evaluating the <code>IN</code> expression.
-            </p>
-            <p>
-              The <code>IN</code> operator is equivalent to the 
-              SPARQL expression:
-            </p>
-            <pre>(rdfTerm = value of expression1) || (rdfTerm = value of expression2) || ...</pre>
-            <p>Examples:</p>
-            <div class="result">
-              <table>
-                <tbody>
-                  <tr>
-                    <td><code>2 IN (1, 2, 3)</code></td>
-                    <td>true</td>
-                  </tr>
-                  <tr>
-                    <td><code>2 IN ()</code></td>
-                    <td>false</td>
-                  </tr>
-                  <tr>
-                    <td><code>2 IN (&lt;http://example/iri&gt;, "str", 2.0)</code></td>
-                    <td>true</td>
-                  </tr>
-                  <tr>
-                    <td><code>2 IN (1/0, 2)</code></td>
-                    <td>true</td>
-                  </tr>
-                  <tr>
-                    <td><code>2 IN (2, 1/0)</code></td>
-                    <td>true</td>
-                  </tr>
-                  <tr>
-                    <td><code>2 IN (3, 1/0)</code></td>
-                    <td>raises an error</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </section>
-          <section id="func-not-in">
-            <h5>NOT IN</h5>
-            <pre class="prototype nohighlight">
-<span class="return">boolean</span>  rdfTerm <span class="operator">NOT IN</span> (<span class="expression">expression</span>, <span class="expression">...</span>)
-</pre>
-            <p>
-              The <code>NOT IN</code> operator tests whether the RDF term on
-              the left-hand side is not found in the values of list of the
-              expressions on the right-hand side. The test is done with the "!="
-              operator, which tests that two values are not the same value, as
-              determined by the
-              <a href="#OperatorMapping">operator mapping</a>.
-            </p>
-            <p>
-              A list of zero terms on the right-hand side is legal and evaluates
-              to <code>true</code>.
-            </p>
-            <p>
-              If <code>NOT IN</code> is used with an expression to produce the
-              <code>rdfTerm</code>, then that expression is evaluated only once, 
-              before evaluating the <code>NOT IN</code> expression.
-            </p>
-            <p>Errors in comparisons cause the <code>NOT IN</code> expression to raise an error if
-              the RDF term being tested is not found elsewhere in the list of
-              terms.</p>
-            <p>
-              The <code>NOT IN</code> operator is equivalent to the
-              SPARQL expression: 
-            </p>
-            <pre>(rdfTerm != value of expression1) &amp;&amp; (rdfTerm != value of expression2) &amp;&amp; ...</pre>
-            <p><code>NOT IN (...)</code> is equivalent to <code>!(IN (...))</code>.</p>
-
-            <p>Examples:</p>
-            <div class="result">
-              <table>
-                <tbody>
-                  <tr>
-                    <td><code>2 NOT IN (1, 2, 3)</code></td>
-                    <td>false</td>
-                  </tr>
-                  <tr>
-                    <td><code>2 NOT IN ()</code></td>
-                    <td>true</td>
-                  </tr>
-                  <tr>
-                    <td><code>2 NOT IN (&lt;http://example/iri&gt;, "str", 2.0)</code></td>
-                    <td>false</td>
-                  </tr>
-                  <tr>
-                    <td><code>2 NOT IN (1/0, 2)</code></td>
-                    <td>false</td>
-                  </tr>
-                  <tr>
-                    <td><code>2 NOT IN (2, 1/0)</code></td>
-                    <td>false</td>
-                  </tr>
-                  <tr>
-                    <td><code>2 NOT IN (3, 1/0)</code></td>
-                    <td>raises an error</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </section>
-        </section>
-        <section id="func-rdfTerms">
-          <h4>Functions on RDF Terms</h4>
           <section id="func-isIRI">
             <h5>isIRI</h5>
             <pre class="prototype nohighlight">


### PR DESCRIPTION
This resolves #67.

This PR moves `RDFterm-equal` and `sameTerm` from the [Functional Forms](https://github.com/w3c/sparql-query/compare/term-func?expand=1#func-forms) section to [Functions on RDF Terms](https://github.com/w3c/sparql-query/compare/term-func?expand=1#func-rdfTerms) section. It also puts `sameTerm` first, swapping the order of `RDFterm-equal` and `sameTerm`.

The PR makes no other changes other than moving these blocks of text.

The git changes shows as if `IN` and `NOT IN` have been moved - they haven't. It's seems git calculated the changeset in a different way.