### PR TITLE
Fixes the algorithm for translating SELECT expressions

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -8967,8 +8967,8 @@ Note, E is a list of pairs of the form (variable, expression), defined in <a hre
 If "SELECT *"
     PV := VS
 
-If  "SELECT <code>selItem ...</code>:"  
-    For each selItem:
+If  "SELECT selItem ..."
+    For each selItem
         If selItem is a variable
             PV := PV ∪ { variable }
         End


### PR DESCRIPTION
… in Section 18.2.4.4.

In [Section 18.2.4.4 of version 1.1](https://www.w3.org/TR/sparql11-query/#sparqlSelectExpressions) of the spec, the algorithm looks as follows.
![image](https://github.com/w3c/sparql-query/assets/584467/cbd329aa-1ce5-478e-9de7-02dceaa941cc)

In [Section 18.2.4.4 of our current draft of version 1.2](https://www.w3.org/TR/sparql12-query/#sparqlSelectExpressions), it looks as follows.
![image](https://github.com/w3c/sparql-query/assets/584467/02f0ab3a-afe5-4f8f-93c1-4c32cf5a4db8)
Notice how the `selItem ...` part is rendered weirdly.

This PR fixes this issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/139.html" title="Last updated on Feb 22, 2024, 1:28 PM UTC (33b2454)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/139/1e15e55...33b2454.html" title="Last updated on Feb 22, 2024, 1:28 PM UTC (33b2454)">Diff</a>