### PR TITLE
Remove the definition of RDF Dataset Merge

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -7878,11 +7878,13 @@ WHERE {
         <h3>Initial Definitions</h3>
         <section id="sparqlDataset">
           <h4>RDF Dataset</h4>
-          <div>
-            <p>The concept of an <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF Dataset</a> is defined in [[RDF12-CONCEPTS]].</p>
-            <p>For the following definitions, we capture each RDF dataset as a set:<br>
-              { G, (&lt;u<sub>1</sub>&gt;, G<sub>1</sub>), (&lt;u<sub>2</sub>&gt;, G<sub>2</sub>),
-              ... (&lt;u<sub>n</sub>&gt;, G<sub>n</sub>) }<br>
+          <p>The concept of an <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF Dataset</a> is defined in [[RDF12-CONCEPTS]].</p>
+          <p>For the following definitions, we capture each RDF dataset as a set:</p>
+          <div class="defn">
+            <p>
+            { G, (&lt;u<sub>1</sub>&gt;, G<sub>1</sub>), (&lt;u<sub>2</sub>&gt;, G<sub>2</sub>),
+              ... (&lt;u<sub>n</sub>&gt;, G<sub>n</sub>) }
+            
               where G and each G<sub>i</sub> are graphs, and each &lt;u<sub>i</sub>&gt; is an IRI or blank node. Each
               &lt;u<sub>i</sub>&gt; is distinct.</p>
             <p>G is called the default graph. (&lt;u<sub>i</sub>&gt;, G<sub>i</sub>) are called named

--- a/spec/index.html
+++ b/spec/index.html
@@ -7893,33 +7893,6 @@ WHERE {
             <p>The <b>active graph</b> is the graph from the dataset used for basic graph pattern
               matching.</p>
           </div>
-          <div class="defn">
-            <div id="defn_RDFDatasetMerge">
-              <b>Definition: RDF Dataset Merge</b>
-            </div>
-            <p>Let DS1 = { G1, (&lt;u1<sub>1</sub>&gt;, G1<sub>1</sub>), (&lt;u1<sub>2</sub>&gt;,
-              G1<sub>2</sub>), . . . (&lt;u1<sub>n</sub>&gt;, G1<sub>n</sub>) },<br>
-              and DS2 = { G2, (&lt;u2<sub>1</sub>&gt;, G2<sub>1</sub>), (&lt;u2<sub>2</sub>&gt;,
-              G2<sub>2</sub>), . . . (&lt;u2<sub>m</sub>&gt;, G2<sub>m</sub>) }</p>
-            <p>then we define the RDF Dataset Merge of DS1 and DS2 to be:<br>
-              DS={ G, (&lt;u<sub>1</sub>&gt;, G<sub>1</sub>), (&lt;u<sub>2</sub>&gt;, G<sub>2</sub>), .
-              . . (&lt;u<sub>k</sub>&gt;, G<sub>k</sub>) }<br>
-              where:</p>
-            <p>Write N1 for { &lt;u1<sub>j</sub>&gt; j = 1 to n }<br>
-              Write N2 for { &lt;u2<sub>j</sub>&gt; j = 1 to m }<br></p>
-            <ul>
-              <li>G is the <a data-cite="RDF12-SEMANTICS#dfn-merge">merge</a> of G1 and G2
-              </li>
-              <li>(&lt;u<sub>i</sub>&gt;, G<sub>i</sub>) where &lt;u<sub>i</sub>&gt; is in N1 but not
-                in N2</li>
-              <li>(&lt;u<sub>i</sub>&gt;, G<sub>i</sub>) where &lt;u<sub>i</sub>&gt; is in N2 but not
-                in N1</li>
-              <li>(&lt;u<sub>i</sub>&gt;, G<sub>i</sub>) where &lt;u<sub>i</sub>&gt; is equal to
-                &lt;u<sub>j</sub>&gt; in N1 and equal to &lt;u<sub>k</sub>&gt; in N2 and G<sub>i</sub>
-                is the <a data-cite="RDF12-SEMANTICS#dfn-merge">merge</a> of G1<sub>j</sub> and G2<sub>k</sub>
-              </li>
-            </ul>
-          </div>
         </section>
         <section id="sparqlQueryVariables">
           <h4>Query Variables</h4>


### PR DESCRIPTION
This closes: #166

The definition  of "RDF Dataset Merge" is moving to RDF Semantics. This PR does the sparql-query part.

Two commits:
* Remove the definition of RDF Dataset Merge
* Suggestion -- put in a box for "dataset" - but not the "Definition" text for RDF dataset.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/167.html" title="Last updated on Nov 1, 2024, 3:41 PM UTC (c8a51aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/167/78300a6...c8a51aa.html" title="Last updated on Nov 1, 2024, 3:41 PM UTC (c8a51aa)">Diff</a>