### PR TITLE
Migrate from quoted triples to triple terms

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -7406,8 +7406,8 @@ WHERE {
         </section>
 
         <!-- QT -->
-        <section id="func-triple-terms">
-          <h4>Functions on Triple Terms</h4>
+        <section id="func-reified-triples">
+          <h4>Functions on Reified Triples</h4>
           <section id="func-triple">
             <h5>TRIPLE</h5>
             <pre class="prototype nohighlight">
@@ -7439,7 +7439,7 @@ class="name">obj</span>)
             <p>
               As a shorthand notation, the <code>TRIPLE</code> function 
               can also be written in the form of a
-              <a href="#rExprQuotedTriple">triple term expression</a>
+              <a href="#rExprTripleTerm">triple term expression</a>
               using <code>&lt;&lt;(</code> and <code>)&gt;&gt;</code>.  There is a
               syntax limitation to this shorthand form: the three elements of
               the triple term expression can only be variables and directly
@@ -7449,18 +7449,24 @@ class="name">obj</span>)
             </p>
             <pre class="query nohighlight">
               PREFIX : &lt;http://example/&gt;
+              PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+
               SELECT ?s ?date {
-                  ?s ?p ?o
-                  BIND( &lt;&lt;( ?s ?p ?o )&gt;&gt; AS ?qt )
-                  ?qt :tripleAdded ?date
+                  ?s ?p ?o .
+                  BIND( &lt;&lt;( ?s ?p ?o )&gt;&gt; AS ?tt )
+                  :myreifier rdf:reifies ?tt .
+                  :myreifier :tripleAdded ?date .
               }
             </pre>
             <pre class="query nohighlight">
               PREFIX : &lt;http://example/&gt;
+              PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+
               SELECT ?s ?date {
-                  ?s ?p ?o
-                  BIND( TRIPLE(?s, ?p, ?o) AS ?qt )
-                  ?qt :tripleAdded ?date
+                  ?s ?p ?o .
+                  BIND( TRIPLE(?s, ?p, ?o) AS ?tt )
+                  :myreifier rdf:reifies ?tt .
+                  :myreifier :tripleAdded ?date .
               }
             </pre>
           </section>
@@ -11805,10 +11811,10 @@ _:x rdf:type xsd:decimal .
             Normative changes:
             <ul>
                 <li>Remove concepts of plain and simple literals, in favor of explicit mentions of xsd:string</li>
-                <li>Update grammar for triple terms and triple functions in <a href="#sparqlGrammar" class="sectionRef"></a></li>
+                <li>Update grammar for reified triples and triple functions in <a href="#sparqlGrammar" class="sectionRef"></a></li>
                 <li>Migrate XML Schema references to 1.1</li>
                 <li>Update references to XPath from 2.0 to 3.1</li>
-                <li>Add functions on triple terms to <a href="#func-triple-terms" class="sectionRef"></a></li>
+                <li>Add functions on reified triples to <a href="#func-reified-triples" class="sectionRef"></a></li>
             </ul>
         </li>
         <li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -11811,7 +11811,7 @@ _:x rdf:type xsd:decimal .
             Normative changes:
             <ul>
                 <li>Remove concepts of plain and simple literals, in favor of explicit mentions of xsd:string</li>
-                <li>Update grammar for reified triples and triple functions in <a href="#sparqlGrammar" class="sectionRef"></a></li>
+                <li>Update grammar for triple terms and triple functions in <a href="#sparqlGrammar" class="sectionRef"></a></li>
                 <li>Migrate XML Schema references to 1.1</li>
                 <li>Update references to XPath from 2.0 to 3.1</li>
                 <li>Add functions on reified triples to <a href="#func-reified-triples" class="sectionRef"></a></li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -11814,7 +11814,7 @@ _:x rdf:type xsd:decimal .
                 <li>Update grammar for triple terms and triple functions in <a href="#sparqlGrammar" class="sectionRef"></a></li>
                 <li>Migrate XML Schema references to 1.1</li>
                 <li>Update references to XPath from 2.0 to 3.1</li>
-                <li>Add functions on reified triples to <a href="#func-reified-triples" class="sectionRef"></a></li>
+                <li>Add functions on triple terms to <a href="#func-triple-terms" class="sectionRef"></a></li>
             </ul>
         </li>
         <li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -7406,8 +7406,8 @@ WHERE {
         </section>
 
         <!-- QT -->
-        <section id="func-reified-triples">
-          <h4>Functions on Reified Triples</h4>
+        <section id="func-triple-terms">
+          <h4>Functions on Triple Terms</h4>
           <section id="func-triple">
             <h5>TRIPLE</h5>
             <pre class="prototype nohighlight">

--- a/spec/index.html
+++ b/spec/index.html
@@ -7406,16 +7406,16 @@ WHERE {
         </section>
 
         <!-- QT -->
-        <section id="func-quoted-triples">
-          <h4>Functions on Quoted Triples</h4>
+        <section id="func-triple-terms">
+          <h4>Functions on Triple Terms</h4>
           <section id="func-triple">
             <h5>TRIPLE</h5>
             <pre class="prototype nohighlight">
-              <span class="return">quoted triple</span>  <span class="operator">TRIPLE</span> (<span class="type RDFterm">RDF term</span> <span class="name">subj</span>, <span class="type RDFterm">RDF term</span> <span class="name">pred</span>, <span class="type RDFterm">RDF term</span> <span
+              <span class="return">triple term</span>  <span class="operator">TRIPLE</span> (<span class="type RDFterm">RDF term</span> <span class="name">subj</span>, <span class="type RDFterm">RDF term</span> <span class="name">pred</span>, <span class="type RDFterm">RDF term</span> <span
 class="name">obj</span>)
             </pre>
             <pre class="query nohighlight">
-                  <span class="operator">&lt;&lt;</span> subj pred obj <span class="operator">&gt;&gt;</span>
+                  <span class="operator">&lt;&lt;(</span> subj pred obj <span class="operator">)&gt;&gt;</span>
             </pre>
             <p>
               If the 3-tuple (<code style="color:black">subj</code>, 
@@ -7423,27 +7423,26 @@ class="name">obj</span>)
               <code style="color:black">obj</code>)
               is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triple</a>
               (that is, <code style="color:black">subj</code> is an
-              <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>,
-              <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a> or
+              <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a> or
               <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>;
               <code style="color:black">pred</code> is an
               <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>;
               and <code style="color:black">obj</code> is an
               <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>,
-              <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>,
+              <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>,
               <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> or
               <a data-cite="RDF12-CONCEPTS#dfn-literal">literal</a>)
-              the function returns a quoted triple with these three elements.
+              the function returns a triple term with these three elements.
               Otherwise, the function raises an error.
             </p>
 
             <p>
               As a shorthand notation, the <code>TRIPLE</code> function 
               can also be written in the form of a
-              <a href="#rExprQuotedTriple">quoted triple expression</a>
-              using <code>&lt;&lt;</code> and <code>&gt;&gt;</code>.  There is a
+              <a href="#rExprQuotedTriple">triple term expression</a>
+              using <code>&lt;&lt;(</code> and <code>)&gt;&gt;</code>.  There is a
               syntax limitation to this shorthand form: the three elements of
-              the quoted triple expression can only be variables and directly
+              the triple term expression can only be variables and directly
               written RDF terms, not arbitrary expressions. 
               In contrast, the function form, <code>TRIPLE</code>,
               can be used with arbitrary expressions.
@@ -7452,7 +7451,7 @@ class="name">obj</span>)
               PREFIX : &lt;http://example/&gt;
               SELECT ?s ?date {
                   ?s ?p ?o
-                  BIND( &lt;&lt; ?s ?p ?o &gt;&gt; AS ?qt )
+                  BIND( &lt;&lt;( ?s ?p ?o )&gt;&gt; AS ?qt )
                   ?qt :tripleAdded ?date
               }
             </pre>
@@ -7468,45 +7467,45 @@ class="name">obj</span>)
 
           <section id="func-subject">
             <h5>SUBJECT</h5>
-            <pre class="prototype nohighlight"><span class="return">RDF term</span>  <span class="operator">SUBJECT</span> (<span class="type RDFterm">quoted triple</span> <span class="name">quoted-triple</span>)</pre>
+            <pre class="prototype nohighlight"><span class="return">RDF term</span>  <span class="operator">SUBJECT</span> (<span class="type RDFterm">triple term</span> <span class="name">triple-term</span>)</pre>
             <p>
 	            If the argument is a
-              <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>, 
+              <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>, 
               the function returns the 
               <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a>
-              of the quoted triple. 
+              of the triple term. 
               If the argument is not a 
-              <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>,
+              <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>,
               an error is raised.
             </p>
           </section>
           
           <section id="func-predicate">
             <h5>PREDICATE</h5>
-            <pre class="prototype nohighlight"><span class="return">RDF term</span>  <span class="operator">PREDICATE</span> (<span class="type RDFterm">quoted triple</span> <span class="name">quoted-triple</span>)</pre>
+            <pre class="prototype nohighlight"><span class="return">RDF term</span>  <span class="operator">PREDICATE</span> (<span class="type RDFterm">triple term</span> <span class="name">triple-term</span>)</pre>
             <p>
               If the argument is a
-              <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>,
+              <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>,
               the function returns the 
               <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>
-              of the quoted triple.
+              of the triple term.
               If the argument is not a 
-              <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>,
+              <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>,
               an error is raised.
             </p>
           </section>
 
           <section id="func-object">
             <h5>OBJECT</h5>
-            <pre class="prototype nohighlight"><span class="return">RDF term</span>  <span class="operator">OBJECT</span> (<span class="type RDFterm">quoted triple</span> <span class="name">quoted-triple</span>)</pre>
+            <pre class="prototype nohighlight"><span class="return">RDF term</span>  <span class="operator">OBJECT</span> (<span class="type RDFterm">triple term</span> <span class="name">triple-term</span>)</pre>
             <p>
               If the argument is a
-              <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>,
+              <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>,
               the function returns the 
               <a data-cite="RDF12-CONCEPTS#dfn-object">object</a>
-              of the quoted triple.
+              of the triple term.
               If the argument is not a 
-              <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>,
+              <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>,
               an error is raised.
             </p>
           </section>
@@ -7515,7 +7514,7 @@ class="name">obj</span>)
             <h5>isTRIPLE</h5>
             <pre class="prototype nohighlight"><span class="return">xsd:boolean</span>  <span class="operator">isTRIPLE</span> (<span class="type RDFterm">RDF term</span> <span class="name">term</span>)</pre>
             <p>
-              If the argument is a <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>, 
+              If the argument is a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>, 
               the function returns true.
               If the argument is any other kind of 
               <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>, 
@@ -11806,10 +11805,10 @@ _:x rdf:type xsd:decimal .
             Normative changes:
             <ul>
                 <li>Remove concepts of plain and simple literals, in favor of explicit mentions of xsd:string</li>
-                <li>Update grammar for quoted triples and triple functions in <a href="#sparqlGrammar" class="sectionRef"></a></li>
+                <li>Update grammar for triple terms and triple functions in <a href="#sparqlGrammar" class="sectionRef"></a></li>
                 <li>Migrate XML Schema references to 1.1</li>
                 <li>Update references to XPath from 2.0 to 3.1</li>
-                <li>Add functions on quoted triples to <a href="#func-quoted-triples" class="sectionRef"></a></li>
+                <li>Add functions on triple terms to <a href="#func-triple-terms" class="sectionRef"></a></li>
             </ul>
         </li>
         <li>


### PR DESCRIPTION
Following the changes in https://github.com/w3c/rdf-concepts/commit/6b7ea76dccfa4ec0d5c9b94cdce7d22dcc0536e5, this PR uses triple terms instead of quoted triples.

For the `TRIPLE` function shorthand, the same syntax was used as in Turtle: `<<( ?s ?p ?o )>>`

This PR does not yet update the grammar, as I believe this was auto-generated before.
@afs I believe you had such a generator? Could you look into running it for these changes? (also for SPARQL Update I guess)
I guess we can do this in a separate PR from this one.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/149.html" title="Last updated on Aug 22, 2024, 6:25 AM UTC (8dcff49)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/149/ca14da9...8dcff49.html" title="Last updated on Aug 22, 2024, 6:25 AM UTC (8dcff49)">Diff</a>