### PR TITLE
Revise RDFterm-equal and function sameTerm. Rename RDFterm-equal to sameValue.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -243,8 +243,7 @@ table.casting	{ font-size: x-small; }
 span.cancast:hover { background-color: #ffa;
                      color: black; }
 
-.SPARQLoperator	{ background-color: #FFFFbf; /* yellow */
-          }
+.SPARQLoperator	{ font-weight: 600; }
 
       /* ReSpec */
       dfn { font-style: normal ; }
@@ -4665,6 +4664,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
         <p>SPARQL language extensions may treat additional types as being derived from XML schema
           datatypes.</p>
       </section>
+
       <section id="evaluation">
         <h3>Filter Evaluation</h3>
         <p>SPARQL provides a subset of the functions and operators defined by 
@@ -4826,6 +4826,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
             with a datatype of <code>xsd:boolean</code> and a lexical value of "false".</p>
         </section>
       </section>
+
       <section id="OperatorMapping">
         <h3>Operator Mapping</h3>
         <p>The SPARQL grammar identifies a set of operators 
@@ -4925,7 +4926,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
               <th colspan="5" class="subHeading" scope="col">Logical Connectives</th>
             </tr>
             <tr>
-              <th>
+              <th><span id="logical-or-operator"/>
                 <a href="#rConditionalOrExpression" title="ConditionalOrExpression">A <span class="FAOTtoken">||</span> B</a>
               </th>
               <td>
@@ -4934,7 +4935,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
               <td>
                 xsd:boolean <a href="#ebv-arg">(EBV)</a>
               </td>
-              <td class="sparqlOp">
+              <td class="sparqlOp"><span id="logical-and-operator"/>
                 <a href="#func-logical-or" class="SPARQLoperator">logical-or</a>(A, B)
               </td>
               <td>xsd:boolean</td>
@@ -5275,32 +5276,91 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
               <th colspan="5" class="subHeading" scope="col">SPARQL Tests</th>
             </tr>
             <tr>
-              <th>
-                <a href="#rRelationalExpression" title="RelationalExpression">A <span class="FAOTtoken">=</span> B</a>
-              </th>
-              <td><span class="type RDFterm">RDF term</span></td>
-              <td><span class="type RDFterm">RDF term</span></td>
-              <td class="xpathOp">
-                <a href="#func-sameValue" class="SPARQLoperator">sameValue</a>(A, B)
+              <th><a href="#rRelationalExpression" title="RelationalExpression">A <span class="FAOTtoken">=</span> B</a></th>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a></span></td>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a></span></td>
+              <td>
+                <a href="#func-sameTerm">sameTerm</a>(A, B)
               </td>
               <td>xsd:boolean</td>
             </tr>
             <tr>
-              <th>
-                <a href="#rRelationalExpression" title="RelationalExpression">A <span class="FAOTtoken">!=</span> B</a>
-              </th>
+              <th><a href="#rRelationalExpression" title="RelationalExpression">A <span class="FAOTtoken">=</span> B</a></th>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-blank-node">Blank Node</a></span></td>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-blank-node">Blank Node</a></span></td>
+              <td>
+                <a href="#func-sameTerm">sameTerm</a>(A, B)
+              </td>
+              <td>xsd:boolean</td>
+            </tr>
+            <tr>
+              <th><a href="#rRelationalExpression" title="RelationalExpression">A <span class="FAOTtoken">=</span> B</a></th>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple Term</a></span></td>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple Term</a></span></td>
+              <td>
+                ( A.subject = B.subject ) <a href="#logical-and-operator" class="SPARQLoperator">&&</a><br/>
+                ( A.predicate = B.predicate ) <a href="#logical-and-operator" class="SPARQLoperator">&&</a><br/>
+                ( A.object = B.object )
+              </td>
+              <td>xsd:boolean</td>
+            </tr>
+            <tr>
+              <th><a href="#rRelationalExpression" title="RelationalExpression">A <span class="FAOTtoken">!=</span> B</a></th>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a></span></td>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a></span></td>
+              <td><a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>(<a href="#func-sameTerm">sameTerm</a>(A, B))</td>
+              <td>xsd:boolean</td>
+            </tr>
+            <tr>
+              <th><a href="#rRelationalExpression" title="RelationalExpression">A <span class="FAOTtoken">!=</span> B</a></th>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-blank-node">Blank Node</a></span></td>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-blank-node">Blank Node</a></span></td>
+              <td>
+                <a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>(<a href="#func-sameTerm">sameTerm</a>(A, B)
+              </td>
+              <td>xsd:boolean</td>
+            </tr>
+            <tr>
+              <th><a href="#rRelationalExpression" title="RelationalExpression">A <span class="FAOTtoken">!=</span> B</a></th>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple Term</a></span></td>
+              <td><span class="type RDFterm"><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple Term</a></span></td>
+              <td>
+                ( A.subject != B.subject ) <a href="#logical-or-operator" class="SPARQLoperator">||</a><br/>
+                ( A.predicate != B.predicate ) <a href="#logical-or-operator" class="SPARQLoperator">||</a><br/>
+                ( A.object != B.object )
+              </td>
+              <td>xsd:boolean</td>
+            </tr>
+            <tr>
+              <th><a href="#rRelationalExpression" title="RelationalExpression">A <span class="FAOTtoken">=</span> B</a></th>
               <td><span class="type RDFterm">RDF term</span></td>
               <td><span class="type RDFterm">RDF term</span></td>
               <td class="xpathOp">
-                <a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>(<a href="#func-sameValue" class="SPARQLoperator">sameValue</a>(A, B))
+                <a href="#func-sameValue">sameValue</a>(A, B)
+              </td> 
+              <td>xsd:boolean</td>
+            </tr>
+            <tr>
+              <th><a href="#rRelationalExpression" title="RelationalExpression">A <span class="FAOTtoken">!=</span> B</a></th>
+              <td><span class="type RDFterm">RDF term</span></td>
+              <td><span class="type RDFterm">RDF term</span></td>
+              <td class="xpathOp">
+                <a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>(<a href="#func-sameValue">sameValue</a>(A, B))
               </td>
               <td>xsd:boolean</td>
             </tr>
           </tbody>
         </table>
-        <div id="ebv-arg"></div>xsd:boolean function arguments marked with "(EBV)" are
+        <p>
+        <span id="ebv-arg"></span>xsd:boolean function arguments marked with "(EBV)" are
         coerced to xsd:boolean by evaluating the <a href="#ebv">effective boolean value of that
           argument.</a>
+        </p>
+        <p>
+          Operators <span class="SPARQLoperator">=</span> and <span class="SPARQLoperator">!=</span> applied to 
+          <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>
+          apply the operator to each of the components.
+        </p>
         <section id="operatorExtensibility">
           <h4>Operator Extensibility</h4>
           <p>SPARQL language extensions may provide additional associations between operators and
@@ -5314,6 +5374,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
                 BY</code></a> clause.</p>
         </section>
       </section>
+
       <section id="SparqlOps">
         <h3>Function Definitions</h3>
         <p>This section defines the operators and functions introduced by the SPARQL query language.
@@ -5678,7 +5739,7 @@ class="expression">expression, ....</span>)
               defined in [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]; returns FALSE otherwise.</p>
             <p>
               |term1| and |term2| are the
-              <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality">same RDF terms</a>
+              <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality">same RDF term</a>
               if one of the following is true:
             </p>
             <ul>
@@ -5756,77 +5817,61 @@ class="expression">expression, ....</span>)
 
             <p>This function cannot be used directly in expressions. The purpose
               of this function is to define the semantics of the "=" operator when applied to
-              two RDF terms that do not fall into any of the other, more concrete cases
+              two RDF terms that do not fall into the concrete cases
               covered in the operator mapping table in Section
               <a href="#OperatorMapping" class="sectionRef"></a>.
             </p>
 
-            <p class="ednote" style="background-color: #EEE">
-              Revise for triple terms.
-              <br/>
-              Consider adding non-literal `=` to operator mapping table.
-            </p>
-
             <p>The result of this function is determined by going through the following steps.</p>
+
             <ol>
               <li>If <code>term1</code> and <code>term2</code> are
                 <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality">equal RDF terms</a>,
-                the return TRUE.
-              </li>
-              <li>If both arguments are literals,
-                <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>
-                and one or both arguments are known to be ill-typed, 
-                then produce a type error.
-              </li>
-              <li>If <code>term1</code> and <code>term2</code> both 
-                <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>
-                and the SPARQL processor can determine the values are equal,
                 then return TRUE.
               </li>
-              <li>If <code>term1</code> and <code>term2</code> both 
+              <li>If <code>term1</code> or <code>term2</code> is an
+                <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a> or a
+                <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>
+                then return FALSE.
+              <li>If <code>term1</code> and <code>term2</code> are both
+                <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>
+                and one or both of these literals has a datatype that is
+                not handled by the SPARQL processor,
+                then produce a type error.
+              </li>
+              <li>If <code>term1</code> and <code>term2</code> are both
+                <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>
+                and one or both of these literals are known to be
+                <a data-cite="RDF12-CONCEPTS#dfn-ill-typed">ill-typed</a>,
+                then produce a type error.
+              </li>
+              <li>
+                `"NaN"^^xsd:double` and `"NaN"^^xsd:float` are considered to 
+                represent the same value.
+                If <code>term1</code> and <code>term2</code> are
+                both "NaN" for either xsd:double or xsd:float, then 
+                return TRUE.
+              </li>
+              <li>If <code>term1</code> and <code>term2</code> are both 
+                <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>
+                and the SPARQL processor can determine that their the values are equal,
+                then return TRUE.
+              </li>
+              <li>If <code>term1</code> and <code>term2</code> are both 
                 <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>
                 and the SPARQL processor can determine the values can not be equal,
                 then return FALSE.
               </li>
-              <li>Otherwise, return FALSE.
+              <li>
+                If <code>term1</code> and <code>term2</code> are both 
+                <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>,
+                apply the function `sameValue` pair-wise to each of the components.
+                Return TRUE if each component pair returns TRUE;
+                produce a type error if any component pair produces an error;
+                otherwise return FALSE.
               </li>
+              <li>Otherwise, return FALSE.</li>
             </ol>
-            <div class="ednote" style="background-color: #EEE">
-              <p>
-                The treatment of `NaN` can not be consistent with both "same term means same value" 
-                and "`fn:numeric-equal(NaN, NaN)` is false". So it is an arbitrary choice with
-                arguments for all three possible choices.
-                For pattern matching, `"NaN"^^xsd:double` must match itself and
-                `"NaN"^^xsd:double` does not pattern match `"NaN"^^xsd:float`.
-              </p>
-              <p>
-                The operator mapping for `=` goes to `fn:numeric-compare` which is false.
-                The `sameValue` result could be made an error (or false) as a special case.
-              </p>
-              <p>
-                `"NaN"^^xsd:double = "NaN"^^xsd:float` is also handled by the
-                operator mapping and is false &ndash; `xsd:float` is promoted to `xsd:double`.
-                A reading of IEEE 754 is that `"NaN"^^xsd:double` and `"NaN"^^xsd:float`
-                are the same term also suggests that `sameValue` is true.
-              </p>
-              <p>
-                <b>Proposal 1</b>: follow "sameTerm means sameValue" and `sameValue("NaN"^^xsd:double, "NaN"^^xsd:double)`
-                and `sameValue("NaN"^^xsd:float, "NaN"^^xsd:float)` are <i>true</i>s.
-                <br/>
-                <b>Proposal 2</b>: 
-                follow "there is one NaN" so `sameValue("NaN"^^xsd:double, "NaN"^^xsd:float)` is <i>true</i>.
-              </p>
-              <p>
-                Ref</i>: <a href="https://www.w3.org/TR/xmlschema11-2/#dt-specialvalue">XSD schema 1.1 special values</a>
-                "are members of the datatype's ·value space·. ". It is not clear whether "special value" literals
-                added to the value spaces of `xsd:double` and `xsd:float` are "the same" literals.
-              <p>
-                <i>Ref</i>: <a href="https://en.wikipedia.org/wiki/IEEE_754#Special_values">(wikipedia) IEEE_754 Special Values</a>
-                <i>IEEE 754 specifies a special value called "Not a Number" (NaN)</i>.
-                suggests they are the same.
-                </p>
-            </div>
-
             <div id="sameValue-ill-typed" class="note">
               <p>A literal is 
                 <a data-cite="RDF12-CONCEPTS#dfn-ill-typed">ill-typed</a>
@@ -5847,31 +5892,19 @@ class="expression">expression, ....</span>)
                 The <a href="#OperatorMapping">Operator Mapping</a> for "`=`"
                 is the function
                 <a data-cite="XPATH-FUNCTIONS-31#func-numeric-equal">`fn:numeric-equal`</a>
-                which returns `false` when comparing arguments involving `NaN`.
-                However, `sameTerm("NaN"^^xsd:double, "NaN"^^xsd:double)` is true;
-                `sameValue` treats "NaN" as the "same value".
-                `sameTerm("NaN"^^xsd:double, "NaN"^^xsd:float)` is `true`.
+                which is defined to return `false` when comparing arguments involving `NaN`.
+                However, `sameTerm("NaN"^^xsd:double, "NaN"^^xsd:double)` is true.
+                The function `sameValue` defines `sameValue("NaN"^^xsd:double, "NaN"^^xsd:double)`
+                to be true because the arguments are the same element of the value space.
               </p>
-            </div>
-            <div id="sameValue-old-name" class="note">
-              <p>This function was previously called `RDFterm-equal`.</p>
-            </div>
-
-            <div class="ednote" style="background-color: #EEE">
               <p>
-                A SPARQL processor may support datatypes beyond those required.
-                Suppose `ex:romanNumeral` is the datatype IRI
-                <a href="https://en.wikipedia.org/wiki/Roman_numerals">roman numerals</a>
-                which are integer numbers. The SPARQL processor may then be able
-                to detemine if two literals have the same value, for example,
-                `sameValue(4, "IV"^^ex:romanNumeral)` can then return `true`
-                because argument bot represent the value 4.
-                For `sameValue("abc"^^xsd:string, "IV"^^ex:romanNumeral)`
-                can return `false` because `xsd:string` and `ex:romanNumeral`
-                have different value spaces so the arguments can not be the same value.
+                `sameValue` treats the values of `"NaN"^^xsd:double` and `"NaN"^^xsd:float` as being
+                the same. `sameValue("NaN"^^xsd:double, "NaN"^^xsd:float)` is `true`.
               </p>
             </div>
-
+            <p id="sameValue-zeros" class="note">
+              For xsd:double and xsd:float, `+0`, `-0` and `0` are same value.
+            </p>
             <p id="func-sameValue-note1" class="note">
               An extended implementation may support additional datatypes for literals. An
               implementation processing a query that tests for equivalence of literals with non-recognized datatypes
@@ -5891,22 +5924,6 @@ class="expression">expression, ....</span>)
                     <th>Results</th>
                   </tr>
                   <tr>
-                    <td><code>sameValue(2, +2)</code></td>
-                    <td>true</td>
-                  </tr>
-                  <tr>
-                    <td><code>sameValue(2.0, 2)</code></td>
-                    <td>true</td>
-                  </tr>
-                  <tr>
-                    <td><code>sameValue(2, "2")</code></td>
-                    <td>false</td>
-                  </tr>
-                  <tr>
-                    <td><code>sameValue(4, "iv"^^my:romanNumeral)</code></td>
-                    <td>error, or true by extension</td>
-                  </tr>
-                  <tr>
                     <td><code>sameValue(1e10, "NaN"^^xsd:double)</code></td>
                     <td>false</td>
                   </tr>
@@ -5918,9 +5935,16 @@ class="expression">expression, ....</span>)
                     <td><code>sameValue("NaN"^^xsd:double, "NaN"^^xsd:float)</code></td>
                     <td>true</td>
                   </tr>
+                  <tr>
+                    <td><code>sameValue( &lt;&lt(:s :p 123)&gt;&gt , &lt;&lt(:s :p 123.0)&gt;&gt )</td>
+                    <td>true</td>
+                  </tr>
                 </tbody>
               </table>
             </div>
+            <p id="sameValue-old-name" class="note">
+              This function was called `RDFterm-equal` up until SPARQL 1.1.
+            </p>
           </section>
 
           <section id="func-isIRI">

--- a/spec/index.html
+++ b/spec/index.html
@@ -5281,7 +5281,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
               <td><span class="type RDFterm">RDF term</span></td>
               <td><span class="type RDFterm">RDF term</span></td>
               <td class="xpathOp">
-                <a href="#func-RDFterm-equal" class="SPARQLoperator">RDFterm-equal</a>(A, B)
+                <a href="#func-sameValue" class="SPARQLoperator">sameValue</a>(A, B)
               </td>
               <td>xsd:boolean</td>
             </tr>
@@ -5292,7 +5292,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
               <td><span class="type RDFterm">RDF term</span></td>
               <td><span class="type RDFterm">RDF term</span></td>
               <td class="xpathOp">
-                <a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>(<a href="#func-RDFterm-equal" class="SPARQLoperator">RDFterm-equal</a>(A, B))
+                <a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>(<a href="#func-sameValue" class="SPARQLoperator">sameValue</a>(A, B))
               </td>
               <td>xsd:boolean</td>
             </tr>
@@ -5672,49 +5672,38 @@ class="expression">expression, ....</span>)
           <h4>Functions on RDF Terms</h4>
 
           <section id="func-sameTerm">
-            <h5>sameTerm</h5>
+            <h5>SameTerm</h5>
             <pre class="prototype nohighlight"> <span class="return">xsd:boolean</span>  <span class="operator">sameTerm</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)</pre>
             <p>Returns TRUE if <code>term1</code> and <code>term2</code> are the same RDF term as
               defined in [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]; returns FALSE otherwise.</p>
-
-            <p class="ednote" style="background-color: #EEE">
-              Finalize when  
-              <a href="https://github.com/w3c/rdf-concepts/issues/154">RDF Concepts issue 154</a>
-              has been resolved.
-            </p>
-
             <p>
-              <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms 
-              if any of the following is true:</p>
+              |term1| and |term2| are 
+              <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality">equal RDF terms</a>
+              if one of the following is true:
+            </p>
             <ul>
-              <li>
-                <span class="name">term1</span> is an <span class="IRI type">IRI</span> 
-                and <span class="name">term2</span> is an <span class="IRI type">IRI</span>
-                such that these two <span class="IRI type">IRIs</span> are equal as per 
-                the notion of <a data-cite="RDF12-CONCEPTS#dfn-iri-equality">IRI equality</a> of
-                [[RDF12-CONCEPTS]].
+              <li><code>term1</code> and <code>term2</code> are 
+                <a data-cite="RDF12-CONCEPTS#iri">IRIs</a> that are 
+                <a data-cite="RDF12-CONCEPTS#dfn-iri-equality">equal as IRIs</a>.
               </li>
-              <li>
-                <span class="name">term1</span> is a <span class="literal type">literal</span> and
-                <span class="name">term2</span> is a <span class="literal type">literal</span> such
-                that these two <span class="literal type">literals</span> are equal as per the
-                notion of
-                <a data-cite="RDF12-CONCEPTS#dfn-literal-term-equality">Literal term equality</a>
-                of [[RDF12-CONCEPTS]].
+              <li><code>term1</code> and <code>term2</code> are 
+                <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a> that are 
+                <a data-cite="RDF12-CONCEPTS#dfn-literal-term-equality">equal as literal terms</a>.
               </li>
-              <li>
-                <span class="name">term1</span> and <span class="name">term2</span> are the same
-                <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>
+              <li><code>term1</code> and <code>term2</code> are 
+                <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank nodes</a> that are 
+                <a data-cite="RDF12-CONCEPTS#dfn-blank-node-equality">equal as blank nodes</a>.
               </li>
-              <li>
-                <span class="name">term1</span> and <span class="name">term2</span> are both
-                <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> and the
+              <li><code>term1</code> and <code>term2</code> are 
+                <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> that are 
+                <a data-cite="RDF12-CONCEPTS#dfn-triple-term-equality">equal as triple terms</a>; that
+                is, the
                 <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a>,
                 <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>, and
-                <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> components are pair-wise the same term.
+                <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> components are pair-wise
+                the same term.
               </li>
             </ul>
-            
             <div class="result">
               <table>
                 <tbody>
@@ -5758,10 +5747,11 @@ class="expression">expression, ....</span>)
             </div>
 
           </section>
-          <section id="func-RDFterm-equal">
-            <h5>RDFterm-equal</h5>
+          <section id="func-sameValue">
+            <span id="func-RDFterm-equal"><!-- obsolete id --></span>
+            <h5>SameValue</h5>
             <pre class="prototype nohighlight">
-              <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">RDFterm-equal</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)
+              <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">sameValue</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)
             </pre>
 
             <p>This function cannot be used directly in expressions. The purpose
@@ -5771,21 +5761,19 @@ class="expression">expression, ....</span>)
               <a href="#OperatorMapping" class="sectionRef"></a>.
             </p>
 
-            <p class="ednote" style="background-color: #EEE">
-              This will be renamed <code>sameValue</code></p>
-
             <ol>
               <li>If one or both arguments are known to be ill-typed, 
                 then produce a type error.
               </li>
-              <li>Returns TRUE if <code>term1</code> and <code>term2</code>
-                are <em>equal</em> RDF terms, as defined below.
+              <li>Returns TRUE if <code>term1</code> and <code>term2</code> are
+                <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality">equal RDF terms</a>.
               </li>
               <li>If the SPARQL processor can determine the values of both terms
                 and it can determine the values are equal, then return TRUE.
               </li>
               <li>If the SPARQL processor can determine that the values of the terms
-                can not be equal, the return FALSE.</li>
+                can not be equal, the return FALSE.
+              </li>
             </ol>
 
             <div class="ednote" style="background-color: #EEE" >
@@ -5842,7 +5830,7 @@ class="expression">expression, ....</span>)
                 of the datatype.
               </p>
               <p>
-                The function `RDFterm-equal` returns true or false in cases where
+                The function `sameValue` returns true or false in cases where
                 the SPARQL processor can determine that the values of the
                 arguments are equal or are not equal. If the SPARQL processor
                 can not be sure, it returns `error`.
@@ -5859,30 +5847,26 @@ class="expression">expression, ....</span>)
                 `sameTerm("NaN"^^xsd:double, "NaN"^^xsd:float)` is `true`.
               </p>
             </div>
+            <div id="sameValue-old-name" class="note">
+              <p>This function was previously called `RDFterm-equal`.</p>
+            </div>
 
             <div class="ednote" style="background-color: #EEE">
               <p>
-              @@ Describe error as extension
-              </p>
-              <p>
-                Possible examples:
-                `sameValue("abc"^^xsd:string, "IV"^^ex:romanNumeral)`
-                <br/>
-                A processor providing only the datatypes required by this spec
-                returns `error` because it can not know that `ex:romanNumeral`
-                is a number.
-              </p>
-              <p>
-                sameValue("32"^^x:meters, "3200"^^x:centimeters)
-              </p>
-              <p>
-                sameValue("abc"^^xsd:integer, "123"^^xsd:integer) -- `error` by (1)
-                argument 1 is
-                <a data-cite="RDF12-CONCEPTS#dfn-ill-typed">ill-typed</a>.
+                A SPARQL processor may support datatypes beyond those required.
+                Suppose `ex:romanNumeral` is the datatype IRI
+                <a href="https://en.wikipedia.org/wiki/Roman_numerals">roman numerals</a>
+                which are integer numbers. The SPARQL processor may then be able
+                to detemine if two literals have the same value, for example,
+                `sameValue(4, "IV"^^ex:romanNumeral)` can then return `true`
+                because argument bot represent the value 4.
+                For `sameValue("abc"^^xsd:string, "IV"^^ex:romanNumeral)`
+                can return `false` because `xsd:string` and `ex:romanNumeral`
+                have different value spaces so the arguments can not be the same value.
               </p>
             </div>
 
-            <p id="func-RDFterm-equal-note1" class="note">
+            <p id="func-sameValue-note1" class="note">
               An extended implementation may support additional datatypes for literals. An
               implementation processing a query that tests for equivalence of literals with non-recognized datatypes
               (and non-identical lexical form and datatype IRI) returns an error, indicating that it
@@ -5897,7 +5881,7 @@ class="expression">expression, ....</span>)
               <table>
                 <tbody>
                   <tr>
-                    <th>RDFterm-equal</th>
+                    <th>sameValue</th>
                     <th>Results</th>
                   </tr>
                   <tr>
@@ -5909,12 +5893,16 @@ class="expression">expression, ....</span>)
                     <td>true</td>
                   </tr>
                   <tr>
-                    <td><code>&nbsp;</code></td>
-                    <td></td>
+                    <td><code>sameValue(2, "2")</code></td>
+                    <td>false</td>
                   </tr>
                   <tr>
                     <td><code>sameValue(4, "iv"^^my:romanNumeral)</code></td>
-                    <td>error or extension</td>
+                    <td>error, or true by extension</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameValue(1e10, "NaN"^^xsd:double)</code></td>
+                    <td>false</td>
                   </tr>
                   <tr>
                     <td><code>sameValue("NaN"^^xsd:double, "NaN"^^xsd:double)</code></td>
@@ -5927,8 +5915,6 @@ class="expression">expression, ....</span>)
                 </tbody>
               </table>
             </div>
-
-
           </section>
 
           <section id="func-isIRI">
@@ -12271,10 +12257,10 @@ _:x rdf:type xsd:decimal .
         <li>
             Editorial changes:
             <ul>
-                <li>Define RDFterm-equal using an actual function signature in <a href="#func-RDFterm-equal" class="sectionRef"></a></li>
+                <li>Give a actual function signature to <a href="#func-sameValue" class="sectionRef"></a></li>
                 <li>Improve wording of blank nodes in <a href="#templatesWithBNodes" class="sectionRef"></a></li>
                 <li>Improve display on mobile</li>
-                <li>Move RDFterm-equal and sameTerm to <a href="#func-rdfTerms" class="sectionRef"></a></li>
+                <li>Move `sameValue` (was `RDFterm-equal`) and `sameTerm` to <a href="#func-rdfTerms" class="sectionRef"></a></li>
                 <li>Add note on deduplication of triples produced by CONSTRUCT to <a href="#construct" class="sectionRef"></a></li>
                 <li>Remove historical notes on rdf:langString datatype from <a href="#func-datatype" class="sectionRef"></a></li>
                 <li>Remove inconsistencies between the definitions of the set functions</li>
@@ -12299,7 +12285,7 @@ _:x rdf:type xsd:decimal .
               <li><a href="https://www.w3.org/2013/sparql-errata#editorial-query-3">editorial-query-3</a>: Incorrect link for DELETE DATA in <a href="#grammarBNodes" class="sectionRef"></a></li>
               <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-1">clarification-query-1</a>: Fix explanation of IN and NOT IN in <a href="#func-in" class="sectionRef"></a> and <a href="#func-not-in" class="sectionRef"></a></li>
               <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-2">clarification-query-2</a>: Remove unneeded reference to the semantics above in <a href="#operatorExtensibility" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-3">clarification-query-3</a>: Rephrase equality definition in <a href="#func-RDFterm-equal" class="sectionRef"></a></li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-3">clarification-query-3</a>: Rephrase equality definition in <a href="#func-sameValue" class="sectionRef"></a></li>
               <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-1">errata-query-1</a>: Let V be an empty set instead of empty multiset in <a href="#defn_evalALP_1">Function ALP definition</a></li>
               <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-2">errata-query-2</a>: Fix grammar of PropertyListPathNotEmpty in <a href="#grammar" class="sectionRef"></a></li>
               <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-4">errata-query-4</a>: Fix CONCAT definition for zero and one argument in <a href="#func-concat" class="sectionRef"></a></li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -5674,15 +5674,30 @@ class="expression">expression, ....</span>)
             <pre class="prototype nohighlight">
               <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">RDFterm-equal</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)
             </pre>
-            <p>This function cannot be used directly in expressions. The purpose of this function is to define the semantics of the "=" operator when applied to two RDF terms that do not fall into any of the other, more concrete cases covered in the operator mapping table in Section&nbsp;<a href="#OperatorMapping" class="sectionRef"></a>.</p>
+
+            <p>This function cannot be used directly in expressions. The purpose
+              of this function is to define the semantics of the "=" operator when applied to
+              two RDF terms that do not fall into any of the other, more concrete cases
+              covered in the operator mapping table in Section
+              <a href="#OperatorMapping" class="sectionRef"></a>.
+            </p>
+
             <p>The function is defined as follows:</p>
             <ul>
-                <li>Returns TRUE if <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms, as defined below.</li>
-                <li>Produces a type error if <code>term1</code> and <code>term2</code> are both literals having the
-              same <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>; this datatype IRI is <em>not</em> in the
-              set of <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>; and the
-              <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical forms</a> of the two literals are different from one another.</li>
+
+                <li>Returns TRUE if <code>term1</code> and <code>term2</code>
+                  are <em>equal</em> RDF terms, as defined below.</li>
+
+                <li>Produces a type error if <code>term1</code> and <code>term2</code> are both
+                  literals having the same 
+                  <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>; 
+                  this datatype IRI is <em>not</em> in the set of
+                  <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>;
+                  and the <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical forms</a> 
+                  of the two literals are different from one another.</li>
+
                 <li>Returns FALSE otherwise.</li>
+
             </ul>
             <p>
               <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms if any of the following is

--- a/spec/index.html
+++ b/spec/index.html
@@ -511,7 +511,8 @@ span.cancast:hover { background-color: #ffa;
               <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
             </li>
             <li>
-              <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
+              <!-- Resolve clash with i18-glossery --> 
+              <a data-cite="RDF12-CONCEPTS#dfn-base-direction" class="lint-ignore">base direction</a> 
             </li>
             <li>
               <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>
@@ -5669,6 +5670,94 @@ class="expression">expression, ....</span>)
         </section>
         <section id="func-rdfTerms">
           <h4>Functions on RDF Terms</h4>
+
+          <section id="func-sameTerm">
+            <h5>sameTerm</h5>
+            <pre class="prototype nohighlight"> <span class="return">xsd:boolean</span>  <span class="operator">sameTerm</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)</pre>
+            <p>Returns TRUE if <code>term1</code> and <code>term2</code> are the same RDF term as
+              defined in [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]; returns FALSE otherwise.</p>
+
+            <p class="ednote" style="background-color: #EEE">
+              Finalize when  
+              <a href="https://github.com/w3c/rdf-concepts/issues/154">RDF Concepts issue 154</a>
+              has been resolved.
+            </p>
+
+            <p>
+              <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms 
+              if any of the following is true:</p>
+            <ul>
+              <li>
+                <span class="name">term1</span> is an <span class="IRI type">IRI</span> 
+                and <span class="name">term2</span> is an <span class="IRI type">IRI</span>
+                such that these two <span class="IRI type">IRIs</span> are equal as per 
+                the notion of <a data-cite="RDF12-CONCEPTS#dfn-iri-equality">IRI equality</a> of
+                [[RDF12-CONCEPTS]].
+              </li>
+              <li>
+                <span class="name">term1</span> is a <span class="literal type">literal</span> and
+                <span class="name">term2</span> is a <span class="literal type">literal</span> such
+                that these two <span class="literal type">literals</span> are equal as per the
+                notion of
+                <a data-cite="RDF12-CONCEPTS#dfn-literal-term-equality">Literal term equality</a>
+                of [[RDF12-CONCEPTS]].
+              </li>
+              <li>
+                <span class="name">term1</span> and <span class="name">term2</span> are the same
+                <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>
+              </li>
+              <li>
+                <span class="name">term1</span> and <span class="name">term2</span> are both
+                <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> and the
+                <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a>,
+                <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>, and
+                <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> components are pair-wise the same term.
+              </li>
+            </ul>
+            
+            <div class="result">
+              <table>
+                <tbody>
+                  <tr>
+                    <td><code>sameTerm(&lt;http://example/&gt;, &lt;http://example/&gt;)</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameTerm(&lt;http://example/&gt;, &lt;https://example/&gt;)</code></td>
+                    <td>false</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameTerm("abc", "abc")</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameTerm("abc"@en, "abc")</code></td>
+                    <td>false</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameTerm("abc"@en, "abc"@EN)</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameTerm("abc"@en--rtl, "abc"@en)</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameTerm(2, 2.0)</code></td>
+                    <td>false</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameTerm(2, "2"^^xsd:integer)</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameTerm(2, "02"^^xsd:integer)</code></td>
+                    <td>false</td>
+                  </tr>
+              </table>
+            </div>
+
+          </section>
           <section id="func-RDFterm-equal">
             <h5>RDFterm-equal</h5>
             <pre class="prototype nohighlight">
@@ -5682,51 +5771,117 @@ class="expression">expression, ....</span>)
               <a href="#OperatorMapping" class="sectionRef"></a>.
             </p>
 
-            <p>The function is defined as follows:</p>
-            <ul>
+            <p class="ednote" style="background-color: #EEE">
+              This will be renamed <code>sameValue</code></p>
 
-                <li>Returns TRUE if <code>term1</code> and <code>term2</code>
-                  are <em>equal</em> RDF terms, as defined below.</li>
+            <ol>
+              <li>If one or both arguments are known to be ill-typed, 
+                then produce a type error.
+              </li>
+              <li>Returns TRUE if <code>term1</code> and <code>term2</code>
+                are <em>equal</em> RDF terms, as defined below.
+              </li>
+              <li>If the SPARQL processor can determine the values of both terms
+                and it can determine the values are equal, then return TRUE.
+              </li>
+              <li>If the SPARQL processor can determine that the values of the terms
+                can not be equal, the return FALSE.</li>
+            </ol>
 
-                <li>Produces a type error if <code>term1</code> and <code>term2</code> are both
-                  literals having the same 
-                  <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>; 
-                  this datatype IRI is <em>not</em> in the set of
-                  <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>;
-                  and the <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical forms</a> 
-                  of the two literals are different from one another.</li>
+            <div class="ednote" style="background-color: #EEE" >
+              <p>If the function is to become callable as 
+                <em>`sameValue(term1, term2)`</em>, add a rule 
+                that if there is an
+                <a href="#OperatorMapping">operation mapping</a> for "="
+                for the arguments, an implementation MUST return the same boolean value
+                from <em>`sameValue(term1, term2)`</em>.
+              </p>
+            </div>
+            <div class="ednote" style="background-color: #EEE" >
+              <p>
+                The treatment of `NaN` can not be consistent with both "same term means same value" 
+                and "`fn:numeric-equal(NaN, NaN)` is false". So it is an arbitrary choice with
+                arguments for all three possible choices.
+                For pattern matching, `"NaN"^^xsd:double` must match itself and
+                `"NaN"^^xsd:double` does not pattern match `"NaN"^^xsd:float`.
+              </p>
+              <p>
+                The operator mapping for `=` goes to `fn:numeric-compare` which is false.
+                The `sameValue` result could be made an error (or false) as a special case.
+              </p>
+              <p>
+                `"NaN"^^xsd:double = "NaN"^^xsd:float` is also handled by the
+                operator mapping and is false &ndash; `xsd:float` is promoted to `xsd:double`.
+                A reading of IEEE 754 is that `"NaN"^^xsd:double` and `"NaN"^^xsd:float`
+                are the same term also suggests that `sameValue` is true.
+              </p>
+              <p>
+                <b>Proposal 1</b>: follow "sameTerm means sameValue" and `sameValue("NaN"^^xsd:double, "NaN"^^xsd:double)`
+                and `sameValue("NaN"^^xsd:float, "NaN"^^xsd:float)` are <i>true</i>s.
+                <br/>
+                <b>Proposal 2</b>: 
+                follow "there is one NaN" so `sameValue("NaN"^^xsd:double, "NaN"^^xsd:float)` is <i>true</i>.
+              </p>
+              <p>
+                Ref</i>: <a href="https://www.w3.org/TR/xmlschema11-2/#dt-specialvalue">XSD schema 1.1 special values</a>
+                "are members of the datatype's ·value space·. ". It is not clear whether "special value" literals
+                added to the value spaces of `xsd:double` and `xsd:float` are "the same" literals.
+              <p>
+                <i>Ref</i>: <a href="https://en.wikipedia.org/wiki/IEEE_754#Special_values">(wikipedia) IEEE_754 Special Values</a>
+                <i>IEEE 754 specifies a special value called "Not a Number" (NaN)</i>.
+                suggests they are the same.
+                </p>
+            </div>
 
-                <li>Returns FALSE otherwise.</li>
+            <div id="sameValue-ill-typed" class="note">
+              <p>A literal is 
+                <a data-cite="RDF12-CONCEPTS#dfn-ill-typed">ill-typed</a>
+                if the datatype is one handled by the SPARQL processor and
+                the lexical form is not in
+                <a data-cite="RDF12-CONCEPTS#dfn-lexical-space">the lexical space</a>
+                of the datatype.
+              </p>
+              <p>
+                The function `RDFterm-equal` returns true or false in cases where
+                the SPARQL processor can determine that the values of the
+                arguments are equal or are not equal. If the SPARQL processor
+                can not be sure, it returns `error`.
+              </p>
+            </div>
+            <div id="sameValue-NaN" class="note">
+              <p>
+                The <a href="#OperatorMapping">Operator Mapping</a> for "`=`""
+                is the function
+                <a data-cite="XPATH-FUNCTIONS-31#func-numeric-equal">fn:numeric-equal`</a>
+                which returns `false` when comparing arguments involving `NaN`.
+                However, `sameTerm("NaN"^^xsd:double, "NaN"^^xsd:double)` is true;
+                `sameValue` treats "NaN" as the "same value".
+                `sameTerm("NaN"^^xsd:double, "NaN"^^xsd:float)` is `true`.
+              </p>
+            </div>
 
-            </ul>
-            <p>
-              <code>term1</code> and <code>term2</code> are <em>equal</em> RDF terms if any of the following is
-              true:</p>
-            <ul>
-              <li>
-                <span class="name">term1</span> is an <span class="IRI type">IRI</span> and <span class="name">term2</span> is an <span class="IRI type">IRI</span>
-                such that these two <span class="IRI type">IRIs</span> are equal as per the notion of <a data-cite="RDF12-CONCEPTS#dfn-iri-equality">IRI equality</a> of
-                [[RDF12-CONCEPTS]].
-              </li>
-              <li>
-                <span class="name">term1</span> is a <span class="literal type">literal</span> and
-                <span class="name">term2</span> is a <span class="literal type">literal</span> such that
-                these two <span class="literal type">literals</span> are equal as per the notion of <a data-cite="RDF12-CONCEPTS#dfn-literal-term-equality">Literal term equality</a> of
-                [[RDF12-CONCEPTS]].
-              </li>
-              <li>
-                <span class="name">term1</span> is a <span class="literal type">literal</span> and
-                <span class="name">term2</span> is a <span class="literal type">literal</span>
-                such that the <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>
-                of each of these two literals is in the set of
-                <a data-cite="RDF12-CONCEPTS#dfn-recognized-datatype-iri">recognized datatype IRIs</a>
-                and both literals have the same <a data-cite="RDF12-CONCEPTS#dfn-literal-value">literal value</a>.
-              </li>
-              <li>
-                <span class="name">term1</span> and <span class="name">term2</span> are the same
-                <span class="bnode type">blank node</span>.
-              </li>
-            </ul>
+            <div class="ednote" style="background-color: #EEE">
+              <p>
+              @@ Describe error as extension
+              </p>
+              <p>
+                Possible examples:
+                `sameValue("abc"^^xsd:string, "IV"^^ex:romanNumeral)`
+                <br/>
+                A processor providing only the datatypes required by this spec
+                returns `error` because it can not know that `ex:romanNumeral`
+                is a number.
+              </p>
+              <p>
+                sameValue("32"^^x:meters, "3200"^^x:centimeters)
+              </p>
+              <p>
+                sameValue("abc"^^xsd:integer, "123"^^xsd:integer) -- `error` by (1)
+                argument 1 is
+                <a data-cite="RDF12-CONCEPTS#dfn-ill-typed">ill-typed</a>.
+              </p>
+            </div>
+
             <p id="func-RDFterm-equal-note1" class="note">
               An extended implementation may support additional datatypes for literals. An
               implementation processing a query that tests for equivalence of literals with non-recognized datatypes
@@ -5734,198 +5889,48 @@ class="expression">expression, ....</span>)
               is unable to determine whether or not the values of the compared literals are equivalent. For example, an
               unextended implementation will produce an error when testing either <span class="queryExcerpt"><code>"iiii"^^my:romanNumeral =
                   "iv"^^my:romanNumeral</code></span> or <span class="queryExcerpt"><code>"iiii"^^my:romanNumeral !=
-                  "iv"^^my:romanNumeral</code></span>.</p>
-            <div class="exampleGroup">
-              <pre class="data nohighlight">
-PREFIX foaf:       &lt;http://xmlns.com/foaf/0.1/&gt;
+                  "iv"^^my:romanNumeral</code></span>.
+            </p>
 
-_:a  foaf:name       "Alice".
-_:a  foaf:mbox       &lt;mailto:alice@work.example&gt; .
-
-_:b  foaf:name       "Ms A.".
-_:b  foaf:mbox       &lt;mailto:alice@work.example&gt; .
-              </pre>
-              <div class="queryGroup">
-                <p>This query finds the people who have multiple <code>foaf:name</code> triples:</p>
-                <pre class="query nohighlight">
-PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
-SELECT ?name1 ?name2
-WHERE {
-    ?x foaf:name  ?name1 ;
-       foaf:mbox  ?mbox1 .
-    ?y foaf:name  ?name2 ;
-       foaf:mbox  ?mbox2 .
-    FILTER (?mbox1 = ?mbox2 &amp;& ?name1 != ?name2)
-}</pre>
-                <p>Query result:</p>
-                <div class="result">
-                  <table class="resultTable">
-                    <tbody>
-                      <tr>
-                        <th>name1</th>
-                        <th>name2</th>
-                      </tr>
-                      <tr>
-                        <td>"Alice"</td>
-                        <td>"Ms A."</td>
-                      </tr>
-                      <tr>
-                        <td>"Ms A."</td>
-                        <td>"Alice"</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
+            <p>Examples:</p>
+            <div class="result">
+              <table>
+                <tbody>
+                  <tr>
+                    <th>RDFterm-equal</th>
+                    <th>Results</th>
+                  </tr>
+                  <tr>
+                    <td><code>sameValue(2, +2)</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameValue(2.0, 2)</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>&nbsp;</code></td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td><code>sameValue(4, "iv"^^my:romanNumeral)</code></td>
+                    <td>error or extension</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameValue("NaN"^^xsd:double, "NaN"^^xsd:double)</code></td>
+                    <td>true</td>
+                  </tr>
+                  <tr>
+                    <td><code>sameValue("NaN"^^xsd:double, "NaN"^^xsd:float)</code></td>
+                    <td>true</td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
-            <p>In this query for documents that were annotated at a specific date and time (New
-              Year's Day 2005, measures in timezone +00:00), the RDF terms are not the same, but have
-              equivalent values according to their datatype:</p>
-            <div class="exampleGroup">
-              <pre class="data nohighlight">
-PREFIX a:          &lt;http://www.w3.org/2000/10/annotation-ns#&gt;
-PREFIX dc:         &lt;http://purl.org/dc/elements/1.1/&gt;
 
-_:b   a:annotates   &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
-_:b   dc:date       "2004-12-31T19:00:00-05:00"^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; .</pre>
-              <div class="queryGroup">
-                <pre class="query nohighlight">
-PREFIX a:      &lt;http://www.w3.org/2000/10/annotation-ns#&gt;
-PREFIX dc:     &lt;http://purl.org/dc/elements/1.1/&gt;
-PREFIX xsd:    &lt;http://www.w3.org/2001/XMLSchema#&gt;
 
-SELECT ?annotates
-WHERE {
-    ?annot  a:annotates  ?annotates .
-    ?annot  dc:date      ?date .
-    FILTER ( ?date = xsd:dateTime("2005-01-01T00:00:00Z") ) 
-}
-                </pre>
-                <div class="result">
-                  <table class="resultTable">
-                    <tbody>
-                      <tr>
-                        <th>annotates</th>
-                      </tr>
-                      <tr>
-                        <td>&lt;http://www.w3.org/TR/rdf-sparql-query/&gt;</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
           </section>
-          <section id="func-sameTerm">
-            <h5>sameTerm</h5>
-            <pre class="prototype nohighlight"> <span class="return">xsd:boolean</span>  <span class="operator">sameTerm</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)</pre>
-            <p>Returns TRUE if <code>term1</code> and <code>term2</code> are the same RDF term as
-              defined in [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]; returns FALSE otherwise.</p>
-            <div class="exampleGroup">
-              <pre class="data nohighlight">
-PREFIX foaf:       &lt;http://xmlns.com/foaf/0.1/&gt;
 
-_:a  foaf:name       "Alice".
-_:a  foaf:mbox       &lt;mailto:alice@work.example&gt; .
-
-_:b  foaf:name       "Ms A.".
-_:b  foaf:mbox       &lt;mailto:alice@work.example&gt; .
-              </pre>
-              <div class="queryGroup">
-                <p>This query finds the people who have multiple <code>foaf:name</code> triples:</p>
-                <pre class="query nohighlight">
-PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
-SELECT ?name1 ?name2
-WHERE {
-    ?x foaf:name  ?name1 ;
-       foaf:mbox  ?mbox1 .
-    ?y foaf:name  ?name2 ;
-       foaf:mbox  ?mbox2 .
-    FILTER (sameTerm(?mbox1, ?mbox2) &amp;& !sameTerm(?name1, ?name2))
-}
-                </pre>
-                <p>Query result:</p>
-                <div class="result">
-                  <table class="resultTable">
-                    <tbody>
-                      <tr>
-                        <th>name1</th>
-                        <th>name2</th>
-                      </tr>
-                      <tr>
-                        <td>"Alice"</td>
-                        <td>"Ms A."</td>
-                      </tr>
-                      <tr>
-                        <td>"Ms A."</td>
-                        <td>"Alice"</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
-            <p>Unlike <span class="operator">RDFterm-equal</span>, <span class="operator">sameTerm</span> can be used to test for non-equivalent <span class="type typedLiteral">typed literals</span> with unsupported datatypes:</p>
-            <div class="exampleGroup">
-              <pre class="data nohighlight">
-PREFIX :          &lt;http://example.org/WMterms#&gt;
-PREFIX t:         &lt;http://example.org/types#&gt;
-
-_:c1  :label        "Container 1" .
-_:c1  :weight       "100"^^t:kilos .
-_:c1  :displacement  "100"^^t:liters .
-
-_:c2  :label        "Container 2" .
-_:c2  :weight       "100"^^t:kilos .
-_:c2  :displacement  "85"^^t:liters .
-
-_:c3  :label        "Container 3" .
-_:c3  :weight       "85"^^t:kilos .
-_:c3  :displacement  "85"^^t:liters .
-              </pre>
-              <div class="queryGroup">
-                <pre class="query nohighlight">
-PREFIX  :      &lt;http://example.org/WMterms#&gt;
-PREFIX  t:     &lt;http://example.org/types#&gt;
-
-SELECT ?aLabel1 ?bLabel
-WHERE { 
-   ?a  :label        ?aLabel .
-   ?a  :weight       ?aWeight .
-   ?a  :displacement ?aDisp .
-
-   ?b  :label        ?bLabel .
-   ?b  :weight       ?bWeight .
-   ?b  :displacement ?bDisp .
-
-   FILTER ( sameTerm(?aWeight, ?bWeight) &amp;& !sameTerm(?aDisp, ?bDisp)) 
-}
-                </pre>
-                <div class="result">
-                  <table class="resultTable">
-                    <tbody>
-                      <tr>
-                        <th>aLabel</th>
-                        <th>bLabel</th>
-                      </tr>
-                      <tr>
-                        <td>"Container 1"</td>
-                        <td>"Container 2"</td>
-                      </tr>
-                      <tr>
-                        <td>"Container 2"</td>
-                        <td>"Container 1"</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
-            <p>The test for boxes with the same weight may also be done with the '=' operator
-              (<a href="#func-RDFterm-equal" class="SPARQLoperator">RDFterm-equal</a>) as the test for
-              <code>"100"^^t:kilos = "85"^^t:kilos</code> will result in an error, eliminating that
-              potential solution.</p>
-          </section>
           <section id="func-isIRI">
             <h5>isIRI</h5>
             <pre class="prototype nohighlight">
@@ -5978,6 +5983,7 @@ WHERE {
               </div>
             </div>
           </section>
+
           <section id="func-isBlank">
             <h5>isBLANK</h5>
             <pre class="prototype nohighlight"> <span class="return">xsd:boolean</span>  <span class="operator">isBLANK</span> (<span class="type"><span class="type">RDF term</span></span> <span class="name">term</span>)</pre>
@@ -7227,12 +7233,12 @@ WHERE {
               <a data-cite="XPATH-FUNCTIONS-31#func-concat">fn:concat</a> function.
               If all input literals are literals with the same 
               <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
-              and same <a>base direction</a>
+              and same <a class="lint-ignore">base direction</a>
               then the returned string literal is a literal with that language
               tag and base direction.
               If  all input literals are literals with the same 
               <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>,
-              but not all the same <a>base direction</a>,
+              but not all the same <a class="lint-ignore">base direction</a>,
               the returned literal is a literal with that language tag and no
               base direction.
             </p>
@@ -12255,7 +12261,7 @@ _:x rdf:type xsd:decimal .
                   <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>:
                   `LANGDIR`, `hasLANG`, hasLANGDIR, and `STRLANGDIR`</li>
                 <li>Define parser input as being an 
-                  <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF string</a>. 
+                  <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a>. 
                   Exclude Unicode surrogates from Unicode escape sequences.</li>
                 <li>Remove concepts of plain and simple literals, in favor of explicit mentions of `xsd:string`</li>
                 <li>Migrate XML Schema references to 1.1</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -5672,19 +5672,19 @@ class="expression">expression, ....</span>)
           <h4>Functions on RDF Terms</h4>
 
           <section id="func-sameTerm">
-            <h5>SameTerm</h5>
+            <h5>sameTerm</h5>
             <pre class="prototype nohighlight"> <span class="return">xsd:boolean</span>  <span class="operator">sameTerm</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)</pre>
             <p>Returns TRUE if <code>term1</code> and <code>term2</code> are the same RDF term as
               defined in [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]; returns FALSE otherwise.</p>
             <p>
-              |term1| and |term2| are 
-              <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality">equal RDF terms</a>
+              |term1| and |term2| are the
+              <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality">same RDF terms</a>
               if one of the following is true:
             </p>
             <ul>
               <li><code>term1</code> and <code>term2</code> are 
-                <a data-cite="RDF12-CONCEPTS#iri">IRIs</a> that are 
-                <a data-cite="RDF12-CONCEPTS#dfn-iri-equality">equal as IRIs</a>.
+                <a data-cite="RDF12-CONCEPTS#iri">IRIs</a> that are the
+                <a data-cite="RDF12-CONCEPTS#dfn-iri-equality">same as IRIs</a>.
               </li>
               <li><code>term1</code> and <code>term2</code> are 
                 <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a> that are 
@@ -5729,7 +5729,7 @@ class="expression">expression, ....</span>)
                   </tr>
                   <tr>
                     <td><code>sameTerm("abc"@en--rtl, "abc"@en)</code></td>
-                    <td>true</td>
+                    <td>false</td>
                   </tr>
                   <tr>
                     <td><code>sameTerm(2, 2.0)</code></td>
@@ -5749,7 +5749,7 @@ class="expression">expression, ....</span>)
           </section>
           <section id="func-sameValue">
             <span id="func-RDFterm-equal"><!-- obsolete id --></span>
-            <h5>SameValue</h5>
+            <h5>sameValue</h5>
             <pre class="prototype nohighlight">
               <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">sameValue</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)
             </pre>
@@ -5761,31 +5761,37 @@ class="expression">expression, ....</span>)
               <a href="#OperatorMapping" class="sectionRef"></a>.
             </p>
 
+            <p class="ednote" style="background-color: #EEE">
+              Revise for triple terms.
+              <br/>
+              Consider adding non-literal `=` to operator mapping table.
+            </p>
+
+            <p>The result of this function is determined by going through the following steps.</p>
             <ol>
-              <li>If one or both arguments are known to be ill-typed, 
+              <li>If <code>term1</code> and <code>term2</code> are
+                <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality">equal RDF terms</a>,
+                the return TRUE.
+              </li>
+              <li>If both arguments are literals,
+                <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>
+                and one or both arguments are known to be ill-typed, 
                 then produce a type error.
               </li>
-              <li>Returns TRUE if <code>term1</code> and <code>term2</code> are
-                <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality">equal RDF terms</a>.
+              <li>If <code>term1</code> and <code>term2</code> both 
+                <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>
+                and the SPARQL processor can determine the values are equal,
+                then return TRUE.
               </li>
-              <li>If the SPARQL processor can determine the values of both terms
-                and it can determine the values are equal, then return TRUE.
+              <li>If <code>term1</code> and <code>term2</code> both 
+                <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>
+                and the SPARQL processor can determine the values can not be equal,
+                then return FALSE.
               </li>
-              <li>If the SPARQL processor can determine that the values of the terms
-                can not be equal, the return FALSE.
+              <li>Otherwise, return FALSE.
               </li>
             </ol>
-
-            <div class="ednote" style="background-color: #EEE" >
-              <p>If the function is to become callable as 
-                <em>`sameValue(term1, term2)`</em>, add a rule 
-                that if there is an
-                <a href="#OperatorMapping">operation mapping</a> for "="
-                for the arguments, an implementation MUST return the same boolean value
-                from <em>`sameValue(term1, term2)`</em>.
-              </p>
-            </div>
-            <div class="ednote" style="background-color: #EEE" >
+            <div class="ednote" style="background-color: #EEE">
               <p>
                 The treatment of `NaN` can not be consistent with both "same term means same value" 
                 and "`fn:numeric-equal(NaN, NaN)` is false". So it is an arbitrary choice with
@@ -5824,23 +5830,23 @@ class="expression">expression, ....</span>)
             <div id="sameValue-ill-typed" class="note">
               <p>A literal is 
                 <a data-cite="RDF12-CONCEPTS#dfn-ill-typed">ill-typed</a>
-                if the datatype is one handled by the SPARQL processor and
-                the lexical form is not in
-                <a data-cite="RDF12-CONCEPTS#dfn-lexical-space">the lexical space</a>
+                if its datatype is handled by the SPARQL processor and
+                its lexical form is not in the
+                <a data-cite="RDF12-CONCEPTS#dfn-lexical-space">lexical space</a>
                 of the datatype.
               </p>
               <p>
-                The function `sameValue` returns true or false in cases where
-                the SPARQL processor can determine that the values of the
-                arguments are equal or are not equal. If the SPARQL processor
-                can not be sure, it returns `error`.
+                If the two arguments are literals, the function `sameValue` 
+                returns `true` or `false` in cases where the SPARQL processor
+                can determine that the values of these literals are equal or are not equal. 
+                If the SPARQL processor can not be sure, it returns `error`.
               </p>
             </div>
             <div id="sameValue-NaN" class="note">
               <p>
-                The <a href="#OperatorMapping">Operator Mapping</a> for "`=`""
+                The <a href="#OperatorMapping">Operator Mapping</a> for "`=`"
                 is the function
-                <a data-cite="XPATH-FUNCTIONS-31#func-numeric-equal">fn:numeric-equal`</a>
+                <a data-cite="XPATH-FUNCTIONS-31#func-numeric-equal">`fn:numeric-equal`</a>
                 which returns `false` when comparing arguments involving `NaN`.
                 However, `sameTerm("NaN"^^xsd:double, "NaN"^^xsd:double)` is true;
                 `sameValue` treats "NaN" as the "same value".
@@ -12257,7 +12263,7 @@ _:x rdf:type xsd:decimal .
         <li>
             Editorial changes:
             <ul>
-                <li>Give a actual function signature to <a href="#func-sameValue" class="sectionRef"></a></li>
+                <li>Give an actual function signature to <a href="#func-sameValue" class="sectionRef"></a></li>
                 <li>Improve wording of blank nodes in <a href="#templatesWithBNodes" class="sectionRef"></a></li>
                 <li>Improve display on mobile</li>
                 <li>Move `sameValue` (was `RDFterm-equal`) and `sameTerm` to <a href="#func-rdfTerms" class="sectionRef"></a></li>


### PR DESCRIPTION
This closes #187.
This closes #25.

Changes:
* Rename `RDFterm-equal` as `sameValue`
* Reorder `sameTerm`, `sameValue`
* Reword `sameValue` (see #187)
* Bring definition/description of RDF term equality up-to-date - see related issue w3c/rdf-concepts#154
* Replace examples


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/194.html" title="Last updated on Apr 4, 2025, 2:02 PM UTC (0391ac4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/194/1dabcb9...0391ac4.html" title="Last updated on Apr 4, 2025, 2:02 PM UTC (0391ac4)">Diff</a>