### PR TITLE
remove errant colon

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -8384,7 +8384,7 @@ WHERE {
 
             <pre class="code nohighlightBlock">
 Let FS := empty set
-For each form FILTER(expr) in the group graph pattern:
+For each form FILTER(expr) in the group graph pattern
     In expr, replace NOT EXISTS{P} with fn:not(<a href="#defn_evalExists">exists(translate(P)))</a> 
     In expr, replace EXISTS{P} with <a href="#defn_evalExists">exists(translate(P))</a>
     FS := FS ∪ {expr}


### PR DESCRIPTION
as in https://github.com/w3c/sparql-query/pull/139/files#r1501003927, to match all other algorithm `for each` statements


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/sparql-query/pull/141.html" title="Last updated on Feb 23, 2024, 6:10 PM UTC (077b904)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/141/3597928...TallTed:077b904.html" title="Last updated on Feb 23, 2024, 6:10 PM UTC (077b904)">Diff</a>