### PR TITLE
Improvement to sentence about grouping and errors

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9588,7 +9588,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           </div>
           <p>Note that, although the result of <a href="#defn_ListEval">ListEval</a>
             may contain errors, and errors may be used
-            to group, solutions containing error values are removed at projection time.</p>
+            to group, solutions containing error values are removed at the
+            end of evaluating the group and any aggregation functions.</p>
           <p>Note also that the result of <a href="#defn_ListEval">ListEval</a>((unbound), <var>μ</var>)
             is the list (error), as the evaluation of an unbound expression is an
             error.</p>


### PR DESCRIPTION
This PR implements the change that @afs suggested in PR #132. See https://github.com/w3c/sparql-query/pull/132#discussion_r1417439560 for the original comment with this change suggestion.

I have to admit that, even with this change, I still don't understand what exactly the sentence is supposed to say. So, maybe we can improve the sentence even more. In particular, the following points still confuse me in this sentence.
1. In the context of talking about "the result of ListEval," the sentence mentions "solutions containing error values." Assuming "solutions" here means solution mappings (as everywhere else in the spec), this part of the sentence doesn't make sense. Solutions cannot contain "error values." By definition!
2. Related to the previous point, the result of ListEval is not a solution (solution mapping) but it is a list consisting of RDF terms and error values. So, perhaps that's what the word "solutions" was meant to refer to?
3. Is this sentence the only place in the spec that is related to the mentioned removal "at the end of evaluating the group and any aggregation functions"? Or is this removal somehow captured somewhere else in the spec as well (explicitly or implicitly)? I couldn't find anything and, thus, I still don't know what exactly is supposed to be removed. @afs do you have a concrete example that demonstrates the removal mentioned in the sentence?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/134.html" title="Last updated on Dec 12, 2023, 5:16 PM UTC (c432c67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/134/826c5d9...c432c67.html" title="Last updated on Dec 12, 2023, 5:16 PM UTC (c432c67)">Diff</a>