### PR TITLE
Renames 'RDFterm-equal' to 'sameValue'

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -5280,7 +5280,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
               <td><span class="type RDFterm">RDF term</span></td>
               <td><span class="type RDFterm">RDF term</span></td>
               <td class="xpathOp">
-                <a href="#func-RDFterm-equal" class="SPARQLoperator">RDFterm-equal</a>(A, B)
+                <a href="#func-sameValue" class="SPARQLoperator">sameValue</a>(A, B)
               </td>
               <td>xsd:boolean</td>
             </tr>
@@ -5291,7 +5291,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
               <td><span class="type RDFterm">RDF term</span></td>
               <td><span class="type RDFterm">RDF term</span></td>
               <td class="xpathOp">
-                <a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>(<a href="#func-RDFterm-equal" class="SPARQLoperator">RDFterm-equal</a>(A, B))
+                <a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>(<a href="#func-sameValue" class="SPARQLoperator">sameValue</a>(A, B))
               </td>
               <td>xsd:boolean</td>
             </tr>
@@ -5669,10 +5669,11 @@ class="expression">expression, ....</span>)
         </section>
         <section id="func-rdfTerms">
           <h4>Functions on RDF Terms</h4>
-          <section id="func-RDFterm-equal">
-            <h5>RDFterm-equal</h5>
+          <section id="func-sameValue">
+            <span id="#func-RDFterm-equal"><!-- obsolete term --></span>
+            <h5>sameValue</h5>
             <pre class="prototype nohighlight">
-              <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">RDFterm-equal</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)
+              <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">sameValue</span> (<span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term1</span>, <span class="type"><span class="type RDFterm">RDF term</span></span> <span class="name">term2</span>)
             </pre>
             <p>This function cannot be used directly in expressions. The purpose of this function is to define the semantics of the "=" operator when applied to two RDF terms that do not fall into any of the other, more concrete cases covered in the operator mapping table in Section&nbsp;<a href="#OperatorMapping" class="sectionRef"></a>.</p>
             <p>The function is defined as follows:</p>
@@ -5712,7 +5713,7 @@ class="expression">expression, ....</span>)
                 <span class="bnode type">blank node</span>.
               </li>
             </ul>
-            <p id="func-RDFterm-equal-note1" class="note">
+            <p id="func-sameValue-note1" class="note">
               An extended implementation may support additional datatypes for literals. An
               implementation processing a query that tests for equivalence of literals with non-recognized datatypes
               (and non-identical lexical form and datatype IRI) returns an error, indicating that it
@@ -5850,7 +5851,8 @@ WHERE {
                 </div>
               </div>
             </div>
-            <p>Unlike <span class="operator">RDFterm-equal</span>, <span class="operator">sameTerm</span> can be used to test for non-equivalent <span class="type typedLiteral">typed literals</span> with unsupported datatypes:</p>
+            <p>Unlike <a href="#func-sameValue" class="operator">sameValue</a>,
+              <span class="operator">sameTerm</span> can be used to test for non-equivalent <span class="type typedLiteral">typed literals</span> with unsupported datatypes:</p>
             <div class="exampleGroup">
               <pre class="data nohighlight">
 PREFIX :          &lt;http://example.org/WMterms#&gt;
@@ -5907,7 +5909,7 @@ WHERE {
               </div>
             </div>
             <p>The test for boxes with the same weight may also be done with the '=' operator
-              (<a href="#func-RDFterm-equal" class="SPARQLoperator">RDFterm-equal</a>) as the test for
+              (<a href="#func-sameValue" class="SPARQLoperator">sameValue</a>) as the test for
               <code>"100"^^t:kilos = "85"^^t:kilos</code> will result in an error, eliminating that
               potential solution.</p>
           </section>
@@ -12250,10 +12252,10 @@ _:x rdf:type xsd:decimal .
         <li>
             Editorial changes:
             <ul>
-                <li>Define RDFterm-equal using an actual function signature in <a href="#func-RDFterm-equal" class="sectionRef"></a></li>
+                <li>Rename RDFterm-equal to sameValue and define it using an actual function signature in <a href="#func-sameValue" class="sectionRef"></a></li>
                 <li>Improve wording of blank nodes in <a href="#templatesWithBNodes" class="sectionRef"></a></li>
                 <li>Improve display on mobile</li>
-                <li>Move RDFterm-equal and sameTerm to <a href="#func-rdfTerms" class="sectionRef"></a></li>
+                <li>Move sameValue (earlier RDFterm-equal) and sameTerm to <a href="#func-rdfTerms" class="sectionRef"></a></li>
                 <li>Add note on deduplication of triples produced by CONSTRUCT to <a href="#construct" class="sectionRef"></a></li>
                 <li>Remove historical notes on rdf:langString datatype from <a href="#func-datatype" class="sectionRef"></a></li>
                 <li>Remove inconsistencies between the definitions of the set functions</li>
@@ -12278,7 +12280,7 @@ _:x rdf:type xsd:decimal .
               <li><a href="https://www.w3.org/2013/sparql-errata#editorial-query-3">editorial-query-3</a>: Incorrect link for DELETE DATA in <a href="#grammarBNodes" class="sectionRef"></a></li>
               <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-1">clarification-query-1</a>: Fix explanation of IN and NOT IN in <a href="#func-in" class="sectionRef"></a> and <a href="#func-not-in" class="sectionRef"></a></li>
               <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-2">clarification-query-2</a>: Remove unneeded reference to the semantics above in <a href="#operatorExtensibility" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-3">clarification-query-3</a>: Rephrase equality definition in <a href="#func-RDFterm-equal" class="sectionRef"></a></li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-3">clarification-query-3</a>: Rephrase equality definition in <a href="#func-sameValue" class="sectionRef"></a> (which used to be RDFterm-equal)</li>
               <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-1">errata-query-1</a>: Let V be an empty set instead of empty multiset in <a href="#defn_evalALP_1">Function ALP definition</a></li>
               <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-2">errata-query-2</a>: Fix grammar of PropertyListPathNotEmpty in <a href="#grammar" class="sectionRef"></a></li>
               <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-4">errata-query-4</a>: Fix CONCAT definition for zero and one argument in <a href="#func-concat" class="sectionRef"></a></li>


### PR DESCRIPTION
As discussed in #25, renames the `RDFterm-equal` function to `sameValue`. Also, [as suggested](https://github.com/w3c/sparql-query/issues/25#issuecomment-2610386674) by @afs, this PR adds a legacy anchor (with an HTML comment that this is anchor is obsolete now, as done for similar cases in RDF-Concepts)

For the sake of keeping this PR small and focused, it does *not* include any changes to the definition of the renamed function (as are currently discussed in #187, and also related to #182).

Closes #25


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/197.html" title="Last updated on Feb 18, 2025, 2:08 PM UTC (73f6d08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/197/1dabcb9...73f6d08.html" title="Last updated on Feb 18, 2025, 2:08 PM UTC (73f6d08)">Diff</a>