### PR TITLE
Update Filter Evaluation language to reference more functional forms.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4746,7 +4746,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
             <a href="#func-if">IF</a>, <a href="#func-in">IN</a>, <a href="#func-not-in">NOT IN</a>, 
             <a href="#func-logical-or">logical-or</a> (<code>||</code>),
             <a href="#func-logical-and">logical-and</a> (<code>&amp;&</code>),
-            <a href="#func-filter-exists">NOT EXISTS</a> and <a href="#func-filter-exists">EXISTS</a>,
+            <a href="#func-filter-exists">NOT EXISTS</a>, and <a href="#func-filter-exists">EXISTS</a>,
             all functions operate on RDF Terms and will produce a type error if any
             arguments are unbound.
           </li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -4741,7 +4741,9 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
             "xsd:boolean (EBV)" in the operator mapping table below), are coerced to
             <code>xsd:boolean</code> using the <a href="#ebv">EBV rules</a> in section 17.2.2.
           </li>
-          <li>Apart from <a href="#func-bound">BOUND</a>, <a href="#func-coalesce">COALESCE</a>,
+          <li>Apart from the <a href="#func-forms">functional forms</a>
+            <a href="#func-bound">BOUND</a>, <a href="#func-coalesce">COALESCE</a>,
+            <a href="#func-if">IF</a>, <a href="#func-in">IN</a>, <a href="#func-not-in">NOT IN</a>, 
             <a href="#func-filter-exists">NOT EXISTS</a> and <a href="#func-filter-exists">EXISTS</a>,
             all functions and operators operate on RDF Terms and will produce a type error if any
             arguments are unbound.

--- a/spec/index.html
+++ b/spec/index.html
@@ -4747,7 +4747,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
             <a href="#func-logical-or">logical-or</a> (<code>||</code>),
             <a href="#func-logical-and">logical-and</a> (<code>&amp;&</code>),
             <a href="#func-filter-exists">NOT EXISTS</a> and <a href="#func-filter-exists">EXISTS</a>,
-            all functions and operators operate on RDF Terms and will produce a type error if any
+            all functions operate on RDF Terms and will produce a type error if any
             arguments are unbound.
           </li>
           <li>Any expression other than <a href="#func-logical-or">logical-or</a> (<code>||</code>)

--- a/spec/index.html
+++ b/spec/index.html
@@ -4744,6 +4744,8 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
           <li>Apart from the <a href="#func-forms">functional forms</a>
             <a href="#func-bound">BOUND</a>, <a href="#func-coalesce">COALESCE</a>,
             <a href="#func-if">IF</a>, <a href="#func-in">IN</a>, <a href="#func-not-in">NOT IN</a>, 
+            <a href="#func-logical-or">logical-or</a> (<code>||</code>),
+            <a href="#func-logical-and">logical-and</a> (<code>&amp;&</code>),
             <a href="#func-filter-exists">NOT EXISTS</a> and <a href="#func-filter-exists">EXISTS</a>,
             all functions and operators operate on RDF Terms and will produce a type error if any
             arguments are unbound.


### PR DESCRIPTION
The previous text in 17.2 Filter Evaluation said:

> Apart from BOUND, COALESCE, NOT EXISTS and EXISTS, all functions and operators operate on RDF Terms and will produce a type error if any arguments are unbound.

This PR updates the text to also include reference to `IF`, `IN`, and `NOT IN`, and describes all of these as functional forms.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/117.html" title="Last updated on Aug 17, 2023, 4:27 PM UTC (7629bfc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/117/797575a...7629bfc.html" title="Last updated on Aug 17, 2023, 4:27 PM UTC (7629bfc)">Diff</a>