### PR TITLE
SPARQL Grammar: initial text direction; nested reified triples

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -10469,6 +10469,7 @@ _:x rdf:type xsd:decimal .
             and not for other path expressions.
           </li>
         </ol>
+
         <!-- GRAMMAR -->
         <div class="grammarTable">
           <table><tbody>
@@ -11289,263 +11290,270 @@ _:x rdf:type xsd:decimal .
                 <td><code>[117]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rReifiedTriple">ReifiedTriple</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rVarOrTerm">VarOrTerm</a> <a href="#rVerb">Verb</a> <a href="#rVarOrTerm">VarOrTerm</a> <a href="#rReifier">Reifier</a>? <span class="token">'&gt;&gt;'</span></code></td>
+                <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rReifiedTripleSubject">ReifiedTripleSubject</a> <a href="#rVerb">Verb</a> <a href="#rReifiedTripleObject">ReifiedTripleObject</a> <a href="#rReifier">Reifier</a>? <span class="token">'&gt;&gt;'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
                 <td><code>[118]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rReifiedTripleData">ReifiedTripleData</span></code></td>
+                <td><code><span class="doc-ref" id="rReifiedTripleSubject">ReifiedTripleSubject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rDataValueTerm">DataValueTerm</a> ( <a href="#riri">iri</a> | <span class="token">'a'</span> ) <a href="#rDataValueTerm">DataValueTerm</a> <a href="#rReifierData">ReifierData</a>? <span class="token">'&gt;&gt;'</span></code></td>
+                <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rReifiedTriple">ReifiedTriple</a> | <a href="#rNIL">NIL</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
                 <td><code>[119]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rReifiedTripleObject">ReifiedTripleObject</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rReifiedTriple">ReifiedTriple</a> | <a href="#rNIL">NIL</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[120]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTripleTerm">TripleTerm</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rVarOrTerm">VarOrTerm</a> <a href="#rVerb">Verb</a> <a href="#rVarOrTerm">VarOrTerm</a> <span class="token">')&gt;&gt;'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[120]&nbsp;&nbsp;</code></td>
+                <td><code>[121]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTripleTermData">TripleTermData</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rDataValueTerm">DataValueTerm</a> ( <a href="#riri">iri</a> | <span class="token">'a'</span> ) <a href="#rDataValueTerm">DataValueTerm</a> <span class="token">')&gt;&gt;'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[121]&nbsp;&nbsp;</code></td>
+                <td><code>[122]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDataValueTerm">DataValueTerm</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#riri">iri</a> |	<a href="#rRDFLiteral">RDFLiteral</a> |	<a href="#rNumericLiteral">NumericLiteral</a> |	<a href="#rBooleanLiteral">BooleanLiteral</a> |	<a href="#rTripleTermData">TripleTermData</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[122]&nbsp;&nbsp;</code></td>
+                <td><code>[123]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVarOrIri">VarOrIri</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[123]&nbsp;&nbsp;</code></td>
+                <td><code>[124]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVar">Var</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVAR1">VAR1</a> | <a href="#rVAR2">VAR2</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[124]&nbsp;&nbsp;</code></td>
+                <td><code>[125]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rExpression">Expression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rConditionalOrExpression">ConditionalOrExpression</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[125]&nbsp;&nbsp;</code></td>
+                <td><code>[126]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rConditionalOrExpression">ConditionalOrExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rConditionalAndExpression">ConditionalAndExpression</a> ( <span class="token">'||'</span> <a href="#rConditionalAndExpression">ConditionalAndExpression</a> )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[126]&nbsp;&nbsp;</code></td>
+                <td><code>[127]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rConditionalAndExpression">ConditionalAndExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rValueLogical">ValueLogical</a> ( <span class="token">'&amp;&amp;'</span> <a href="#rValueLogical">ValueLogical</a> )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[127]&nbsp;&nbsp;</code></td>
+                <td><code>[128]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rValueLogical">ValueLogical</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rRelationalExpression">RelationalExpression</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[128]&nbsp;&nbsp;</code></td>
+                <td><code>[129]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rRelationalExpression">RelationalExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rNumericExpression">NumericExpression</a> ( <span class="token">'='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'!='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> | <span class="token">'NOT'</span> <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> )?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[129]&nbsp;&nbsp;</code></td>
+                <td><code>[130]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNumericExpression">NumericExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rAdditiveExpression">AdditiveExpression</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[130]&nbsp;&nbsp;</code></td>
+                <td><code>[131]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rAdditiveExpression">AdditiveExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rMultiplicativeExpression">MultiplicativeExpression</a> ( <span class="token">'+'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | <span class="token">'-'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | ( <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a> ) ( ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) | ( <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) )* )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[131]&nbsp;&nbsp;</code></td>
+                <td><code>[132]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rMultiplicativeExpression">MultiplicativeExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rUnaryExpression">UnaryExpression</a> ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> | <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[132]&nbsp;&nbsp;</code></td>
+                <td><code>[133]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rUnaryExpression">UnaryExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'!'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'+'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'-'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<a href="#rPrimaryExpression">PrimaryExpression</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[133]&nbsp;&nbsp;</code></td>
+                <td><code>[134]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPrimaryExpression">PrimaryExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#ririOrFunction">iriOrFunction</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprTripleTerm">ExprTripleTerm</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[134]&nbsp;&nbsp;</code></td>
+                <td><code>[135]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rExprVarOrTerm">ExprVarOrTerm</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprTripleTerm">ExprTripleTerm</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[135]&nbsp;&nbsp;</code></td>
+                <td><code>[136]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rExprTripleTerm">ExprTripleTerm</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rExprVarOrTerm">ExprVarOrTerm</a> <a href="#rVerb">Verb</a> <a href="#rExprVarOrTerm">ExprVarOrTerm</a> <span class="token">')&gt;&gt;'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[136]&nbsp;&nbsp;</code></td>
+                <td><code>[137]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBrackettedExpression">BrackettedExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[137]&nbsp;&nbsp;</code></td>
+                <td><code>[138]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBuiltInCall">BuiltInCall</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">&nbsp;&nbsp;<a href="#rAggregate">Aggregate</a> <br/>|	<span class="token">'STR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANGMATCHES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DATATYPE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BOUND'</span> <span class="token">'('</span> <a href="#rVar">Var</a> <span class="token">')'</span> <br/>|	<span class="token">'IRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BNODE'</span> ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> | <a href="#rNIL">NIL</a> ) <br/>|	<span class="token">'RAND'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'ABS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CEIL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'FLOOR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ROUND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONCAT'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<a href="#rSubstringExpression">SubstringExpression</a> <br/>|	<span class="token">'STRLEN'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<a href="#rStrReplaceExpression">StrReplaceExpression</a> <br/>|	<span class="token">'UCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ENCODE_FOR_URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONTAINS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRSTARTS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRENDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRBEFORE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRAFTER'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'YEAR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MONTH'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DAY'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'HOURS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MINUTES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SECONDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TIMEZONE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TZ'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'NOW'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'UUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'STRUUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'MD5'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA1'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA256'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA384'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA512'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'COALESCE'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<span class="token">'IF'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRDT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'sameTerm'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isIRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isURI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isBLANK'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isLITERAL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isNUMERIC'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<a href="#rRegexExpression">RegexExpression</a> <br/>|	<a href="#rExistsFunc">ExistsFunc</a> <br/>|	<a href="#rNotExistsFunc">NotExistsFunc</a> <br/>|	<span class="token">'isTRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SUBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'PREDICATE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'OBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
+                <td><code class="gRuleBody">&nbsp;&nbsp;<a href="#rAggregate">Aggregate</a> <br/>|	<span class="token">'STR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANGMATCHES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DATATYPE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BOUND'</span> <span class="token">'('</span> <a href="#rVar">Var</a> <span class="token">')'</span> <br/>|	<span class="token">'IRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BNODE'</span> ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> | <a href="#rNIL">NIL</a> ) <br/>|	<span class="token">'RAND'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'ABS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CEIL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'FLOOR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ROUND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONCAT'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<a href="#rSubstringExpression">SubstringExpression</a> <br/>|	<span class="token">'STRLEN'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<a href="#rStrReplaceExpression">StrReplaceExpression</a> <br/>|	<span class="token">'UCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ENCODE_FOR_URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONTAINS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRSTARTS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRENDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRBEFORE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRAFTER'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'YEAR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MONTH'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DAY'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'HOURS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MINUTES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SECONDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TIMEZONE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TZ'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'NOW'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'UUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'STRUUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'MD5'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA1'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA256'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA384'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA512'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'COALESCE'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<span class="token">'IF'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRLANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRDT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'sameTerm'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isIRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isURI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isBLANK'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isLITERAL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isNUMERIC'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'hasLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'hasLANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<a href="#rRegexExpression">RegexExpression</a> <br/>|	<a href="#rExistsFunc">ExistsFunc</a> <br/>|	<a href="#rNotExistsFunc">NotExistsFunc</a> <br/>|	<span class="token">'isTRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SUBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'PREDICATE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'OBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[138]&nbsp;&nbsp;</code></td>
+                <td><code>[139]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rRegexExpression">RegexExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'REGEX'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[139]&nbsp;&nbsp;</code></td>
+                <td><code>[140]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSubstringExpression">SubstringExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'SUBSTR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[140]&nbsp;&nbsp;</code></td>
+                <td><code>[141]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rStrReplaceExpression">StrReplaceExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'REPLACE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[141]&nbsp;&nbsp;</code></td>
+                <td><code>[142]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rExistsFunc">ExistsFunc</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'EXISTS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[142]&nbsp;&nbsp;</code></td>
+                <td><code>[143]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNotExistsFunc">NotExistsFunc</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'NOT'</span> <span class="token">'EXISTS'</span> <a href="#rGroupGraphPattern">GroupGraphPattern</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[143]&nbsp;&nbsp;</code></td>
+                <td><code>[144]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rAggregate">Aggregate</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'COUNT'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? ( <span class="token">'*'</span> | <a href="#rExpression">Expression</a> ) <span class="token">')'</span> <br/>| <span class="token">'SUM'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MIN'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MAX'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'AVG'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SAMPLE'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'GROUP_CONCAT'</span> <span class="token">'('</span> <span class="token">'DISTINCT'</span>? <a href="#rExpression">Expression</a> ( <span class="token">';'</span> <span class="token">'SEPARATOR'</span> <span class="token">'='</span> <a href="#rString">String</a> )? <span class="token">')'</span> </code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[144]&nbsp;&nbsp;</code></td>
+                <td><code>[145]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="ririOrFunction">iriOrFunction</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a>?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[145]&nbsp;&nbsp;</code></td>
+                <td><code>[146]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rRDFLiteral">RDFLiteral</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rString">String</a> ( <a href="#rLANGTAG">LANGTAG</a> | ( <span class="token">'^^'</span> <a href="#riri">iri</a> ) )?</code></td>
+                <td><code class="gRuleBody"><a href="#rString">String</a> ( <a href="#rLANG_DIR">LANG_DIR</a> | <span class="token">'^^'</span> <a href="#riri">iri</a> )?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[146]&nbsp;&nbsp;</code></td>
+                <td><code>[147]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNumericLiteral">NumericLiteral</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rNumericLiteralUnsigned">NumericLiteralUnsigned</a> | <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[147]&nbsp;&nbsp;</code></td>
+                <td><code>[148]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNumericLiteralUnsigned">NumericLiteralUnsigned</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rINTEGER">INTEGER</a> |	<a href="#rDECIMAL">DECIMAL</a> |	<a href="#rDOUBLE">DOUBLE</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[148]&nbsp;&nbsp;</code></td>
+                <td><code>[149]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNumericLiteralPositive">NumericLiteralPositive</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rINTEGER_POSITIVE">INTEGER_POSITIVE</a> |	<a href="#rDECIMAL_POSITIVE">DECIMAL_POSITIVE</a> |	<a href="#rDOUBLE_POSITIVE">DOUBLE_POSITIVE</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[149]&nbsp;&nbsp;</code></td>
+                <td><code>[150]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNumericLiteralNegative">NumericLiteralNegative</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rINTEGER_NEGATIVE">INTEGER_NEGATIVE</a> |	<a href="#rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</a> |	<a href="#rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[150]&nbsp;&nbsp;</code></td>
+                <td><code>[151]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBooleanLiteral">BooleanLiteral</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'true'</span> |	<span class="token">'false'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[151]&nbsp;&nbsp;</code></td>
+                <td><code>[152]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rString">String</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a> | <a href="#rSTRING_LITERAL2">STRING_LITERAL2</a> | <a href="#rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</a> | <a href="#rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[152]&nbsp;&nbsp;</code></td>
+                <td><code>[153]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="riri">iri</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rIRIREF">IRIREF</a> |	<a href="#rPrefixedName">PrefixedName</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[153]&nbsp;&nbsp;</code></td>
+                <td><code>[154]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPrefixedName">PrefixedName</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPNAME_LN">PNAME_LN</a> | <a href="#rPNAME_NS">PNAME_NS</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[154]&nbsp;&nbsp;</code></td>
+                <td><code>[155]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBlankNode">BlankNode</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rBLANK_NODE_LABEL">BLANK_NODE_LABEL</a> |	<a href="#rANON">ANON</a></code></td>
@@ -11557,245 +11565,245 @@ _:x rdf:type xsd:decimal .
           <table><tbody>
 
               <tr style="vertical-align: baseline">
-                <td><code>[155]&nbsp;&nbsp;</code></td>
+                <td><code>[156]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rIRIREF">IRIREF</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'&lt;' ([^&lt;&gt;"{}|^`\]-[#x00-#x20])* '&gt;'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[156]&nbsp;&nbsp;</code></td>
+                <td><code>[157]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPNAME_NS">PNAME_NS</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPN_PREFIX">PN_PREFIX</a>? ':'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[157]&nbsp;&nbsp;</code></td>
+                <td><code>[158]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPNAME_LN">PNAME_LN</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPNAME_NS">PNAME_NS</a> <a href="#rPN_LOCAL">PN_LOCAL</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[158]&nbsp;&nbsp;</code></td>
+                <td><code>[159]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBLANK_NODE_LABEL">BLANK_NODE_LABEL</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'_:' ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] ) ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[159]&nbsp;&nbsp;</code></td>
+                <td><code>[160]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVAR1">VAR1</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'?' <a href="#rVARNAME">VARNAME</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[160]&nbsp;&nbsp;</code></td>
+                <td><code>[161]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVAR2">VAR2</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'$' <a href="#rVARNAME">VARNAME</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[161]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rLANGTAG">LANGTAG</span></code></td>
+                <td><code>[162]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rLANG_DIR">LANG_DIR</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)*</code></td>
+                <td><code class="gRuleBody">'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)* ('--' [a-zA-Z]+)?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[162]&nbsp;&nbsp;</code></td>
+                <td><code>[163]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rINTEGER">INTEGER</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[0-9]+</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[163]&nbsp;&nbsp;</code></td>
+                <td><code>[164]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDECIMAL">DECIMAL</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[0-9]* '.' [0-9]+</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[164]&nbsp;&nbsp;</code></td>
+                <td><code>[165]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDOUBLE">DOUBLE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[0-9]+ '.' [0-9]* <a href="#rEXPONENT">EXPONENT</a> | '.' ([0-9])+ <a href="#rEXPONENT">EXPONENT</a> | ([0-9])+ <a href="#rEXPONENT">EXPONENT</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[165]&nbsp;&nbsp;</code></td>
+                <td><code>[166]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rINTEGER_POSITIVE">INTEGER_POSITIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rINTEGER">INTEGER</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[166]&nbsp;&nbsp;</code></td>
+                <td><code>[167]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDECIMAL_POSITIVE">DECIMAL_POSITIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[167]&nbsp;&nbsp;</code></td>
+                <td><code>[168]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDOUBLE_POSITIVE">DOUBLE_POSITIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[168]&nbsp;&nbsp;</code></td>
+                <td><code>[169]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rINTEGER_NEGATIVE">INTEGER_NEGATIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rINTEGER">INTEGER</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[169]&nbsp;&nbsp;</code></td>
+                <td><code>[170]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[170]&nbsp;&nbsp;</code></td>
+                <td><code>[171]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[171]&nbsp;&nbsp;</code></td>
+                <td><code>[172]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rEXPONENT">EXPONENT</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[eE] [+-]? [0-9]+</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[172]&nbsp;&nbsp;</code></td>
+                <td><code>[173]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL1">STRING_LITERAL1</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">"'" ( ([^#x27#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* "'"</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[173]&nbsp;&nbsp;</code></td>
+                <td><code>[174]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL2">STRING_LITERAL2</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'"' ( ([^#x22#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* '"'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[174]&nbsp;&nbsp;</code></td>
+                <td><code>[175]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">"'''" ( ( "'" | "''" )? ( [^'\] | <a href="#rECHAR">ECHAR</a> ) )* "'''"</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[175]&nbsp;&nbsp;</code></td>
+                <td><code>[176]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'"""' ( ( '"' | '""' )? ( [^"\] | <a href="#rECHAR">ECHAR</a> ) )* '"""'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[176]&nbsp;&nbsp;</code></td>
+                <td><code>[177]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rECHAR">ECHAR</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'\' [tbnrf\"']</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[177]&nbsp;&nbsp;</code></td>
+                <td><code>[178]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNIL">NIL</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'(' <a href="#rWS">WS</a>* ')'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[178]&nbsp;&nbsp;</code></td>
+                <td><code>[179]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rWS">WS</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">#x20 | #x9 | #xD | #xA</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[179]&nbsp;&nbsp;</code></td>
+                <td><code>[180]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rANON">ANON</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'['  <a href="#rWS">WS</a>* ']'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[180]&nbsp;&nbsp;</code></td>
+                <td><code>[181]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_CHARS_BASE">PN_CHARS_BASE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[A-Z] | [a-z] | [#x00C0-#x00D6] | [#x00D8-#x00F6] | [#x00F8-#x02FF] | [#x0370-#x037D] | [#x037F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[181]&nbsp;&nbsp;</code></td>
+                <td><code>[182]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_CHARS_U">PN_CHARS_U</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> | '_'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[182]&nbsp;&nbsp;</code></td>
+                <td><code>[183]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVARNAME">VARNAME</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">( <a href="#rPN_CHARS_U">PN_CHARS_U</a>  | [0-9] ) ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[183]&nbsp;&nbsp;</code></td>
+                <td><code>[184]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_CHARS">PN_CHARS</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPN_CHARS_U">PN_CHARS_U</a> | '-' | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040]</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[184]&nbsp;&nbsp;</code></td>
+                <td><code>[185]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_PREFIX">PN_PREFIX</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[185]&nbsp;&nbsp;</code></td>
+                <td><code>[186]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_LOCAL">PN_LOCAL</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">(<a href="#rPN_CHARS_U">PN_CHARS_U</a> | ':' | [0-9] | <a href="#rPLX">PLX</a> ) ((<a href="#rPN_CHARS">PN_CHARS</a> | '.' | ':' | <a href="#rPLX">PLX</a>)* (<a href="#rPN_CHARS">PN_CHARS</a> | ':' | <a href="#rPLX">PLX</a>) )?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[186]&nbsp;&nbsp;</code></td>
+                <td><code>[187]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPLX">PLX</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPERCENT">PERCENT</a> | <a href="#rPN_LOCAL_ESC">PN_LOCAL_ESC</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[187]&nbsp;&nbsp;</code></td>
+                <td><code>[188]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPERCENT">PERCENT</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'%' <a href="#rHEX">HEX</a> <a href="#rHEX">HEX</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[188]&nbsp;&nbsp;</code></td>
+                <td><code>[189]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rHEX">HEX</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[0-9] | [A-F] | [a-f]</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[189]&nbsp;&nbsp;</code></td>
+                <td><code>[190]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_LOCAL_ESC">PN_LOCAL_ESC</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )</code></td>
@@ -11803,6 +11811,7 @@ _:x rdf:type xsd:decimal .
           </tbody></table>
         </div>
         <!-- GRAMMAR -->
+
       </section>
     </section>
 
@@ -11889,6 +11898,7 @@ _:x rdf:type xsd:decimal .
                 <li>Remove concepts of plain and simple literals, in favor of explicit mentions of xsd:string</li>
                 <li>Update grammar for triple terms, reifiers, reified triples, annotation syntax, and triple term functions
                   in <a href="#sparqlGrammar" class="sectionRef"></a></li>
+                <li>Update grammar for initial text direction syntax and functions in <a href="#sparqlGrammar" class="sectionRef"></a></li>
                 <li>Migrate XML Schema references to 1.1</li>
                 <li>Update references to XPath from 2.0 to 3.1</li>
                 <li>Add functions on triple terms to <a href="#func-triple-terms" class="sectionRef"></a></li>


### PR DESCRIPTION
This PR updates the SPARQL Grammar to include initial text direction syntax and functions. There is also a fix for nested reified triples.

This replaces the grammar changes in #113 in order to get all the SPARQL 1.2 grammar changes into the working draft. 

The rest of #113 (updated) with the the function definitions will follow separately.

Initial text direction functions:
* Functions `isLang`, `isLangDir`, `LANGDIR`, and `STRLANGDIR`.

Changes to reification:
* Fix: allow reified triples to be nested.
* Fix: remove production `ReifiedTripleData` (removal causes renumbering)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/153.html" title="Last updated on Sep 18, 2024, 6:28 PM UTC (3590523)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/153/d0ebc5d...3590523.html" title="Last updated on Sep 18, 2024, 6:28 PM UTC (3590523)">Diff</a>