### PR TITLE
Fixes the definition of the Flatten function

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9649,9 +9649,11 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <p>Flatten is a function which is used to collapse a sequence of lists into a single list.
             For example, [(1,&nbsp;2), (3,&nbsp;4)] becomes (1, 2, 3, 4).</p>
           <div class="defn">
-            <p><b>Definition: Flatten</b></p>
-            <p>The Flatten(S) function takes a sequence of lists, S = [(L<sub>1</sub>, L<sub>2</sub>,
-              ...), ...], and returns the list ( x | L in S and x in L ).</p>
+            <p><b>Definition: <span id="defn_Flatten">Flatten</span></b></p>
+            <p>The Flatten(S) function takes a sequence S of lists,
+              i.e., S = [L<sub>1</sub>, L<sub>2</sub>, ..., L<sub>m</sub>]
+              where every L<sub>i</sub> is a list,
+              and returns the list ( x | L in S and x in L ).</p>
           </div>
           <p>Card is a function that returns the cardinality of a sequence or a list of elements (which may be solution mappings or other types of elements, depending on the context).
           <div class="defn">


### PR DESCRIPTION
As I just noticed when writing https://github.com/w3c/sparql-query/pull/122#issuecomment-1730246199, in PR #98 I made a mistake in the definition of the 'Flatten' function. This PR fixes this mistake.

While the text in the definition was correct, the formula that illustrates of what form the sequence S is was wrong.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/123.html" title="Last updated on Sep 21, 2023, 8:39 PM UTC (1e22564)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/123/bced028...1e22564.html" title="Last updated on Sep 21, 2023, 8:39 PM UTC (1e22564)">Diff</a>