### PR TITLE
Moves the definition of Flatten(..) and Card(..)

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9722,7 +9722,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               and <a href="#defn_Card">Card</a>, which are defined as follows.</p>
             <p><a href="#defn_Flatten">Flatten</a> is a function which is
               used to collapse a sequence of lists into a single list.
-              For example, [(1,&nbsp;2), (3,&nbsp;4)] becomes (1, 2, 3, 4).</p>
+              For example, [(1,&nbsp;2), (3,&nbsp;4)] becomes (1,&nbsp;2,&nbsp;3,&nbsp;4).</p>
             <div class="defn">
               <p><b>Definition: <span id="defn_Flatten">Flatten</span></b></p>
               <p>Let <var>S</var> be a sequence of lists,

--- a/spec/index.html
+++ b/spec/index.html
@@ -9717,31 +9717,33 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               this requires the parser to know whether some IRI refers to a function, cast, or
               aggregate before it can determine if there are any errors in a query where aggregates
               are used.</p>
-            <p>The definitions of the set functions in the following sections are based on two functions, <a href="#defn_Flatten">Flatten</a> and <a href="#defn_Card">Card</a>, which are defined as follows.</p>
-          <p><a href="#defn_Flatten">Flatten</a> is a function which is
-            used to collapse a sequence of lists into a single list.
-            For example, [(1,&nbsp;2), (3,&nbsp;4)] becomes (1, 2, 3, 4).</p>
-          <div class="defn">
-            <p><b>Definition: <span id="defn_Flatten">Flatten</span></b></p>
-            <p>Let <var>S</var> be a sequence of lists,
-              i.e., <var>S</var> =
-              [<var>L<sub>1</sub></var>,
-              <var>L<sub>2</sub></var>, ...,
-              <var>L<sub><var>m</var></sub></var>]
-              where, for every <var>i</var> &in; {1, ..., <var>m</var>},
-              <var>L<sub><var>i</var></sub></var> is a list.</p>
-            <p>Flatten(<var>S</var>) is the list
-              ( <var>x</var> | <var>L</var> in <var>S</var> and
-              <var>x</var> in <var>L</var> ).</p>
-          </div>
-          <p><a href="#defn_Card">Card</a> is a function that returns the
-            cardinality of a sequence or a list of elements (which may be
-            solution mappings or other types of elements, depending on the
-            context).
-          <div class="defn">
-            <p><b>Definition: <span id="defn_Card">Card</span></b></p>
-            <p>Given a sequence or a list |L|, Card(|L|) is the cardinality of |L|.</p>
-          </div>
+            <p>The definitions of the set functions in the following sections
+              are based on two functions, <a href="#defn_Flatten">Flatten</a>
+              and <a href="#defn_Card">Card</a>, which are defined as follows.</p>
+            <p><a href="#defn_Flatten">Flatten</a> is a function which is
+              used to collapse a sequence of lists into a single list.
+              For example, [(1,&nbsp;2), (3,&nbsp;4)] becomes (1, 2, 3, 4).</p>
+            <div class="defn">
+              <p><b>Definition: <span id="defn_Flatten">Flatten</span></b></p>
+              <p>Let <var>S</var> be a sequence of lists,
+                i.e., <var>S</var> =
+                [<var>L<sub>1</sub></var>,
+                <var>L<sub>2</sub></var>, ...,
+                <var>L<sub><var>m</var></sub></var>]
+                where, for every <var>i</var> &in; {1, ..., <var>m</var>},
+                <var>L<sub><var>i</var></sub></var> is a list.</p>
+              <p>Flatten(<var>S</var>) is the list
+                ( <var>x</var> | <var>L</var> in <var>S</var> and
+                <var>x</var> in <var>L</var> ).</p>
+            </div>
+            <p><a href="#defn_Card">Card</a> is a function that returns the
+              cardinality of a sequence or a list of elements (which may be
+              solution mappings or other types of elements, depending on the
+              context).
+            <div class="defn">
+              <p><b>Definition: <span id="defn_Card">Card</span></b></p>
+              <p>Given a sequence or a list |L|, Card(|L|) is the cardinality of |L|.</p>
+            </div>
           </section>
 
           <section id="aggCount">

--- a/spec/index.html
+++ b/spec/index.html
@@ -9697,20 +9697,6 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               ..., agg<sub>n</sub>→val<sub>n</sub> | key in K and key→val<sub>i</sub> in
               S<sub>i</sub> for each 1 &le; i &le; n }</p>
           </div>
-          <p>Flatten is a function which is used to collapse a sequence of lists into a single list.
-            For example, [(1,&nbsp;2), (3,&nbsp;4)] becomes (1, 2, 3, 4).</p>
-          <div class="defn">
-            <p><b>Definition: <span id="defn_Flatten">Flatten</span></b></p>
-            <p>The Flatten(S) function takes a sequence S of lists,
-              i.e., S = [L<sub>1</sub>, L<sub>2</sub>, ..., L<sub>m</sub>]
-              where every L<sub>i</sub> is a list,
-              and returns the list ( x | L in S and x in L ).</p>
-          </div>
-          <p>Card is a function that returns the cardinality of a sequence or a list of elements (which may be solution mappings or other types of elements, depending on the context).
-          <div class="defn">
-            <p><b>Definition: <span id="defn_Card">Card</span></b></p>
-            <p>Given a sequence or a list |L|, Card(|L|) is the cardinality of |L|.</p>
-          </div>
           <section id="setFunctions">
             <h5>Set Functions</h5>
             <p>The set functions which underlie SPARQL aggregates all have a common signature:
@@ -9731,6 +9717,31 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
               this requires the parser to know whether some IRI refers to a function, cast, or
               aggregate before it can determine if there are any errors in a query where aggregates
               are used.</p>
+            <p>The definitions of the set functions in the following sections are based on two functions, <a href="#defn_Flatten">Flatten</a> and <a href="#defn_Card">Card</a>, which are defined as follows.</p>
+          <p><a href="#defn_Flatten">Flatten</a> is a function which is
+            used to collapse a sequence of lists into a single list.
+            For example, [(1,&nbsp;2), (3,&nbsp;4)] becomes (1, 2, 3, 4).</p>
+          <div class="defn">
+            <p><b>Definition: <span id="defn_Flatten">Flatten</span></b></p>
+            <p>Let <var>S</var> be a sequence of lists,
+              i.e., <var>S</var> =
+              [<var>L<sub>1</sub></var>,
+              <var>L<sub>2</sub></var>, ...,
+              <var>L<sub><var>m</var></sub></var>]
+              where, for every <var>i</var> &in; {1, ..., <var>m</var>},
+              <var>L<sub><var>i</var></sub></var> is a list.</p>
+            <p>Flatten(<var>S</var>) is the list
+              ( <var>x</var> | <var>L</var> in <var>S</var> and
+              <var>x</var> in <var>L</var> ).</p>
+          </div>
+          <p><a href="#defn_Card">Card</a> is a function that returns the
+            cardinality of a sequence or a list of elements (which may be
+            solution mappings or other types of elements, depending on the
+            context).
+          <div class="defn">
+            <p><b>Definition: <span id="defn_Card">Card</span></b></p>
+            <p>Given a sequence or a list |L|, Card(|L|) is the cardinality of |L|.</p>
+          </div>
           </section>
 
           <section id="aggCount">


### PR DESCRIPTION
The functions Flatten(..) and Card(..) are currently defined at the end of [Sec.18.5.1 Aggregate Algebra](https://www.w3.org/TR/sparql12-query/#aggregateAlgebra), directly before [Sec.18.5.1.1 Set Functions](https://www.w3.org/TR/sparql12-query/#setFunctions). There is no explanation why these functions are needed.

Since the main purpose of these functions is to be helper functions that are used for defining the set functions in Sections 18.5.1.2 to 18.5.1.8, I find it much more natural to introduce these two functions in [Sec.18.5.1.1 Set Functions](https://www.w3.org/TR/sparql12-query/#setFunctions).

Hence, this PR moves the definitions of these two functions into [Sec.18.5.1.1 Set Functions](https://www.w3.org/TR/sparql12-query/#setFunctions) and adds a sentence that introduces the purpose of these two functions.

Additionally, the PR improves the readability of the definition of Flatten.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/135.html" title="Last updated on Dec 14, 2023, 8:55 PM UTC (bb1812d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/135/826c5d9...bb1812d.html" title="Last updated on Dec 14, 2023, 8:55 PM UTC (bb1812d)">Diff</a>