### PR TITLE
Update section number referred to in F&O

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -7601,7 +7601,7 @@ class="name">obj</span>)
           [[[XPATH-FUNCTIONS-31]]] [[XPATH-FUNCTIONS-31]] in
           section 
           <a data-cite="XPATH-FUNCTIONS-31#casting-from-primitive-to-primitive"
-          >17.1 Casting from primitive types to primitive types</a>.
+          >19.1 Casting from primitive types to primitive types</a>.
           SPARQL constructors include all of the XPath constructors for
           the <a href="#operandDataTypes">SPARQL operand datatypes</a> plus
           the <a href="#operandDataTypes">additional datatypes</a> imposed by

--- a/spec/index.html
+++ b/spec/index.html
@@ -7596,15 +7596,23 @@ class="name">obj</span>)
       </section>
       <section id="FunctionMapping">
         <h3>XPath Constructor Functions</h3>
-        <p>SPARQL imports a subset of the XPath constructor functions defined in [[[XPATH-FUNCTIONS-31]]]
-          [[XPATH-FUNCTIONS-31]] in section <a data-cite="XPATH-FUNCTIONS-31#casting-from-primitive-to-primitive">17.1 Casting
-            from primitive types to primitive types</a>. SPARQL constructors include all of the XPath
-          constructors for the <a href="#operandDataTypes">SPARQL operand datatypes</a> plus the
-          <a href="#operandDataTypes">additional datatypes</a> imposed by the RDF data model. Casting
-          in SPARQL is performed by calling a constructor function for the target type on an operand of
-          the source type.</p>
-        <p>XPath defines only the casts from one XML Schema datatype to another. The remaining cast
-          is defined as follows:</p>
+        <p>
+          SPARQL imports a subset of the XPath constructor functions defined in
+          [[[XPATH-FUNCTIONS-31]]] [[XPATH-FUNCTIONS-31]] in
+          section 
+          <a data-cite="XPATH-FUNCTIONS-31#casting-from-primitive-to-primitive"
+          >17.1 Casting from primitive types to primitive types</a>.
+          SPARQL constructors include all of the XPath constructors for
+          the <a href="#operandDataTypes">SPARQL operand datatypes</a> plus
+          the <a href="#operandDataTypes">additional datatypes</a> imposed by
+          the RDF data model. Casting in SPARQL is performed by calling a
+          constructor function for the target type on an operand of the source
+          type.
+        </p>
+        <p>
+          XPath defines only the casts from one XML Schema datatype to another. The remaining cast
+          is defined as follows:
+        </p>
         <ul>
           <li>Casting an <span class="IRI type">IRI</span> to an <code>xsd:string</code> produces a
             <span class="IRI literal">literal</span> with a lexical value of the codepoints


### PR DESCRIPTION
What was section 17.1 is now 19.1 after the Functions and Operator version update.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/174.html" title="Last updated on Dec 15, 2024, 11:19 AM UTC (a2695ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/174/e884490...a2695ee.html" title="Last updated on Dec 15, 2024, 11:19 AM UTC (a2695ee)">Diff</a>