### PR TITLE
Fixes Sum example to be on a sequence of lists

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9708,7 +9708,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
                 1<br>
                 Sum(L) = op:numeric-add(L<sub>1</sub>, 0) if <a href="#defn_Card">Card</a>(L) = 1<br>
                 Sum(L) = "0"^^xsd:integer if <a href="#defn_Card">Card</a>(L) = 0</p>
-              <p>In this way, Sum( (1, 2, 3) ) = op:numeric-add(1, op:numeric-add(2,
+              <p>In this way, Sum([(1), (2), (3)]) = op:numeric-add(1, op:numeric-add(2,
                 op:numeric-add(3, 0))).</p>
             </div>
           </section>


### PR DESCRIPTION
The other examples where fixed but Sum seemed to have slipped

Errata https://www.w3.org/2013/sparql-errata#errata-query-22 Issue #24


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/122.html" title="Last updated on Sep 21, 2023, 4:54 PM UTC (0dc4893)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/122/bced028...0dc4893.html" title="Last updated on Sep 21, 2023, 4:54 PM UTC (0dc4893)">Diff</a>