### PR TITLE
Fixes a mistake in Dedup function

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9605,7 +9605,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <p><b>Special Case:</b> when <code>COUNT</code> is used with the expression
               <code>*</code>, then F(Ψ) is the cardinality of the group solution sequence,
               i.e., F(Ψ)&nbsp;=&nbsp;<a href="#defn_Card">Card</a>(Ψ),
-              or F(Ψ)&nbsp;=&nbsp;<a href="#defn_Card">Card</a>(Dedup(Ψ))
+              or F(Ψ)&nbsp;=&nbsp;<a href="#defn_Card">Card</a>(<a href="#defn_algDistinct">Distinct</a>(Ψ))
               if the <code>DISTINCT</code> keyword is present.</p>
           </div>
           <p><i>scalarvals</i> are used to pass values to the underlying set function, bypassing

--- a/spec/index.html
+++ b/spec/index.html
@@ -9577,11 +9577,10 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               (where each such list in this sequence may contain RDF terms and
               errors, as it is produced by the ListEval function).</p>
             <ol>
-              <li>Every unique list in M(Ψ) is contained in Dedup(M(Ψ)).</li>
-              <li>Every list in Dedup(M(Ψ)) is contained in M(Ψ).</li>
-              <li>Dedup(M(Ψ)) is free of duplicates. That is, the list at the |i|-th position in Dedup(M(Ψ)) is not the same list as the list at the |j|-th position in Dedup(M(Ψ)) for every two natural numbers |i| and |j| such that |i| &ne; |j|.
-                <br/>
-                Two lists <var>L</var> and <var>L'</var> from M(Ψ) are
+              <li>For every list&nbsp;<var>L</var> in M(Ψ) there exists a
+                list&nbsp;<var>L'</var> in Dedup(M(Ψ)) such that <var>L</var>
+                and <var>L'</var> are the same,
+                where two lists <var>L</var> and <var>L'</var> from M(Ψ) are
                 considered the same iff they have the same number of elements
                 and, for every position&nbsp;<var>k</var> within the two lists,
                 any of the following two conditions is true:
@@ -9595,6 +9594,10 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
                     <var>L'</var> is also an error.</li>
                 </ul>
               </li>
+              <li>For every list&nbsp;<var>L</var> in Dedup(M(Ψ)) there exists
+                a list&nbsp;<var>L'</var> in M(Ψ) such that <var>L</var> and
+                <var>L'</var> are the same.</li>
+              <li>Dedup(M(Ψ)) is free of duplicates. That is, the list at the |i|-th position in Dedup(M(Ψ)) is not the same list as the list at the |j|-th position in Dedup(M(Ψ)) for every two natural numbers |i| and |j| such that |i| &ne; |j|.</li>
               <li>For any two lists <var>L<sub>1</sub></var> and <var>L<sub>2</sub></var> in Dedup(M(Ψ)), the relative order of their first occurrences in M(Ψ) is preserved in Dedup(M(Ψ)). That is, if <var>i<sub>1</sub></var>&nbsp;&lt;&nbsp;<var>i<sub>2</sub></var>, then <var>j<sub>1</sub></var>&nbsp;&lt;&nbsp;<var>j<sub>2</sub></var>, where
                 <ul>
                   <li><var>i<sub>1</sub></var> is the smallest natural number such that <var>L<sub>1</sub></var> is at the <var>i<sub>1</sub></var>-th position in M(Ψ),</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9584,14 +9584,17 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
                 Two lists <var>L</var> and <var>L'</var> from M(Ψ) are
                 considered the same iff they have the same number of elements
                 and, for every position&nbsp;<var>k</var> within the two lists,
-                the element at the <var>k</var>-th position of <var>L</var> is
-                an RDF term, the element at the <var>k</var>-th position of
-                <var>L'</var> is an RDF term, and these two RDF terms are the
-                <a href="#func-sameTerm">same term</a> (as a consequence of
-                this definition, if any of the two lists, <var>L</var> or
-                <var>L'</var>, contains an error, then the two lists cannot
-                be the same list, no matter what RDF terms they contain in
-                other positions).</li>
+                any of the following two conditions is true:
+                <ul>
+                  <li>either the element at the <var>k</var>-th position of
+                    <var>L</var> is an RDF term, the element at the <var>k</var>-th
+                    position of <var>L'</var> is also an RDF term, and these two
+                    RDF terms are the <a href="#func-sameTerm">same term</a>;</li>
+                  <li>or the element at the <var>k</var>-th position of <var>L</var>
+                    is an error and the element at the <var>k</var>-th position of
+                    <var>L'</var> is also an error.</li>
+                </ul>
+              </li>
               <li>For any two lists <var>L<sub>1</sub></var> and <var>L<sub>2</sub></var> in Dedup(M(Ψ)), the relative order of their first occurrences in M(Ψ) is preserved in Dedup(M(Ψ)). That is, if <var>i<sub>1</sub></var>&nbsp;&lt;&nbsp;<var>i<sub>2</sub></var>, then <var>j<sub>1</sub></var>&nbsp;&lt;&nbsp;<var>j<sub>2</sub></var>, where
                 <ul>
                   <li><var>i<sub>1</sub></var> is the smallest natural number such that <var>L<sub>1</sub></var> is at the <var>i<sub>1</sub></var>-th position in M(Ψ),</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9573,17 +9573,31 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               &nbsp;&nbsp;M(Ψ) = [ ListEval(exprlist, μ) | μ in Ψ ]<br>
               &nbsp;&nbsp;F(Ψ) = func(M(Ψ), scalarvals), for non-<code>DISTINCT</code><br>
               &nbsp;&nbsp;F(Ψ) = func(Dedup(M(Ψ)), scalarvals), for <code>DISTINCT</code></p>
-            <p>with Dedup(M(Ψ)) being an order-preserving, duplicate-free version of the sequence M(Ψ); that is, Dedup(M(Ψ)) is a sequence of RDF terms that has the following four properties.</p>
+            <p>with Dedup(M(Ψ)) being an order-preserving, duplicate-free version of the sequence M(Ψ); that is, Dedup(M(Ψ)) is a sequence of lists that has the following four properties
+              (where each such list in this sequence may contain RDF terms and
+              errors, as it is produced by the ListEval function).</p>
             <ol>
-              <li>Every unique element in M(Ψ) is contained in Dedup(M(Ψ)).</li>
-              <li>Every element in Dedup(M(Ψ)) is contained in M(Ψ).</li>
-              <li>Dedup(M(Ψ)) is free of duplicates. That is, the element at the |i|-th position in Dedup(M(Ψ)) is not the same term as the element at the |j|-th position in Dedup(M(Ψ)) for every two natural numbers |i| and |j| such that |i| &ne; |j|.</li>
-              <li>For any two elements <var>e<sub>1</sub></var> and <var>e<sub>2</sub></var> in Dedup(M(Ψ)), the relative order of their first occurrences in M(Ψ) is preserved in Dedup(M(Ψ)). That is, if <var>i<sub>1</sub></var>&nbsp;&lt;&nbsp;<var>i<sub>2</sub></var>, then <var>j<sub>1</sub></var>&nbsp;&lt;&nbsp;<var>j<sub>2</sub></var>, where
+              <li>Every unique list in M(Ψ) is contained in Dedup(M(Ψ)).</li>
+              <li>Every list in Dedup(M(Ψ)) is contained in M(Ψ).</li>
+              <li>Dedup(M(Ψ)) is free of duplicates. That is, the list at the |i|-th position in Dedup(M(Ψ)) is not the same list as the list at the |j|-th position in Dedup(M(Ψ)) for every two natural numbers |i| and |j| such that |i| &ne; |j|.
+                <br/>
+                Two lists <var>L</var> and <var>L'</var> from M(Ψ) are
+                considered the same iff they have the same number of elements
+                and, for every position&nbsp;<var>k</var> within the two lists,
+                the element at the <var>k</var>-th position of <var>L</var> is
+                an RDF term, the element at the <var>k</var>-th position of
+                <var>L'</var> is an RDF term, and these two RDF terms are the
+                <a href="#func-sameTerm">same term</a> (as a consequence of
+                this definition, if any of the two lists, <var>L</var> or
+                <var>L'</var>, contains an error, then the two lists cannot
+                be the same list, no matter what RDF terms they contain in
+                other positions).</li>
+              <li>For any two lists <var>L<sub>1</sub></var> and <var>L<sub>2</sub></var> in Dedup(M(Ψ)), the relative order of their first occurrences in M(Ψ) is preserved in Dedup(M(Ψ)). That is, if <var>i<sub>1</sub></var>&nbsp;&lt;&nbsp;<var>i<sub>2</sub></var>, then <var>j<sub>1</sub></var>&nbsp;&lt;&nbsp;<var>j<sub>2</sub></var>, where
                 <ul>
-                  <li><var>i<sub>1</sub></var> is the smallest natural number such that <var>e<sub>1</sub></var> is at the <var>i<sub>1</sub></var>-th position in M(Ψ),</li>
-                  <li><var>i<sub>2</sub></var> is the smallest natural number such that <var>e<sub>2</sub></var> is at the <var>i<sub>2</sub></var>-th position in M(Ψ),</li>
-                  <li><var>j<sub>1</sub></var> is the position of <var>e<sub>1</sub></var> in Dedup(M(Ψ)), and</li>
-                  <li><var>j<sub>2</sub></var> is the position of <var>e<sub>2</sub></var> in Dedup(M(Ψ)).</li>
+                  <li><var>i<sub>1</sub></var> is the smallest natural number such that <var>L<sub>1</sub></var> is at the <var>i<sub>1</sub></var>-th position in M(Ψ),</li>
+                  <li><var>i<sub>2</sub></var> is the smallest natural number such that <var>L<sub>2</sub></var> is at the <var>i<sub>2</sub></var>-th position in M(Ψ),</li>
+                  <li><var>j<sub>1</sub></var> is the position of <var>L<sub>1</sub></var> in Dedup(M(Ψ)), and</li>
+                  <li><var>j<sub>2</sub></var> is the position of <var>L<sub>2</sub></var> in Dedup(M(Ψ)).</li>
                 </ul>
               </li>
             </ol>
@@ -9599,7 +9613,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <code>GROUP_CONCAT(?x ; separator="|")</code> has a scalarvals argument of { "separator"
             → "|" }.</p>
           <p>All aggregates may have the <code>DISTINCT</code> keyword as the first token in their
-            argument list. If this keyword is present then first argument to func is Distinct(M).</p>
+            argument list. If this keyword is present, then first argument to func is Dedup(M(Ψ)).</p>
           <p>Example</p>
           <p>Given a solution sequence Ψ with the following values:</p>
           <table>


### PR DESCRIPTION
I just realized that I made another smaller mistake in PR #98. This PR is meant to fix this mistake.

The mistake is in the definition of the (new) Dedup function that PR #98 introduces as a helper function within the definition of the [Aggregation operator](https://www.w3.org/TR/sparql12-query/#defn_algAggregation). In particular, the issue is that the definition of Dedup assumes that M(Ψ) is a sequence of RDF terms, which is not the case. Instead, M(Ψ) is a sequence of lists that are produced by the ListEval function, where each such list may contain RDF terms and errors (that may have occurred when evaluating any of the expressions that is given as an argument to the corresponding aggregate).

The fix that I am proposing in this PR is twofold: First, it makes explicit that M(Ψ) is a sequence of (a specific type of) lists. Second, in the part of the definition of Dedup that focuses on the removal of duplicates (i.e., the third property in the definition of Dedup), I have now made clear what it means for two such lists to be the same (i.e., duplicates). While the first of these two things is probably not controversial, the second one is a bit more delicate. The issue here is: what to do with lists that contain errors?

The stance that the PR in its current form takes regarding this question is that lists with errors cannot be the same lists. While I think that this is a reasonable option, I also notice that there is a sentence directly below the definition of the ListEval function that says that "errors may be used to group." For the sake of consistency, I would be okay with changing the corresponding part of this PR to say that two lists are considered the same not only if they have the same RDF terms in the same positions but also if they have errors in the same positions. The only thing that worries me about this is that it means to throw all types of errors in the same bucket (in fact, I have the same worry about the aforementioned sentence below the definition of ListEval). Opinions?

As a side node, I have to say that I do not like the term "list" in this context. I would prefer to use the term "tuple" instead. That is, the ListEval function produces a sequence of tuples that consists of RDF terms and errors, and thus the Dedup function operates over sequences of tuples and sequences of tuples are then passed to the set functions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/125.html" title="Last updated on Oct 11, 2023, 7:05 AM UTC (05521cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/125/ef0ad55...05521cf.html" title="Last updated on Oct 11, 2023, 7:05 AM UTC (05521cf)">Diff</a>