### PR TITLE
Improves the definitions of Count, Avg, and Sample

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9688,10 +9688,10 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               has a bound, non-error value within the aggregate group.</p>
             <div class="defn">
               <p><b>Definition: <span id="defn_aggCount">Count</span></b></p>
-              <pre class="code nohighlight">xsd:integer Count(sequence S)</pre>
-              <p>L = <a href="#defn_Flatten">Flatten</a>(S)</p>
-              <p>remove error elements from L</p>
-              <p>Count(S) = <a href="#defn_Card">Card</a>(L)</p>
+              <pre class="code nohighlight">xsd:integer <var>Count</var>(sequence <var>S</var>)</pre>
+              <p><var>Count</var>(<var>S</var>) = <a href="#defn_Card">Card</a>(<var>L'</var>),</p>
+              <p>where <var>L'</var> is the list <var>L</var> = <a href="#defn_Flatten">Flatten</a>(<var>S</var>)
+                with all error elements removed.</p>
             </div>
           </section>
           <section id="aggSum">
@@ -9729,11 +9729,17 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             average value for an expression over a group. It is defined in terms of Sum and Count.
             <div class="defn">
               <p><b>Definition: <span id="defn_aggAvg">Avg</span></b></p>
-              <pre class="code nohighlight">numeric Avg(sequence S)</pre>
-              <p>Avg(S) = "0"^^xsd:integer if Count(S) = 0</p>
-              <p>Avg(S) = Sum(S) / Count(S) if Count(S) &gt; 0</p>
+              <pre class="code nohighlight">numeric <var>Avg</var>(sequence <var>S</var>)</pre>
+              <p>If <var><a href="#defn_aggCount">Count</a></var>(<var>S</var>) = 0,
+                then <var>Avg</var>(<var>S</var>) = "0"^^<code>xsd:integer</code>.</p>
+              <p>If <var><a href="#defn_aggCount">Count</a></var>(<var>S</var>) &gt; 0,
+                then <var>Avg</var>(<var>S</var>) =
+                <var><a href="#defn_aggSum">Sum</a></var>(<var>S</var>) /
+                <var><a href="#defn_aggCount">Count</a></var>(<var>S</var>).</p>
             </div>
-            <p>For example, Avg([(1), (2), (3)]) = Sum([(1), (2), (3)])/Count([(1), (2), (3)]) = 6/3 = 2.</p>
+            <p>For example, <var>Avg</var>([(1), (2), (3)]) =
+              <var>Sum</var>([(1), (2), (3)])/<var>Count</var>([(1), (2), (3)])
+              = 6/3 = 2.</p>
           </section>
           <section id="aggMin">
             <h5>Min</h5>
@@ -9830,12 +9836,15 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               to it.</p>
             <div class="defn">
               <p><b>Definition: <span id="defn_aggSample">Sample</span></b></p>
-              <pre class="code nohighlight">RDFTerm Sample(sequence S)</pre>
-              <p>Sample(S) = v, where v in <a href="#defn_Flatten">Flatten</a>(S)</p>
-              <p>Sample([]) = error</p>
+              <pre class="code nohighlight">RDFTerm <var>Sample</var>(sequence <var>S</var>)</pre>
+              <p>If <a href="#defn_Card">Card</a>(<var>S</var>) = 0, then
+                <var>Sample</var>(<var>S</var>) = error.</p>
+              <p>If <a href="#defn_Card">Card</a>(<var>S</var>) &gt; 0, then
+                <var>Sample</var>(<var>S</var>) = <var>v</var>, where <var>v</var>
+                in <a href="#defn_Flatten">Flatten</a>(<var>S</var>).</p>
             </div>
-            <p>For example, given Sample([("a"), ("b"), ("c")]), "a", "b", and "c" are all valid return
-              values. Note that Sample() is not required to be deterministic for a given input, the
+            <p>For example, given <var>Sample</var>([("a"), ("b"), ("c")]), "a", "b", and "c" are all valid return
+              values. Note that the <var>Sample</var> function is not required to be deterministic for a given input. The
               only restriction is that the output value must be present in the input sequence.</p>
           </section>
         </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9689,7 +9689,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <div class="defn">
               <p><b>Definition: <span id="defn_aggCount">Count</span></b></p>
               <pre class="code nohighlight">xsd:integer Count(sequence S)</pre>
-              <p>L = Flatten(S)</p>
+              <p>L = <a href="#defn_Flatten">Flatten</a>(S)</p>
               <p>remove error elements from L</p>
               <p>Count(S) = <a href="#defn_Card">Card</a>(L)</p>
             </div>
@@ -9705,7 +9705,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               <p><b>Definition: <span id="defn_aggSum">Sum</span></b></p>
               <pre class="code nohighlight">numeric <var>Sum</var>(sequence <var>S</var>)</pre>
               <p><var>Sum</var>(<var>S</var>) = <var>SumList</var>(<var>L</var>),</p>
-              <p>where <var>L</var> = Flatten(<var>S</var>) and
+              <p>where <var>L</var> = <a href="#defn_Flatten">Flatten</a>(<var>S</var>) and
                 <var>SumList</var>(<var>L</var>) is defined recursively as follows.</p>
               <ul>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 0, then
@@ -9745,7 +9745,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               <p><b>Definition: <span id="defn_aggMin">Min</span></b></p>
               <pre class="code nohighlight">term <var>Min</var>(sequence <var>S</var>)</pre>
               <p><var>Min</var>(<var>S</var>) = <var>MinList</var>(<var>L</var>),</p>
-              <p>where <var>L</var> is the list of values obtained by Flatten(<var>S</var>)
+              <p>where <var>L</var> is the list of values obtained by
+                <a href="#defn_Flatten">Flatten</a>(<var>S</var>)
                 and then ordered as per the <code>ORDER BY ASC</code> clause,
                 and <var>MinList</var>(<var>L</var>) is defined as follows.</p>
               <ul>
@@ -9768,7 +9769,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               <p><b>Definition: <span id="defn_aggMax">Max</span></b></p>
               <pre class="code nohighlight">term <var>Max</var>(sequence <var>S</var>)</pre>
               <p><var>Max</var>(<var>S</var>) = <var>MaxList</var>(<var>L</var>),</p>
-              <p>where <var>L</var> is the list of values obtained by Flatten(<var>S</var>)
+              <p>where <var>L</var> is the list of values obtained by
+                <a href="#defn_Flatten">Flatten</a>(<var>S</var>)
                 and then ordered as per the <code>ORDER BY DESC</code> clause,
                 and <var>MaxList</var>(<var>L</var>) is defined as follows.</p>
               <ul>
@@ -9801,8 +9803,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               </ul>
               <p><var>GroupConcat</var>(<var>S</var>, <var>scalarvals</var>) =
                 <var>GCList</var>(<var>L</var>, <var>sep</var>),</p>
-              <p>where <var>L</var> = Flatten(<var>S</var>) and
-                <var>GCList</var>(<var>L</var>, <var>sep</var>)
+              <p>where <var>L</var> = <a href="#defn_Flatten">Flatten</a>(<var>S</var>)
+                and <var>GCList</var>(<var>L</var>, <var>sep</var>)
                 is defined recursively as follows.</p>
               <ul>
                 <li>If <a href="#defn_Card">Card</a>(<var>L</var>) = 0, then
@@ -9829,7 +9831,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
             <div class="defn">
               <p><b>Definition: <span id="defn_aggSample">Sample</span></b></p>
               <pre class="code nohighlight">RDFTerm Sample(sequence S)</pre>
-              <p>Sample(S) = v, where v in Flatten(S)</p>
+              <p>Sample(S) = v, where v in <a href="#defn_Flatten">Flatten</a>(S)</p>
               <p>Sample([]) = error</p>
             </div>
             <p>For example, given Sample([("a"), ("b"), ("c")]), "a", "b", and "c" are all valid return


### PR DESCRIPTION
As a follow-up to PR #124, which has improved the definitions of Sum, Min, Max, and GroupConcat, this PR introduces the same improved presentation style for the other set functions (Count, Avg, and Sample). Additionally, this PR adds links to the Flatten function in the definitions of all the set functions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/127.html" title="Last updated on Oct 10, 2023, 9:15 AM UTC (0c735c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/127/6afce45...0c735c0.html" title="Last updated on Oct 10, 2023, 9:15 AM UTC (0c735c0)">Diff</a>