### PR TITLE
errata-query-11

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -8769,9 +8769,9 @@ Let P := the algebra translation of the GroupGraphPattern of the query level
 Let E := [], a list of pairs of the form (variable, expression)
 
 If Q contains GROUP BY exprlist
-   Let G := Group(exprlist, ToList(P))
+   Let Grp := Group(exprlist, ToList(P))
 Else If Q contains an aggregate in SELECT, HAVING, ORDER BY
-   Let G := Group((1), ToList(P))
+   Let Grp := Group((1), ToList(P))
 Else
    skip the rest of the aggregate step
    End
@@ -8784,14 +8784,14 @@ For each (X AS Var) in SELECT, each HAVING(X), and each ORDER BY X in Q
       End
   For each aggregate R(args ; scalarvals) now in X
       # note scalarvals may be omitted, then it's equivalent to the empty set
-      A<span><sub>i</sub></span> := Aggregation(args, R, scalarvals, G)
+      A<span><sub>i</sub></span> := Aggregation(args, R, scalarvals, Grp)
       Replace R(...) with agg<span><sub>i</sub></span> in Q
       i := i + 1
       End
   End
 
 For each variable V appearing outside of an aggregate
-   A<span><sub>i</sub></span> := Aggregation(V, Sample, {}, G)
+   A<span><sub>i</sub></span> := Aggregation(V, Sample, {}, Grp)
    E := E append (V, agg<span><sub>i</sub></span>)
    i := i + 1
    End
@@ -9763,8 +9763,8 @@ eval(D(G), Graph(var,P)) =
             <div id="defn_evalAggregation">
               <b>Definition: Evaluation of Aggregation</b>
             </div>
-            <p>eval(D(G), Aggregation(exprlist, func, scalarvals, P)) = Aggregation(exprlist, func,
-              scalarvals, eval(D(G), P))</p>
+            <p>eval(D(G), Aggregation(exprlist, func, scalarvals, Grp)) = Aggregation(exprlist, func,
+              scalarvals, eval(D(G), Grp))</p>
           </div>
           <div class="defn">
             <div id="defn_evalAggregateJoin">


### PR DESCRIPTION
As I argue in #94, the suggested fix for [errata-query-11](https://www.w3.org/2013/sparql-errata#errata-query-11) is not needed but a small renaming of variables may help to avoid the confusion that led to the errata. This PR implements my proposed variable renaming.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/109.html" title="Last updated on Jun 29, 2023, 11:48 AM UTC (d1efdf6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/109/ae554d5...d1efdf6.html" title="Last updated on Jun 29, 2023, 11:48 AM UTC (d1efdf6)">Diff</a>