### PR TITLE
Removes inconsistencies between the definitions of the set functions

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9649,11 +9649,13 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               SEPARATOR.</p>
             <div class="defn">
               <p><b>Definition: <span id="defn_aggGroupConcat">GroupConcat</span></b></p>
-              <pre class="code nohighlight">literal GroupConcat(sequence S)</pre>
-              <p>If the "separator" scalar argument is absent from GROUP_CONCAT then it is taken to
-                be the "space" character, unicode codepoint U+0020.</p>
+              <pre class="code nohighlight">literal GroupConcat(sequence S, function scalarvals)</pre>
+              <p>If the scalarvals argument is absent from GROUP_CONCAT, then scalarvals is taken to
+                be the empty function.</p>
+              <p>|separator| = scalarvals("separator") if scalarvals is defined for the argument "separator"</p>
+              <p>|separator| = the "space" character, unicode codepoint U+0020, if scalarvals is undefined for the argument "separator"</p>
               <p>L = Flatten(S)</p>
-              <p>GroupConcat(S, scalarvals) = GroupConcat(L, scalarvals("separator"))</p>
+              <p>GroupConcat(S, scalarvals) = GroupConcat(L, |separator|)</p>
               <p>GroupConcat(L, sep) = "" if <a href="#defn_Card">Card</a>(L) = 0</p>
               <p>GroupConcat(L, sep) = CONCAT("", L<sub>0</sub>) if
                 <a href="#defn_Card">Card</a>(L) = 1</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9474,9 +9474,10 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             </ol>
 
             <p><b>Special Case:</b> when <code>COUNT</code> is used with the expression
-              <code>*</code> the value of F will be the cardinality of the group solution sequence,
-              <code>card[Ψ]</code>, or <code>card[Dedup(Ψ)]</code> if the <code>DISTINCT</code>
-              keyword is present.</p>
+              <code>*</code>, then F(Ψ) is the cardinality of the group solution sequence,
+              i.e., F(Ψ)&nbsp;=&nbsp;<a href="#defn_Card">Card</a>(Ψ),
+              or F(Ψ)&nbsp;=&nbsp;<a href="#defn_Card">Card</a>(Dedup(Ψ))
+              if the <code>DISTINCT</code> keyword is present.</p>
           </div>
           <p><i>scalarvals</i> are used to pass values to the underlying set function, bypassing
             the mechanics of the grouping. For example, the aggregate expression
@@ -9537,6 +9538,11 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <p>The Flatten(S) function takes a sequence of lists, S = [(L<sub>1</sub>, L<sub>2</sub>,
               ...), ...], and returns the list ( x | L in S and x in L ).</p>
           </div>
+          <p>Card is a function that returns the cardinality of a sequence or a list of elements (which may be solution mappings or other types of elements, depending on the context).
+          <div class="defn">
+            <p><b>Definition: <span id="defn_Card">Card</span></b></p>
+            <p>Given a sequence or a list |L|, Card(|L|) is the cardinality of |L|.</p>
+          </div>
           <section id="setFunctions">
             <h5>Set Functions</h5>
             <p>The set functions which underlie SPARQL aggregates all have a common signature:
@@ -9568,7 +9574,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               <pre class="code nohighlight">xsd:integer Count(sequence S)</pre>
               <p>L = Flatten(S)</p>
               <p>remove error elements from L</p>
-              <p>Count(S) = card[L]</p>
+              <p>Count(S) = <a href="#defn_Card">Card</a>(L)</p>
             </div>
           </section>
           <section id="aggSum">
@@ -9583,10 +9589,10 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               <pre class="code nohighlight">numeric Sum(sequence S)</pre>
               <p>L = Flatten(S)</p>
               <p>Sum(S) = Sum(L)</p>
-              <p>Sum(L) = op:numeric-add(L<sub>1</sub>, Sum(L<sub>2..n</sub>)) when card[L] &gt;
+              <p>Sum(L) = op:numeric-add(L<sub>1</sub>, Sum(L<sub>2..n</sub>)) when <a href="#defn_Card">Card</a>(L) &gt;
                 1<br>
-                Sum(L) = op:numeric-add(L<sub>1</sub>, 0) when card[L] = 1<br>
-                Sum(L) = "0"^^xsd:integer when card[L] = 0</p>
+                Sum(L) = op:numeric-add(L<sub>1</sub>, 0) when <a href="#defn_Card">Card</a>(L) = 1<br>
+                Sum(L) = "0"^^xsd:integer when <a href="#defn_Card">Card</a>(L) = 0</p>
               <p>In this way, Sum( (1, 2, 3) ) = op:numeric-add(1, op:numeric-add(2,
                 op:numeric-add(3, 0))).</p>
             </div>
@@ -9615,8 +9621,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               <p>L = Flatten(S)</p>
               <p>Min(S) = Min(L)</p>
               <p>The flattened list L of values is ordered as per the <code>ORDER BY ASC</code> clause.</p>
-              <p>Min(L) = L<sub>0</sub> if card[L] > 0<br>
-                Min(L) = error if card[L] = 0</p>
+              <p>Min(L) = L<sub>0</sub> if <a href="#defn_Card">Card</a>(L) > 0<br>
+                Min(L) = error if <a href="#defn_Card">Card</a>(L) = 0</p>
             </div>
           </section>
           <section id="aggMax">
@@ -9631,8 +9637,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               <p>L = Flatten(S)</p>
               <p>Max(S) = Max(L)</p>
               <p>The flattened list L of values is ordered as per the <code>ORDER BY DESC</code> clause.</p>
-              <p>Max(L) = L<sub>0</sub> if card[L] > 0<br>
-                Max(L) = error if card[L] = 0</p>
+              <p>Max(L) = L<sub>0</sub> if <a href="#defn_Card">Card</a>(L) > 0<br>
+                Max(L) = error if <a href="#defn_Card">Card</a>(L) = 0</p>
             </div>
           </section>
           <section id="aggGroupConcat">
@@ -9648,12 +9654,11 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
                 be the "space" character, unicode codepoint U+0020.</p>
               <p>L = Flatten(S)</p>
               <p>GroupConcat(S, scalarvals) = GroupConcat(L, scalarvals("separator"))</p>
-              <p>GroupConcat(L, sep) = "", where <span style=
-                                                       "font-size: 140%">|</span>L<span style="font-size: 140%">|</span> = 0</p>
+              <p>GroupConcat(L, sep) = "", where <a href="#defn_Card">Card</a>(L) = 0</p>
               <p>GroupConcat(L, sep) = CONCAT("", L<sub>0</sub>), where 
-                <span style="font-size: 140%">|</span>L<span style="font-size: 140%">|</span> = 1</p>
+                <a href="#defn_Card">Card</a>(L) = 1</p>
               <p>GroupConcat(L, sep) = CONCAT(L<sub>0</sub>, sep, GroupConcat(L<sub>1..n-1</sub>,
-                sep)), where <span style="font-size: 140%">|</span>L<span style="font-size: 140%">|</span> &gt; 1</p>
+                sep)), where <a href="#defn_Card">Card</a>(L) &gt; 1</p>
             </div>
             <p>For example, GroupConcat([("a"), ("b"), ("c")], {"separator" → "."}) = "a.b.c".</p>
           </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9525,11 +9525,11 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <p><b>Definition: AggregateJoin</b></p>
             <p>Let S<sub>1</sub>, ..., S<sub>n</sub> be a list of sets, where each set
               S<sub>i</sub> contains key to (aggregated) value maps as produced by Aggregate.</p>
-            <p>Let K = { key | key in dom(S<sub>j</sub>) for some 1 &lt;= j &lt;= n } be the set of
+            <p>Let K = { key | key in dom(S<sub>j</sub>) for some 1 &le; j &le; n } be the set of
               keys, then<br>
               AggregateJoin(S<sub>1</sub>, ..., S<sub>n</sub>) = { agg<sub>1</sub>→val<sub>1</sub>,
               ..., agg<sub>n</sub>→val<sub>n</sub> | key in K and key→val<sub>i</sub> in
-              S<sub>i</sub> for each 1 &lt;= i &lt;= n }</p>
+              S<sub>i</sub> for each 1 &le; i &le; n }</p>
           </div>
           <p>Flatten is a function which is used to collapse a sequence of lists into a single list.
             For example, [(1,&nbsp;2), (3,&nbsp;4)] becomes (1, 2, 3, 4).</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9621,7 +9621,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               <p>L = Flatten(S)</p>
               <p>Min(S) = Min(L)</p>
               <p>The flattened list L of values is ordered as per the <code>ORDER BY ASC</code> clause.</p>
-              <p>Min(L) = L<sub>0</sub> if <a href="#defn_Card">Card</a>(L) > 0<br>
+              <p>Min(L) = L<sub>1</sub> if <a href="#defn_Card">Card</a>(L) > 0<br>
                 Min(L) = error if <a href="#defn_Card">Card</a>(L) = 0</p>
             </div>
           </section>
@@ -9637,7 +9637,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               <p>L = Flatten(S)</p>
               <p>Max(S) = Max(L)</p>
               <p>The flattened list L of values is ordered as per the <code>ORDER BY DESC</code> clause.</p>
-              <p>Max(L) = L<sub>0</sub> if <a href="#defn_Card">Card</a>(L) > 0<br>
+              <p>Max(L) = L<sub>1</sub> if <a href="#defn_Card">Card</a>(L) > 0<br>
                 Max(L) = error if <a href="#defn_Card">Card</a>(L) = 0</p>
             </div>
           </section>
@@ -9657,9 +9657,9 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               <p>L = Flatten(S)</p>
               <p>GroupConcat(S, scalarvals) = GroupConcat(L, |separator|)</p>
               <p>GroupConcat(L, sep) = "" if <a href="#defn_Card">Card</a>(L) = 0</p>
-              <p>GroupConcat(L, sep) = CONCAT("", L<sub>0</sub>) if
+              <p>GroupConcat(L, sep) = CONCAT("", L<sub>1</sub>) if
                 <a href="#defn_Card">Card</a>(L) = 1</p>
-              <p>GroupConcat(L, sep) = CONCAT(L<sub>0</sub>, sep, GroupConcat(L<sub>1..n-1</sub>,
+              <p>GroupConcat(L, sep) = CONCAT(L<sub>1</sub>, sep, GroupConcat(L<sub>2..n</sub>,
                 sep)) if <a href="#defn_Card">Card</a>(L) &gt; 1</p>
             </div>
             <p>For example, GroupConcat([("a"), ("b"), ("c")], {"separator" → "."}) = "a.b.c".</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9589,10 +9589,10 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               <pre class="code nohighlight">numeric Sum(sequence S)</pre>
               <p>L = Flatten(S)</p>
               <p>Sum(S) = Sum(L)</p>
-              <p>Sum(L) = op:numeric-add(L<sub>1</sub>, Sum(L<sub>2..n</sub>)) when <a href="#defn_Card">Card</a>(L) &gt;
+              <p>Sum(L) = op:numeric-add(L<sub>1</sub>, Sum(L<sub>2..n</sub>)) if <a href="#defn_Card">Card</a>(L) &gt;
                 1<br>
-                Sum(L) = op:numeric-add(L<sub>1</sub>, 0) when <a href="#defn_Card">Card</a>(L) = 1<br>
-                Sum(L) = "0"^^xsd:integer when <a href="#defn_Card">Card</a>(L) = 0</p>
+                Sum(L) = op:numeric-add(L<sub>1</sub>, 0) if <a href="#defn_Card">Card</a>(L) = 1<br>
+                Sum(L) = "0"^^xsd:integer if <a href="#defn_Card">Card</a>(L) = 0</p>
               <p>In this way, Sum( (1, 2, 3) ) = op:numeric-add(1, op:numeric-add(2,
                 op:numeric-add(3, 0))).</p>
             </div>
@@ -9604,8 +9604,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <div class="defn">
               <p><b>Definition: <span id="defn_aggAvg">Avg</span></b></p>
               <pre class="code nohighlight">numeric Avg(sequence S)</pre>
-              <p>Avg(S) = "0"^^xsd:integer, where Count(S) = 0</p>
-              <p>Avg(S) = Sum(S) / Count(S), where Count(S) &gt; 0</p>
+              <p>Avg(S) = "0"^^xsd:integer if Count(S) = 0</p>
+              <p>Avg(S) = Sum(S) / Count(S) if Count(S) &gt; 0</p>
             </div>
             <p>For example, Avg([(1), (2), (3)]) = Sum([(1), (2), (3)])/Count([(1), (2), (3)]) = 6/3 = 2.</p>
           </section>
@@ -9654,11 +9654,11 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
                 be the "space" character, unicode codepoint U+0020.</p>
               <p>L = Flatten(S)</p>
               <p>GroupConcat(S, scalarvals) = GroupConcat(L, scalarvals("separator"))</p>
-              <p>GroupConcat(L, sep) = "", where <a href="#defn_Card">Card</a>(L) = 0</p>
-              <p>GroupConcat(L, sep) = CONCAT("", L<sub>0</sub>), where 
+              <p>GroupConcat(L, sep) = "" if <a href="#defn_Card">Card</a>(L) = 0</p>
+              <p>GroupConcat(L, sep) = CONCAT("", L<sub>0</sub>) if
                 <a href="#defn_Card">Card</a>(L) = 1</p>
               <p>GroupConcat(L, sep) = CONCAT(L<sub>0</sub>, sep, GroupConcat(L<sub>1..n-1</sub>,
-                sep)), where <a href="#defn_Card">Card</a>(L) &gt; 1</p>
+                sep)) if <a href="#defn_Card">Card</a>(L) &gt; 1</p>
             </div>
             <p>For example, GroupConcat([("a"), ("b"), ("c")], {"separator" → "."}) = "a.b.c".</p>
           </section>


### PR DESCRIPTION
... as pointed out in #99


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/108.html" title="Last updated on Jun 29, 2023, 10:56 AM UTC (dedb4d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/108/ae554d5...dedb4d0.html" title="Last updated on Jun 29, 2023, 10:56 AM UTC (dedb4d0)">Diff</a>