### PR TITLE
Adds a note on deduplication of triples produced by CONSTRUCT

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4241,7 +4241,7 @@ SELECT  ?title (?p AS ?fullPrice) (?fullPrice*(1-?discount) AS ?customerPrice)
           (known as ground or explicit triples), and these also appear in the output RDF graph returned
           by the CONSTRUCT query form.</p>
         <p class="note">
-          Note that the construction of the result graph by "set union" does not
+          The construction of the result graph by "set union" does not
           enforce whether or not duplicated triples appear in the graph serialization.
           Implementations are allowed to produce duplicate triples or to deduplicate them.
         </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -4240,6 +4240,11 @@ SELECT  ?title (?p AS ?fullPrice) (?fullPrice*(1-?discount) AS ?customerPrice)
           included in the output RDF graph. The graph template can contain triples with no variables
           (known as ground or explicit triples), and these also appear in the output RDF graph returned
           by the CONSTRUCT query form.</p>
+        <p class="note">
+          Note that the construction of the result graph by "set union" does not
+          enforce anything on the appearance or not of duplicated triples in the graph serialization.
+          Implementations are allowed to produce duplicate triples or to deduplicate them.
+        </p>
         <div class="exampleGroup">
           <pre class="data nohighlight">
 @prefix  foaf:  &lt;http://xmlns.com/foaf/0.1/&gt; .

--- a/spec/index.html
+++ b/spec/index.html
@@ -4242,7 +4242,7 @@ SELECT  ?title (?p AS ?fullPrice) (?fullPrice*(1-?discount) AS ?customerPrice)
           by the CONSTRUCT query form.</p>
         <p class="note">
           Note that the construction of the result graph by "set union" does not
-          enforce anything on the appearance or not of duplicated triples in the graph serialization.
+          enforce whether or not duplicated triples appear in the graph serialization.
           Implementations are allowed to produce duplicate triples or to deduplicate them.
         </p>
         <div class="exampleGroup">


### PR DESCRIPTION
States that "set union" does not mandates deduplication.

Issue #91


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/93.html" title="Last updated on Jun 9, 2023, 2:46 PM UTC (df7795e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/93/81781e8...df7795e.html" title="Last updated on Jun 9, 2023, 2:46 PM UTC (df7795e)">Diff</a>