### PR TITLE
capital letters in refs

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4582,7 +4582,7 @@ foaf:mbox_sha1sum  rdf:type  owl:InverseFunctionalProperty .
             </div>
           </div>
           <p>which includes the blank node closure for the 
-            vCard vocabulary <code>vcard:N</code>.
+            <a data-cite="vcard-rdf#" class="inform">vCard vocabulary</a> <code>vcard:N</code>.
             Other possible mechanisms for deciding what
             information to return include Concise Bounded Descriptions [[CBD]].</p>
           <p>For a vocabulary such as FOAF, where the resources are typically blank nodes, returning

--- a/spec/index.html
+++ b/spec/index.html
@@ -385,8 +385,8 @@ span.cancast:hover { background-color: #ffa;
       </p>
       <p>
         The SPARQL query language for RDF is designed to meet the use cases and
-        requirements identified by the RDF Data Access Working Group in [[rdf-dawg-uc]],
-        the SPARQL 1.1 Working Group in [[sparql-features]], and the RDF-star Working Group.
+        requirements identified by the RDF Data Access Working Group in [[RDF-DAWG-UC]],
+        the SPARQL 1.1 Working Group in [[SPARQL-FEATURES]], and the RDF-star Working Group.
       </p>
       <section id="docOutline">
         <h3>Document Outline</h3>
@@ -4582,7 +4582,7 @@ foaf:mbox_sha1sum  rdf:type  owl:InverseFunctionalProperty .
             </div>
           </div>
           <p>which includes the blank node closure for the 
-            <a data-cite="vcard-rdf#" class="inform">vCard vocabulary</a> <code>vcard:N</code>.
+            vCard vocabulary <code>vcard:N</code>.
             Other possible mechanisms for deciding what
             information to return include Concise Bounded Descriptions [[CBD]].</p>
           <p>For a vocabulary such as FOAF, where the resources are typically blank nodes, returning
@@ -10260,7 +10260,7 @@ _:x rdf:type xsd:decimal .
         <h3>Grammar</h3>
         <p>The EBNF notation used in the grammar is defined in 
           Extensible Markup Language (XML) 1.1 
-          [[xml11]] 
+          [[XML11]] 
           section 6 <a data-cite="xml11#sec-notation">Notation</a>.</p>
         <p>Notes:</p>
         <ol>


### PR DESCRIPTION
- unification of items in References - now all items are in capital letters
- ~~remove vCard from References - now vCard vocab is treated the same as FOAF vocab~~


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 21, 2023, 4:31 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fsparql-query%2F973dbd729c4c691f004d541b93860bfda838ed7a%2Fspec%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 404: http://labs.w3.org/spec-generator/uploads/IGyLAg/spec/index.html
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/sparql-query%23119.)._
</details>
