### PR TITLE
introduces a function called multiplicity to replace card[Ω](μ)

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -8947,9 +8947,9 @@ The set PV is used later for projection.
         <p>Write <var>μ</var> for solution mappings.</p>
         <p>Write <var>μ<sub>0</sub></var> for the mapping such that <var>dom</var>(<var>μ<sub>0</sub></var>) is the empty set.</p>
         <p>Write <var>Ω<sub>0</sub></var> for the multiset consisting of exactly the empty mapping
-          μ<sub>0,</sub> with multiplicity 1. This is the join identity.</p>
-        <p>Write μ(x) for the solution mapping variable x to RDF term t : { (x, t) }</p>
-        <p>Write Ω(x) for the multiset consisting of exactly μ(?x-&gt;t), that is, { { (x, t) } }
+          <var>μ<sub>0</sub></var>, with multiplicity 1. This is the join identity.</p>
+        <p>Write <var>μ</var>(<var>x</var>) for the solution mapping variable <var>x</var> to RDF term <var>t</var> : { (<var>x</var>, <var>t</var>) }.</p>
+        <p>Write <var>Ω</var>(<var>x</var>) for the multiset consisting of exactly <var>μ</var>(<var>?x</var>-&gt;<var>t</var>), that is, <code>{ { (x, t) } }</code>
           with multiplicity 1.</p>
         <div class="defn">
           <p><b>Definition: <span id="defn_algCompatibleMapping">Compatible Mappings</span></b></p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -8964,12 +8964,12 @@ The set PV is used later for projection.
           μ<sub>2</sub></p>
         <div class="defn">
           <p><b>Definition: <span id="defn_Multiplicity">Multiplicity</span></b></p>
-          <p>Given a multiset&nbsp;Ω of solution mappings and a solution
-            mapping&nbsp;μ, we write multiplicity<sup>Ω</sup>(μ) to denote
-            the number of times μ appears in Ω.</p>
-          <p>Similarly, given a solution sequence&nbsp;Ψ and a solution
-            mapping&nbsp;μ, we write multiplicity<sup>Ψ</sup>(μ) to denote
-            the number of times μ appears in Ψ.</p>
+          <p>Given a multiset&nbsp;<var>Ω</var> of solution mappings and a solution
+            mapping&nbsp;<var>μ</var>, we write <var>multiplicity<sup><var>Ω</var></sup></var>(<var>μ</var>)
+            to denote the number of times <var>μ</var> appears in <var>Ω</var>.</p>
+          <p>Similarly, given a solution sequence&nbsp;<var>Ψ</var> and a solution
+            mapping&nbsp;<var>μ</var>, we write <var>multiplicity<sup><var>Ψ</var></sup></var>(<var>μ</var>)
+            to denote the number of times <var>μ</var> appears in <var>Ψ</var>.</p>
         </div>
         <section id="BGPsparql">
           <h4>SPARQL Basic Graph Pattern Matching</h4>

--- a/spec/index.html
+++ b/spec/index.html
@@ -8944,9 +8944,9 @@ The set PV is used later for projection.
           unordered collection of elements in which each element may appear more than once. It is
           described by a set of elements and a function giving the multiplicity of each of these
           elements (i.e., the number of times the element is contained in the multiset).</p>
-        <p>Write μ for solution mappings.</p>
-        <p>Write μ<sub>0</sub> for the mapping such that dom(μ<sub>0</sub>) is the empty set.</p>
-        <p>Write Ω<sub>0</sub> for the multiset consisting of exactly the empty mapping
+        <p>Write <var>μ</var> for solution mappings.</p>
+        <p>Write <var>μ<sub>0</sub></var> for the mapping such that <var>dom</var>(<var>μ<sub>0</sub></var>) is the empty set.</p>
+        <p>Write <var>Ω<sub>0</sub></var> for the multiset consisting of exactly the empty mapping
           μ<sub>0,</sub> with multiplicity 1. This is the join identity.</p>
         <p>Write μ(x) for the solution mapping variable x to RDF term t : { (x, t) }</p>
         <p>Write Ω(x) for the multiset consisting of exactly μ(?x-&gt;t), that is, { { (x, t) } }

--- a/spec/index.html
+++ b/spec/index.html
@@ -8993,8 +8993,8 @@ The set PV is used later for projection.
             <p>μ is a <b>solution</b> for BGP from G when there is a pattern instance mapping P such
               that P(BGP) is a subgraph of G and μ is the restriction of P to the query variables in
               BGP.</p>
-            <p><a href="#defn_Multiplicity">multiplicity</a><sup>Ω</sup>(μ) = number of distinct RDF instance mappings, σ, such that P = μ(σ)
-              is a pattern instance mapping and P(BGP) is a subgraph of G</p>
+            <p>card[Ω](μ) = card[Ω](number of distinct RDF instance mappings, σ, such that P = μ(σ)
+              is a pattern instance mapping and P(BGP) is a subgraph of G).</p>
           </div>
           <p>If a basic graph pattern is the empty set, then the solution is Ω<sub>0</sub>.</p>
         </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -8965,10 +8965,10 @@ The set PV is used later for projection.
         <div class="defn">
           <p><b>Definition: <span id="defn_Multiplicity">Multiplicity</span></b></p>
           <p>Given a multiset&nbsp;<var>Ω</var> of solution mappings and a solution
-            mapping&nbsp;<var>μ</var>, we write <var>multiplicity<sup><var>Ω</var></sup></var>(<var>μ</var>)
+            mapping&nbsp;<var>μ</var>, we write <var>multiplicity</var>(<var>μ</var>&nbsp;|&nbsp;<var>Ω</var>)
             to denote the number of times <var>μ</var> appears in <var>Ω</var>.</p>
           <p>Similarly, given a solution sequence&nbsp;<var>Ψ</var> and a solution
-            mapping&nbsp;<var>μ</var>, we write <var>multiplicity<sup><var>Ψ</var></sup></var>(<var>μ</var>)
+            mapping&nbsp;<var>μ</var>, we write <var>multiplicity</var>(<var>μ</var>&nbsp;|&nbsp;<var>Ψ</var>)
             to denote the number of times <var>μ</var> appears in <var>Ψ</var>.</p>
         </div>
         <section id="BGPsparql">
@@ -9262,8 +9262,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <p>Let Ω be a multiset of solution mappings and expr be an expression. We define:</p>
           <p>Filter(expr, Ω) = { μ | μ in Ω and expr(μ) is an expression that has an
             effective boolean value of true }</p>
-          <p><a href="#defn_Multiplicity">multiplicity</a><sup>Filter(expr, Ω)</sup>(μ)
-            = <a href="#defn_Multiplicity">multiplicity</a><sup>Ω</sup>(μ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | Filter(expr, Ω) )
+            = <a href="#defn_Multiplicity">multiplicity</a>( μ | Ω )</p>
           <blockquote>
             Note that evaluating an <code>exists(pattern)</code> expression uses the dataset and
             active graph, D(G). See the <a href="#defn_evalFilter">evaluation of filter</a>.

--- a/spec/index.html
+++ b/spec/index.html
@@ -3916,8 +3916,8 @@ SELECT DISTINCT ?name WHERE { ?x foaf:name ?name }
             <h4>REDUCED</h4>
             <p>While the <code>DISTINCT</code> modifier ensures that duplicate solutions are
               eliminated from the solution set, <code>REDUCED</code> simply permits them to be
-              eliminated. The cardinality of any set of variable bindings in a <code>REDUCED</code>
-              solution set is at least one and not more than the cardinality of the solution set with
+              eliminated. The multiplicity of any solution in a <code>REDUCED</code>
+              solution set is at least one and not more than the multiplicity of the solution within the solution set with
               no <code>DISTINCT</code> or <code>REDUCED</code> modifier. For example, using the data
               above, the query</p>
             <div class="queryGroup">
@@ -8880,7 +8880,7 @@ The set PV is used later for projection.
             <li>Limit</li>
           </ul>
           <p>Step: ToList</p>
-          <p>ToList turns a multiset into a sequence with the same elements and cardinality. There is
+          <p>ToList turns a multiset into a sequence with the same elements and multiplicities. There is
             no implied ordering to the sequence; duplicates need not be adjacent.</p>
           <blockquote>
             <p>Let M := ToList(Pattern)</p>
@@ -8993,8 +8993,9 @@ The set PV is used later for projection.
             <p>μ is a <b>solution</b> for BGP from G when there is a pattern instance mapping P such
               that P(BGP) is a subgraph of G and μ is the restriction of P to the query variables in
               BGP.</p>
-            <p>card[Ω](μ) = card[Ω](number of distinct RDF instance mappings, σ, such that P = μ(σ)
-              is a pattern instance mapping and P(BGP) is a subgraph of G).</p>
+            <p><a href="#defn_Multiplicity">multiplicity</a>( μ | Ω ) =
+              number of distinct RDF instance mappings, σ, such that P = μ(σ)
+              is a pattern instance mapping and P(BGP) is a subgraph of G.</p>
           </div>
           <p>If a basic graph pattern is the empty set, then the solution is Ω<sub>0</sub>.</p>
         </section>
@@ -9275,16 +9276,16 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <p>Join(Ω<sub>1</sub>, Ω<sub>2</sub>) = { merge(μ<sub>1</sub>, μ<sub>2</sub>) |
             μ<sub>1</sub> in Ω<sub>1</sub> and μ<sub>2</sub> in Ω<sub>2</sub>, and μ<sub>1</sub> and
             μ<sub>2</sub> are compatible }</p>
-          <p>card[Join(Ω<sub>1</sub>, Ω<sub>2</sub>)](μ) =<br>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | Join(Ω<sub>1</sub>, Ω<sub>2</sub>) ) =<br>
             &nbsp;&nbsp;&nbsp; for each merge(μ<sub>1</sub>, μ<sub>2</sub>), μ<sub>1</sub> in
             Ω<sub>1</sub> and μ<sub>2</sub> in Ω<sub>2</sub> such that μ = merge(μ<sub>1</sub>,
             μ<sub>2</sub>),<br>
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; sum over (μ<sub>1</sub>, μ<sub>2</sub>),
-            card[Ω<sub>1</sub>](μ<sub>1</sub>)*card[Ω<sub>2</sub>](μ<sub>2</sub>)</p>
+            <a href="#defn_Multiplicity">multiplicity</a>( μ<sub>1</sub> | Ω<sub>1</sub> ) * <a href="#defn_Multiplicity">multiplicity</a>( μ<sub>2</sub> | Ω<sub>2</sub> )</p>
         </div>
         <p>It is possible that a solution mapping μ in a Join can arise in different solution
-          mappings, μ<sub>1</sub> and μ<sub>2</sub> in the multisets being joined. The cardinality
-          of&nbsp; μ is the sum of the cardinalities from all possibilities.</p>
+          mappings, μ<sub>1</sub> and μ<sub>2</sub> in the multisets being joined. The multiplicity
+          of&nbsp; μ is the sum of the multiplicities from all possibilities.</p>
         <div class="defn">
           <p><b>Definition: <span id="defn_algDiff">Diff</span></b></p>
           <p>Let Ω<sub>1</sub> and Ω<sub>2</sub> be multisets of solution mappings and expr be an
@@ -9292,7 +9293,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <p>Diff(Ω<sub>1</sub>, Ω<sub>2</sub>, expr) = { μ | μ in Ω<sub>1</sub> such that ∀ μ′ in
             Ω<sub>2</sub>, either μ and μ′ are not compatible or μ and μ' are compatible and
             expr(merge(μ, μ')) does not have an effective boolean value of true }</p>
-          <p>card[Diff(Ω<sub>1</sub>, Ω<sub>2</sub>, expr)](μ) = card[Ω<sub>1</sub>](μ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | Diff(Ω<sub>1</sub>, Ω<sub>2</sub>, expr) ) =
+            <a href="#defn_Multiplicity">multiplicity</a>( μ | Ω<sub>1</sub> )</p>
         </div>
         <p>The evaluation of expr(merge(μ, μ')) does not have an effective boolean
           value of true if it evaluates to false or if it raises an error.</p>
@@ -9303,9 +9305,10 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             expression. We define:</p>
           <p>LeftJoin(Ω<sub>1</sub>, Ω<sub>2</sub>, expr) = Filter(expr, Join(Ω<sub>1</sub>,
             Ω<sub>2</sub>)) ∪ Diff(Ω<sub>1</sub>, Ω<sub>2</sub>, expr)</p>
-          <p>card[LeftJoin(Ω<sub>1</sub>, Ω<sub>2</sub>, expr)](μ) = card[Filter(expr,
-            Join(Ω<sub>1</sub>, Ω<sub>2</sub>))](μ) + card[Diff(Ω<sub>1</sub>, Ω<sub>2</sub>,
-            expr)](μ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | LeftJoin(Ω<sub>1</sub>, Ω<sub>2</sub>, expr) ) =
+            <a href="#defn_Multiplicity">multiplicity</a>( μ | Filter(expr,Join(Ω<sub>1</sub>, Ω<sub>2</sub>)) ) +
+            <a href="#defn_Multiplicity">multiplicity</a>( μ | Diff(Ω<sub>1</sub>, Ω<sub>2</sub>,
+            expr) )</p>
         </div>
 
         <div class="defn">
@@ -9313,8 +9316,9 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <p>Let Ω<sub>1</sub> and Ω<sub>2</sub> be multisets of solution mappings. We define:</p>
           <p>Union(Ω<sub>1</sub>, Ω<sub>2</sub>) = { μ | μ in Ω<sub>1</sub> or μ in Ω<sub>2</sub>
             }</p>
-          <p>card[Union(Ω<sub>1</sub>, Ω<sub>2</sub>)](μ) = card[Ω<sub>1</sub>](μ) +
-            card[Ω<sub>2</sub>](μ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | Union(Ω<sub>1</sub>, Ω<sub>2</sub>) ) =
+            <a href="#defn_Multiplicity">multiplicity</a>( μ | Ω<sub>1</sub> ) +
+            <a href="#defn_Multiplicity">multiplicity</a>( μ | Ω<sub>2</sub> )</p>
         </div>
         <div class="defn">
           <p><b>Definition: <span id="defn_algMinus">Minus</span></b></p>
@@ -9322,7 +9326,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <p>Minus(Ω<sub>1</sub>, Ω<sub>2</sub>) = { μ | μ in Ω<sub>1</sub> . ∀ μ' in
             Ω<sub>2</sub>, either μ and μ' are not compatible or dom(μ) and dom(μ') are disjoint
             }</p>
-          <p>card[Minus(Ω<sub>1</sub>, Ω<sub>2</sub>)](μ) = card[Ω<sub>1</sub>](μ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | Minus(Ω<sub>1</sub>, Ω<sub>2</sub>) ) =
+            <a href="#defn_Multiplicity">multiplicity</a>( μ | Ω<sub>1</sub> )</p>
         </div>
         <p>The additional restriction on dom(μ) and dom(μ') is added because otherwise if there is
           a solution mapping in Ω<sub>2</sub> that has no variables in common with the solution
@@ -9340,13 +9345,14 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <p>Extend(Ω, var, expr) = { Extend(μ, var, expr) | μ in Ω }</p>
         </div>
         <p>Write [ x | C ] for a sequence of elements where C is a condition on x.</p>
-        <p>Write card[L](x) to be the cardinality of x in L.</p>
         <div class="defn">
           <p><b>Definition: <span id="defn_algToList">ToList</span></b></p>
           <p>Let Ω be a multiset of solution mappings. We define:</p>
-          <p>ToList(Ω) = a sequence of mappings μ in Ω in any order, with card[Ω](μ) occurrences of
+          <p>ToList(Ω) = a sequence of mappings μ in Ω in any order, with
+            <a href="#defn_Multiplicity">multiplicity</a>( μ | Ω ) occurrences of
             μ</p>
-          <p>card[ToList(Ω)](μ) = card[Ω](μ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | ToList(Ω) ) =
+            <a href="#defn_Multiplicity">multiplicity</a>( μ | Ω )</p>
         </div>
         <div class="defn">
           <p><b>Definition: <span id="defn_algOrdered">OrderBy</span></b></p>
@@ -9354,31 +9360,40 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <div id="defn_algOrderBy">
             OrderBy
           </div>(Ψ, condition) = [ μ | μ in Ψ and the sequence satisfies the ordering condition]
-          <p>card[OrderBy(Ψ, condition)](μ) = card[Ψ](μ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | OrderBy(Ψ, condition) ) =
+            <a href="#defn_Multiplicity">multiplicity</a>( μ | Ψ )</p>
         </div>
         <div class="defn">
           <p><b>Definition: <span id="defn_algProjection">Project</span></b></p>
           <p>Let Ψ be a sequence of solution mappings and PV a set of variables.</p>
           <p>For mapping μ, write Proj(μ, PV) to be the restriction of μ to variables in PV.</p>
           <p>Project(Ψ, PV) = [ Proj(μ, PV) | μ in Ψ ]</p>
-          <p>card[Project(Ψ, PV)](μ) = sum(card[Ψ](ν) | ν in Ψ such that ν = Proj(μ, PV))</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | Project(Ψ, PV) ) =
+            sum( <a href="#defn_Multiplicity">multiplicity</a>( ν | Ψ ) | ν in Ψ such that ν = Proj(μ, PV))</p>
           <p>The order of Project(Ψ, PV) must preserve any ordering given by OrderBy.</p>
         </div>
         <div class="defn">
           <p><b>Definition: <span id="defn_algDistinct">Distinct</span></b></p>
           <p>Let Ψ be a sequence of solution mappings. We define:</p>
           <p>Distinct(Ψ) = [ μ | μ in Ψ ]</p>
-          <p>card[Distinct(Ψ)](μ) = 1</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | Distinct(Ψ) ) = 1
+            for every μ ∈ Distinct(Ψ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | Distinct(Ψ) ) = 0
+            for every μ ∉ Distinct(Ψ)</p>
           <p>The order of Distinct(Ψ) must preserve any ordering given by OrderBy.</p>
         </div>
         <div class="defn">
           <p><b>Definition: <span id="defn_algReduced">Reduced</span></b></p>
           <p>Let Ψ be a sequence of solution mappings. We define:</p>
           <p>Reduced(Ψ) = [ μ | μ in Ψ ]</p>
-          <p>card[Reduced(Ψ)](μ) is between 1 and card[Ψ](μ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | Reduced(Ψ) ) is
+            between 1 and <a href="#defn_Multiplicity">multiplicity</a>( μ | Ψ )
+            for every μ ∈ Reduced(Ψ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | Reduced(Ψ) ) = 0
+            for every μ ∉ Reduced(Ψ)</p>
           <p>The order of Reduced(Ψ) must preserve any ordering given by OrderBy.</p>
         </div>
-        <p>The Reduced solution sequence modifier does not guarantee a defined cardinality.</p>
+        <p>The Reduced solution sequence modifier does not guarantee a defined multiplicity.</p>
         <div class="defn">
           <p><b>Definition: <span id="defn_algSlice">Slice</span></b></p>
           <p>Let Ψ be a sequence of solution mappings. We define:</p>
@@ -9390,7 +9405,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <p><b>Definition: <span id="defn_algToMultiSet">ToMultiSet</span></b></p>
           <p>Let Ψ be a solution sequence. We define:</p>
           <p>ToMultiSet(Ψ) = { μ | μ in Ψ }</p>
-          <p>card[ToMultiSet(Ψ)](μ) = card[Ψ](μ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a>( μ | ToMultiSet(Ψ) ) =
+            <a href="#defn_Multiplicity">multiplicity</a>( μ | Ψ )</p>
         </div>
         <p>ListEval is a function which is used to evaluate a list of expressions against a
           solution and return a list of the resulting values.</p>
@@ -9398,7 +9414,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <div id="defn_algToMultiset">
             <b>Definition: ToMultiset</b>
           </div>
-          <p>ToMultiset turns a sequence into a multiset with the same elements and cardinality as
+          <p>ToMultiset turns a sequence into a multiset with the same elements and multiplicities as
             the sequence. The order of the sequence has no effect on the resulting multiset, and
             duplicates are preserved.</p>
         </div>
@@ -9748,8 +9764,8 @@ eval(D(G), Graph(var,P)) =
     the result is R
             </pre>
           </div>
-          <p>The evaluation of graph uses the SPARQL algebra union operator. The cardinality of a
-            solution mapping is the sum of the cardinalities of that solution mapping in each join
+          <p>The evaluation of graph uses the SPARQL algebra union operator. The multiplicity of a
+            solution mapping is the sum of the multiplicities of that solution mapping in each join
             operation.</p>
           <div class="defn">
             <div id="defn_evalGroup">

--- a/spec/index.html
+++ b/spec/index.html
@@ -8942,15 +8942,15 @@ The set PV is used later for projection.
           <a href="https://en.wikipedia.org/w/index.php?title=Multiset">multiset</a>, 
           also known as a <i>bag</i>. A multiset is an
           unordered collection of elements in which each element may appear more than once. It is
-          described by a set of elements and a cardinality function giving the number of occurrences of
-          each element from the set in the multiset.</p>
+          described by a set of elements and a function giving the multiplicity of each of these
+          elements (i.e., the number of times the element is contained in the multiset).</p>
         <p>Write μ for solution mappings.</p>
         <p>Write μ<sub>0</sub> for the mapping such that dom(μ<sub>0</sub>) is the empty set.</p>
         <p>Write Ω<sub>0</sub> for the multiset consisting of exactly the empty mapping
-          μ<sub>0,</sub> with cardinality 1. This is the join identity.</p>
+          μ<sub>0,</sub> with multiplicity 1. This is the join identity.</p>
         <p>Write μ(x) for the solution mapping variable x to RDF term t : { (x, t) }</p>
         <p>Write Ω(x) for the multiset consisting of exactly μ(?x-&gt;t), that is, { { (x, t) } }
-          with cardinality 1.</p>
+          with multiplicity 1.</p>
         <div class="defn">
           <p><b>Definition: <span id="defn_algCompatibleMapping">Compatible Mappings</span></b></p>
           <p>Two solution mappings μ<sub>1</sub> and μ<sub>2</sub> are compatible if, for every
@@ -8962,8 +8962,15 @@ The set PV is used later for projection.
         <p>If μ<sub>1</sub> and μ<sub>2</sub> are compatible then μ<sub>1</sub> ∪ μ<sub>2</sub> is
           also a mapping. Write merge(μ<sub>1</sub>, μ<sub>2</sub>) for μ<sub>1</sub> ∪
           μ<sub>2</sub></p>
-        <p>Write card[Ω](μ) for the cardinality of solution mapping μ in a multiset of mappings
-          Ω.</p>
+        <div class="defn">
+          <p><b>Definition: <span id="defn_Multiplicity">Multiplicity</span></b></p>
+          <p>Given a multiset&nbsp;Ω of solution mappings and a solution
+            mapping&nbsp;μ, we write multiplicity<sup>Ω</sup>(μ) to denote
+            the number of times μ appears in Ω.</p>
+          <p>Similarly, given a solution sequence&nbsp;Ψ and a solution
+            mapping&nbsp;μ, we write multiplicity<sup>Ψ</sup>(μ) to denote
+            the number of times μ appears in Ψ.</p>
+        </div>
         <section id="BGPsparql">
           <h4>SPARQL Basic Graph Pattern Matching</h4>
           <p>A basic graph pattern is matched against the active graph for that part of the query.
@@ -8986,8 +8993,8 @@ The set PV is used later for projection.
             <p>μ is a <b>solution</b> for BGP from G when there is a pattern instance mapping P such
               that P(BGP) is a subgraph of G and μ is the restriction of P to the query variables in
               BGP.</p>
-            <p>card[Ω](μ) = card[Ω](number of distinct RDF instance mappings, σ, such that P = μ(σ)
-              is a pattern instance mapping and P(BGP) is a subgraph of G).</p>
+            <p><a href="#defn_Multiplicity">multiplicity</a><sup>Ω</sup>(μ) = number of distinct RDF instance mappings, σ, such that P = μ(σ)
+              is a pattern instance mapping and P(BGP) is a subgraph of G</p>
           </div>
           <p>If a basic graph pattern is the empty set, then the solution is Ω<sub>0</sub>.</p>
         </section>
@@ -9255,7 +9262,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <p>Let Ω be a multiset of solution mappings and expr be an expression. We define:</p>
           <p>Filter(expr, Ω) = { μ | μ in Ω and expr(μ) is an expression that has an
             effective boolean value of true }</p>
-          <p>card[Filter(expr, Ω)](μ) = card[Ω](μ)</p>
+          <p><a href="#defn_Multiplicity">multiplicity</a><sup>Filter(expr, Ω)</sup>(μ)
+            = <a href="#defn_Multiplicity">multiplicity</a><sup>Ω</sup>(μ)</p>
           <blockquote>
             Note that evaluating an <code>exists(pattern)</code> expression uses the dataset and
             active graph, D(G). See the <a href="#defn_evalFilter">evaluation of filter</a>.


### PR DESCRIPTION
In the context of [discussing the new Card(..) function introduced](https://github.com/w3c/sparql-query/pull/108#issuecomment-1618880551) in PR #108, @afs [writes](https://github.com/w3c/sparql-query/pull/108#issuecomment-1618937017):

> `card[Ω]` evaluates to a function that gives the number of instances of `μ`.
>
> We could change that "multiplicity" or something based on that word ("multiplicity" seems a bit long but may be necessary).

This PR here is a proposal to address this comment. In particular, this PR introduces a function called 'multiplicity' with a definition that can be cross-referenced, and (currently) one place where this function is used (namely, in the definition of Filter). The latter is to demonstrate how it would look like to use this functions instead of the notation `card[Ω](μ)`. My proposal is to replace all occurrences of `card[Ω](μ)` in this way.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/110.html" title="Last updated on Oct 16, 2023, 5:33 PM UTC (376e0c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/110/fc0566b...376e0c6.html" title="Last updated on Oct 16, 2023, 5:33 PM UTC (376e0c6)">Diff</a>