### PR TITLE
Improves the section about the Sum set function

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9702,13 +9702,21 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <div class="defn">
               <p><b>Definition: <span id="defn_aggSum">Sum</span></b></p>
               <pre class="code nohighlight">numeric <var>Sum</var>(sequence <var>S</var>)</pre>
-              <p>|Sum|(|S|) = <var>Sum'</var>(|L|),
-                where |L| = Flatten(|S|)
-                and <var>Sum'</var>(|L|) is defined recursively as follows.</p>
-              <p><var>Sum'</var>(|L|) = op:numeric-add(|L|<sub>1</sub>, <var>Sum'</var>(|L|<sub>2..n</sub>)) if <a href="#defn_Card">Card</a>(|L|) &gt;
-                1<br>
-                <var>Sum'</var>(|L|) = op:numeric-add(|L|<sub>1</sub>, 0) if <a href="#defn_Card">Card</a>(|L|) = 1<br>
-                <var>Sum'</var>(|L|) = "0"^^xsd:integer if <a href="#defn_Card">Card</a>(|L|) = 0</p>
+              <p><var>Sum</var>(<var>S</var>) = <var>Sum'</var>(<var>L</var>),</p>
+              <p>where <var>L</var> = Flatten(<var>S</var>) and
+                <var>Sum'</var>(<var>L</var>) is defined recursively as follows.</p>
+              <ul>
+                <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 0, then
+                  <var>Sum'</var>(<var>L</var>) = "0"^^<code>xsd:integer</code>.</li>
+                <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 1, then
+                  <var>Sum'</var>(<var>L</var>) = <a data-cite="XPATH-FUNCTIONS-31#func-numeric-add">op:numeric-add</a>(<var>L</var><sub>1</sub>, 0).</li>
+                <li>If <a href="#defn_Card">Card</a>(<var>L</var>) > 1, then
+                  <var>Sum'</var>(<var>L</var>) = <a data-cite="XPATH-FUNCTIONS-31#func-numeric-add">op:numeric-add</a>(<var>L</var><sub>1</sub>,
+                  <var>Sum'</var>(<var>L</var><sub>2..n</sub>)).</li>
+              </ul>
+              <p>Note that <var>L</var><sub>1</sub> is the first element in
+                <var>L</var>, and <var>L</var><sub>2..n</sub> is <var>L</var>
+                without its first element.</p>
             </div>
             <p>In this way, <var>Sum</var>( [(1), (2), (3)] ) = <var>Sum'</var>( (1, 2, 3) ) =
               op:numeric-add(1, op:numeric-add(2, op:numeric-add(3, 0))).</p>
@@ -9733,12 +9741,19 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               arbitrarily typed expressions.</p>
             <div class="defn">
               <p><b>Definition: <span id="defn_aggMin">Min</span></b></p>
-              <pre class="code nohighlight">term Min(sequence S)</pre>
-              <p>L = Flatten(S)</p>
-              <p>Min(S) = Min(L)</p>
-              <p>The flattened list L of values is ordered as per the <code>ORDER BY ASC</code> clause.</p>
-              <p>Min(L) = L<sub>1</sub> if <a href="#defn_Card">Card</a>(L) > 0<br>
-                Min(L) = error if <a href="#defn_Card">Card</a>(L) = 0</p>
+              <pre class="code nohighlight">term <var>Min</var>(sequence <var>S</var>)</pre>
+              <p><var>Min</var>(<var>S</var>) = <var>Min'</var>(<var>L</var>),</p>
+              <p>where <var>L</var> is the list of values obtained by Flatten(<var>S</var>)
+                and then ordered as per the <code>ORDER BY ASC</code> clause,
+                and <var>Min'</var>(<var>L</var>) is defined as follows.</p>
+              <ul>
+                <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 0, then
+                  <var>Min'</var>(<var>L</var>) = error.</li>
+                <li>If <a href="#defn_Card">Card</a>(<var>L</var>) > 0, then
+                  <var>Min'</var>(<var>L</var>) = <var>L</var><sub>1</sub>,
+                  where <var>L</var><sub>1</sub> is the first element in
+                  <var>L</var>.</li>
+              </ul>
             </div>
           </section>
           <section id="aggMax">
@@ -9749,12 +9764,19 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               arbitrarily typed expressions.</p>
             <div class="defn">
               <p><b>Definition: <span id="defn_aggMax">Max</span></b></p>
-              <pre class="code nohighlight">term Max(sequence S)</pre>
-              <p>L = Flatten(S)</p>
-              <p>Max(S) = Max(L)</p>
-              <p>The flattened list L of values is ordered as per the <code>ORDER BY DESC</code> clause.</p>
-              <p>Max(L) = L<sub>1</sub> if <a href="#defn_Card">Card</a>(L) > 0<br>
-                Max(L) = error if <a href="#defn_Card">Card</a>(L) = 0</p>
+              <pre class="code nohighlight">term <var>Max</var>(sequence <var>S</var>)</pre>
+              <p><var>Max</var>(<var>S</var>) = <var>Max'</var>(<var>L</var>),</p>
+              <p>where <var>L</var> is the list of values obtained by Flatten(<var>S</var>)
+                and then ordered as per the <code>ORDER BY DESC</code> clause,
+                and <var>Max'</var>(<var>L</var>) is defined as follows.</p>
+              <ul>
+                <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 0, then
+                  <var>Max'</var>(<var>L</var>) = error.</li>
+                <li>If <a href="#defn_Card">Card</a>(<var>L</var>) > 0, then
+                 <var>Max'</var>(<var>L</var>) = <var>L</var><sub>1</sub>,
+                 where <var>L</var><sub>1</sub> is the first element in
+                 <var>L</var>.</li>
+              </ul>
             </div>
           </section>
           <section id="aggGroupConcat">
@@ -9765,20 +9787,38 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               SEPARATOR.</p>
             <div class="defn">
               <p><b>Definition: <span id="defn_aggGroupConcat">GroupConcat</span></b></p>
-              <pre class="code nohighlight">literal GroupConcat(sequence S, function scalarvals)</pre>
-              <p>If the scalarvals argument is absent from GROUP_CONCAT, then scalarvals is taken to
-                be the empty function.</p>
-              <p>|separator| = scalarvals("separator") if scalarvals is defined for the argument "separator"</p>
-              <p>|separator| = the "space" character, unicode codepoint U+0020, if scalarvals is undefined for the argument "separator"</p>
-              <p>L = Flatten(S)</p>
-              <p>GroupConcat(S, scalarvals) = GroupConcat(L, |separator|)</p>
-              <p>GroupConcat(L, sep) = "" if <a href="#defn_Card">Card</a>(L) = 0</p>
-              <p>GroupConcat(L, sep) = CONCAT("", L<sub>1</sub>) if
-                <a href="#defn_Card">Card</a>(L) = 1</p>
-              <p>GroupConcat(L, sep) = CONCAT(L<sub>1</sub>, sep, GroupConcat(L<sub>2..n</sub>,
-                sep)) if <a href="#defn_Card">Card</a>(L) &gt; 1</p>
+              <pre class="code nohighlight">literal <var>GroupConcat</var>(sequence <var>S</var>, function <var>scalarvals</var>)</pre>
+              <p>If the <var>scalarvals</var> argument is absent from GROUP_CONCAT,
+                then <var>scalarvals</var> is taken to be the empty function.</p>
+              <p>Let <var>sep</var> be a string that is defined as follows.</p>
+              <ul>
+                <li>If <var>scalarvals</var> is defined for the argument "separator",
+                  then <var>sep</var> = <var>scalarvals</var>("separator").</li>
+                <li>If <var>scalarvals</var> is undefined for the argument "separator",
+                  then <var>sep</var> is the "space" character (i.e., unicode codepoint U+0020).</li>
+              </ul>
+              <p><var>GroupConcat</var>(<var>S</var>, <var>scalarvals</var>) =
+                <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>),</p>
+              <p>where <var>L</var> = Flatten(<var>S</var>) and
+                <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>)
+                is defined recursively as follows.</p>
+              <ul>
+                <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 0, then
+                  <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>) = "".</li>
+                <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 1, then
+                  <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>) =
+                  CONCAT("", <var>L</var><sub>1</sub>).</li>
+                <li>If <a href="#defn_Card">Card</a>(<var>L</var>) > 1, then
+                  <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>) =
+                  CONCAT(<var>L</var><sub>1</sub>, <var>sep</var>, <var>GroupConcat'</var>(<var>L</var><sub>2..n</sub>, <var>sep</var>)).</li>
+              </ul>
+              <p>Note that <var>L</var><sub>1</sub> is the first element in
+                <var>L</var>, and <var>L</var><sub>2..n</sub> is <var>L</var>
+                without its first element.</p>
             </div>
-            <p>For example, GroupConcat([("a"), ("b"), ("c")], {"separator" → "."}) = "a.b.c".</p>
+            <p>For example, <var>GroupConcat</var>([("a"), ("b"), ("c")], {"separator" → "."})
+              = <var>GroupConcat'</var>( ("a", "b", "c"), "." )
+              = "a.b.c".</p>
           </section>
           <section id="aggSample">
             <h5>Sample</h5>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9788,7 +9788,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <div class="defn">
               <p><b>Definition: <span id="defn_aggGroupConcat">GroupConcat</span></b></p>
               <pre class="code nohighlight">literal <var>GroupConcat</var>(sequence <var>S</var>, function <var>scalarvals</var>)</pre>
-              <p>If the <var>scalarvals</var> argument is absent from GROUP_CONCAT,
+              <p>If the <var>scalarvals</var> argument is absent from <code>GROUP_CONCAT</code>,
                 then <var>scalarvals</var> is taken to be the empty function.</p>
               <p>Let <var>sep</var> be a string that is defined as follows.</p>
               <ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9702,23 +9702,23 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <div class="defn">
               <p><b>Definition: <span id="defn_aggSum">Sum</span></b></p>
               <pre class="code nohighlight">numeric <var>Sum</var>(sequence <var>S</var>)</pre>
-              <p><var>Sum</var>(<var>S</var>) = <var>Sum'</var>(<var>L</var>),</p>
+              <p><var>Sum</var>(<var>S</var>) = <var>SumList</var>(<var>L</var>),</p>
               <p>where <var>L</var> = Flatten(<var>S</var>) and
-                <var>Sum'</var>(<var>L</var>) is defined recursively as follows.</p>
+                <var>SumList</var>(<var>L</var>) is defined recursively as follows.</p>
               <ul>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 0, then
-                  <var>Sum'</var>(<var>L</var>) = "0"^^<code>xsd:integer</code>.</li>
+                  <var>SumList</var>(<var>L</var>) = "0"^^<code>xsd:integer</code>.</li>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 1, then
-                  <var>Sum'</var>(<var>L</var>) = <a data-cite="XPATH-FUNCTIONS-31#func-numeric-add">op:numeric-add</a>(<var>L</var><sub>1</sub>, 0).</li>
+                  <var>SumList</var>(<var>L</var>) = <a data-cite="XPATH-FUNCTIONS-31#func-numeric-add">op:numeric-add</a>(<var>L</var><sub>1</sub>, 0).</li>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) > 1, then
-                  <var>Sum'</var>(<var>L</var>) = <a data-cite="XPATH-FUNCTIONS-31#func-numeric-add">op:numeric-add</a>(<var>L</var><sub>1</sub>,
-                  <var>Sum'</var>(<var>L</var><sub>2..n</sub>)).</li>
+                  <var>SumList</var>(<var>L</var>) = <a data-cite="XPATH-FUNCTIONS-31#func-numeric-add">op:numeric-add</a>(<var>L</var><sub>1</sub>,
+                  <var>SumList</var>(<var>L</var><sub>2..n</sub>)).</li>
               </ul>
               <p>Note that <var>L</var><sub>1</sub> is the first element in
                 <var>L</var>, and <var>L</var><sub>2..n</sub> is <var>L</var>
                 without its first element.</p>
             </div>
-            <p>In this way, <var>Sum</var>( [(1), (2), (3)] ) = <var>Sum'</var>( (1, 2, 3) ) =
+            <p>In this way, <var>Sum</var>( [(1), (2), (3)] ) = <var>SumList</var>( (1, 2, 3) ) =
               op:numeric-add(1, op:numeric-add(2, op:numeric-add(3, 0))).</p>
           </section>
           <section id="aggAvg">
@@ -9742,15 +9742,15 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <div class="defn">
               <p><b>Definition: <span id="defn_aggMin">Min</span></b></p>
               <pre class="code nohighlight">term <var>Min</var>(sequence <var>S</var>)</pre>
-              <p><var>Min</var>(<var>S</var>) = <var>Min'</var>(<var>L</var>),</p>
+              <p><var>Min</var>(<var>S</var>) = <var>MinList</var>(<var>L</var>),</p>
               <p>where <var>L</var> is the list of values obtained by Flatten(<var>S</var>)
                 and then ordered as per the <code>ORDER BY ASC</code> clause,
-                and <var>Min'</var>(<var>L</var>) is defined as follows.</p>
+                and <var>MinList</var>(<var>L</var>) is defined as follows.</p>
               <ul>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 0, then
-                  <var>Min'</var>(<var>L</var>) = error.</li>
+                  <var>MinList</var>(<var>L</var>) = error.</li>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) > 0, then
-                  <var>Min'</var>(<var>L</var>) = <var>L</var><sub>1</sub>,
+                  <var>MinList</var>(<var>L</var>) = <var>L</var><sub>1</sub>,
                   where <var>L</var><sub>1</sub> is the first element in
                   <var>L</var>.</li>
               </ul>
@@ -9765,15 +9765,15 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <div class="defn">
               <p><b>Definition: <span id="defn_aggMax">Max</span></b></p>
               <pre class="code nohighlight">term <var>Max</var>(sequence <var>S</var>)</pre>
-              <p><var>Max</var>(<var>S</var>) = <var>Max'</var>(<var>L</var>),</p>
+              <p><var>Max</var>(<var>S</var>) = <var>MaxList</var>(<var>L</var>),</p>
               <p>where <var>L</var> is the list of values obtained by Flatten(<var>S</var>)
                 and then ordered as per the <code>ORDER BY DESC</code> clause,
-                and <var>Max'</var>(<var>L</var>) is defined as follows.</p>
+                and <var>MaxList</var>(<var>L</var>) is defined as follows.</p>
               <ul>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 0, then
-                  <var>Max'</var>(<var>L</var>) = error.</li>
+                  <var>MaxList</var>(<var>L</var>) = error.</li>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) > 0, then
-                 <var>Max'</var>(<var>L</var>) = <var>L</var><sub>1</sub>,
+                 <var>MaxList</var>(<var>L</var>) = <var>L</var><sub>1</sub>,
                  where <var>L</var><sub>1</sub> is the first element in
                  <var>L</var>.</li>
               </ul>
@@ -9798,26 +9798,26 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
                   then <var>sep</var> is the "space" character (i.e., unicode codepoint U+0020).</li>
               </ul>
               <p><var>GroupConcat</var>(<var>S</var>, <var>scalarvals</var>) =
-                <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>),</p>
+                <var>GCList</var>(<var>L</var>, <var>sep</var>),</p>
               <p>where <var>L</var> = Flatten(<var>S</var>) and
-                <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>)
+                <var>GCList</var>(<var>L</var>, <var>sep</var>)
                 is defined recursively as follows.</p>
               <ul>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 0, then
-                  <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>) = "".</li>
+                  <var>GCList</var>(<var>L</var>, <var>sep</var>) = "".</li>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 1, then
-                  <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>) =
+                  <var>GCList</var>(<var>L</var>, <var>sep</var>) =
                   <a href="#func-concat"><code>CONCAT</code></a>("", <var>L</var><sub>1</sub>).</li>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) > 1, then
-                  <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>) =
-                  <a href="#func-concat"><code>CONCAT</code></a>(<var>L</var><sub>1</sub>, <var>sep</var>, <var>GroupConcat'</var>(<var>L</var><sub>2..n</sub>, <var>sep</var>)).</li>
+                  <var>GCList</var>(<var>L</var>, <var>sep</var>) =
+                  <a href="#func-concat"><code>CONCAT</code></a>(<var>L</var><sub>1</sub>, <var>sep</var>, <var>GCList</var>(<var>L</var><sub>2..n</sub>, <var>sep</var>)).</li>
               </ul>
               <p>Note that <var>L</var><sub>1</sub> is the first element in
                 <var>L</var>, and <var>L</var><sub>2..n</sub> is <var>L</var>
                 without its first element.</p>
             </div>
             <p>For example, <var>GroupConcat</var>([("a"), ("b"), ("c")], {"separator" → "."})
-              = <var>GroupConcat'</var>( ("a", "b", "c"), "." )
+              = <var>GCList</var>( ("a", "b", "c"), "." )
               = "a.b.c".</p>
           </section>
           <section id="aggSample">

--- a/spec/index.html
+++ b/spec/index.html
@@ -9807,10 +9807,10 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
                   <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>) = "".</li>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 1, then
                   <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>) =
-                  CONCAT("", <var>L</var><sub>1</sub>).</li>
+                  <a href="#func-concat"><code>CONCAT</code></a>("", <var>L</var><sub>1</sub>).</li>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) > 1, then
                   <var>GroupConcat'</var>(<var>L</var>, <var>sep</var>) =
-                  CONCAT(<var>L</var><sub>1</sub>, <var>sep</var>, <var>GroupConcat'</var>(<var>L</var><sub>2..n</sub>, <var>sep</var>)).</li>
+                  <a href="#func-concat"><code>CONCAT</code></a>(<var>L</var><sub>1</sub>, <var>sep</var>, <var>GroupConcat'</var>(<var>L</var><sub>2..n</sub>, <var>sep</var>)).</li>
               </ul>
               <p>Note that <var>L</var><sub>1</sub> is the first element in
                 <var>L</var>, and <var>L</var><sub>2..n</sub> is <var>L</var>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9701,16 +9701,17 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               be 6.0 (float).</p>
             <div class="defn">
               <p><b>Definition: <span id="defn_aggSum">Sum</span></b></p>
-              <pre class="code nohighlight">numeric Sum(sequence S)</pre>
-              <p>L = Flatten(S)</p>
-              <p>Sum(S) = Sum(L)</p>
-              <p>Sum(L) = op:numeric-add(L<sub>1</sub>, Sum(L<sub>2..n</sub>)) if <a href="#defn_Card">Card</a>(L) &gt;
+              <pre class="code nohighlight">numeric <var>Sum</var>(sequence <var>S</var>)</pre>
+              <p>|Sum|(|S|) = <var>Sum'</var>(|L|),
+                where |L| = Flatten(|S|)
+                and <var>Sum'</var>(|L|) is defined recursively as follows.</p>
+              <p><var>Sum'</var>(|L|) = op:numeric-add(|L|<sub>1</sub>, <var>Sum'</var>(|L|<sub>2..n</sub>)) if <a href="#defn_Card">Card</a>(|L|) &gt;
                 1<br>
-                Sum(L) = op:numeric-add(L<sub>1</sub>, 0) if <a href="#defn_Card">Card</a>(L) = 1<br>
-                Sum(L) = "0"^^xsd:integer if <a href="#defn_Card">Card</a>(L) = 0</p>
-              <p>In this way, Sum( (1, 2, 3) ) = op:numeric-add(1, op:numeric-add(2,
-                op:numeric-add(3, 0))).</p>
+                <var>Sum'</var>(|L|) = op:numeric-add(|L|<sub>1</sub>, 0) if <a href="#defn_Card">Card</a>(|L|) = 1<br>
+                <var>Sum'</var>(|L|) = "0"^^xsd:integer if <a href="#defn_Card">Card</a>(|L|) = 0</p>
             </div>
+            <p>In this way, <var>Sum</var>( [(1), (2), (3)] ) = <var>Sum'</var>( (1, 2, 3) ) =
+              op:numeric-add(1, op:numeric-add(2, op:numeric-add(3, 0))).</p>
           </section>
           <section id="aggAvg">
             <h5>Avg</h5>


### PR DESCRIPTION
Related to the discussion in PR #122, this PR here demonstrates how I think the definition of the Sum function should be improved and how the corresponding example can be presented.

Note that this PR uses the feature of ReSpec to explicitly markup symbols in math formulas (as we are planning to use for the whole spec, as per #102). Hence, you can click on every symbol (including function names) and see where else in the section this symbol is used.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/124.html" title="Last updated on Oct 5, 2023, 7:04 PM UTC (ae8c77c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/124/bced028...ae8c77c.html" title="Last updated on Oct 5, 2023, 7:04 PM UTC (ae8c77c)">Diff</a>