### PR TITLE
Errata: projection cardinality

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9322,8 +9322,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <p><b>Definition: <span id="defn_algProjection">Project</span></b></p>
           <p>Let Ψ be a sequence of solution mappings and PV a set of variables.</p>
           <p>For mapping μ, write Proj(μ, PV) to be the restriction of μ to variables in PV.</p>
-          <p>Project(Ψ, PV) = [ Proj(Ψ[μ], PV) | μ in Ψ ]</p>
-          <p>card[Project(Ψ, PV)](μ) = card[Ψ](μ)</p>
+          <p>Project(Ψ, PV) = [ Proj(μ, PV) | μ in Ψ ]</p>
+          <p>card[Project(Ψ, PV)](μ) = sum(card[Ψ](ν) | ν in Ψ such that ν = Proj(μ, PV))</p>
           <p>The order of Project(Ψ, PV) must preserve any ordering given by OrderBy.</p>
         </div>
         <div class="defn">


### PR DESCRIPTION
This resolves #80.

This is an errata to  SPARQL 1.0.

The cardinality of an element _x_ in a project is the sum of cardinalities of all elements in the input that project to _x_.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/81.html" title="Last updated on May 23, 2023, 9:19 AM UTC (5e264eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/81/f80d5a8...5e264eb.html" title="Last updated on May 23, 2023, 9:19 AM UTC (5e264eb)">Diff</a>