### PR TITLE
Consider bnode graph names in evaluation of Graph

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -10373,7 +10373,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
                 where <var>Ω</var> is the multiset of solution mappings produced by the following algorithm:
                 <pre class="code nohighlight" style="font-family: sans-serif;">
 <var>Ω</var> := the empty multiset
-foreach <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a> <var>gn</var> in <var>D</var>
+foreach <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a> <var>gn</var> in <var>D</var> (recall that a graph name may be an IRI or a blank node)
     <var>G'</var> := the RDF graph of the named graph with name <var>gn</var> in <var>D</var>
     <var>Ω'</var> := <a href="#defn_eval" class="evalFct">eval</a>( <var>D</var>(<var>G'</var>), <var>P</var> )
     <var>Ω</var> := <a href="#defn_algUnion" class="algFct">Union</a>( <var>Ω</var>, <a href="#defn_algJoin" class="algFct">Join</a>(<var>Ω'</var>, <var>μ</var>) ), where <var>μ</var> = {<var>x</var> → <var>gn</var>}

--- a/spec/index.html
+++ b/spec/index.html
@@ -107,6 +107,7 @@ pre.prototype	{ background-color:#f7f8ff;
 div.defn p	{ margin-top: 1ex ; margin-bottom: 1.5ex ;}
 div.defn ul	{ margin-top: 1ex ; margin-bottom: 1.5ex ; }
 span.definedTerm	{font-weight: bold;}
+div.indentedFormula { margin-left: 5ex ; margin-top: 2mm ; margin-bottom: 2mm ; }
 
 div.grammarExtract
                 { border: thin solid #888888;
@@ -9448,8 +9449,6 @@ The set PV is used later for projection.
         <p>Write <var>Ω<sub>0</sub></var> for the multiset consisting of exactly the empty mapping
           <var>μ<sub>0</sub></var>, with multiplicity 1. This is the join identity.</p>
         <p>Write <var>μ</var>(<var>x</var>) for the solution mapping variable <var>x</var> to RDF term <var>t</var> : { (<var>x</var>, <var>t</var>) }.</p>
-        <p>Write <var>Ω</var>(<var>x</var>) for the multiset consisting of exactly <var>μ</var>(<var>?x</var>-&gt;<var>t</var>), that is, <code>{ { (x, t) } }</code>
-          with multiplicity 1.</p>
         <div class="defn">
           <p><b>Definition: <span id="defn_algCompatibleMapping">Compatible Mappings</span></b></p>
           <p>Two solution mappings μ<sub>1</sub> and μ<sub>2</sub> are compatible if, for every
@@ -10288,9 +10287,8 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           <h3>Evaluation Semantics</h3>
           <p id="defn_eval">We define <a href="#defn_eval" class="evalFct">eval</a>(|D|(|G|), |A|) as the evaluation of an algebra expression |A| with
             respect to a <a href="#sparqlDataset">dataset</a> |D| having <a href="#defn_ActiveGraph">active graph</a> |G|. The active graph is initially the default
-            graph of |D|. Further symbols and notation used in the following definitions are:</p>
+            graph of |D|. Further symbols used in the following definitions are:</p>
           <ul>
-            <li>|D|[|i|] : Denotes the graph with IRI |i| in dataset |D|</li>
             <li>|P|, <var>P<sub>1</sub></var>, <var>P<sub>2</sub></var> : graph patterns</li>
             <li>|L| : a solution sequence</li>
             <li>|F| : an expression</li>
@@ -10344,25 +10342,46 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
           </div>
           <div class="defn">
             <p><b>Definition: <span id="defn_evalGraph">Evaluation of Graph</span></b></p>
-            <pre class="code nohighlight">
-if <var>IRI</var> is a graph name in <var>D</var>
-    <a href="#defn_eval" class="evalFct">eval</a>( <var>D</var>(<var>G</var>), Graph(<var>IRI</var>,<var>P</var>) ) = <a href="#defn_eval" class="evalFct">eval</a>( <var>D</var>(<var>D</var>[<var>IRI</var>]), <var>P</var> )
-            </pre>
-            <pre class="code nohighlight">
-              if <var>IRI</var> is not a graph name in <var>D</var>
-                  <a href="#defn_eval" class="evalFct">eval</a>( <var>D</var>(<var>G</var>), Graph(<var>IRI</var>,<var>P</var>) ) = the empty multiset
-            </pre>
-            <pre class="code nohighlight">
-<a href="#defn_eval" class="evalFct">eval</a>( <var>D</var>(<var>G</var>), Graph(<var>var</var>,<var>P</var>) ) =
-    Let <var>R</var> be the empty multiset
-    foreach IRI <var>i</var> in <var>D</var>
-        <var>R</var> := <a href="#defn_algUnion" class="algFct">Union</a>(<var>R</var>, <a href="#defn_algJoin" class="algFct">Join</a>( <a href="#defn_eval" class="evalFct">eval</a>(<var>D</var>(<var>D</var>[<var>i</var>]), <var>P</var>) , Ω(<var>var</var>-&gt;<var>i</var>) ) )
-    the result is <var>R</var>
-            </pre>
+            <p>For every |x| that is
+              an <a data-cite="RDF12-CONCEPTS#dfn-IRI">IRI</a> or
+              a <a href="#defn_QueryVariable">variable</a>,
+              <a href="#defn_eval" class="evalFct">eval</a>( |D|(|G|), Graph(|x|, |P|) )
+              is defined as follows:</p>
+            <ul>
+              <li>If |x| is an IRI
+                that is a <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a> in |D|,
+                <div class="indentedFormula">
+                  <a href="#defn_eval" class="evalFct">eval</a>( |D|(|G|), Graph(|x|, |P|) )
+                  =
+                  <a href="#defn_eval" class="evalFct">eval</a>( |D|(<var>G<sub>|x|</sub></var>), |P| ),
+                </div>
+                where <var>G<sub>|x|</sub></var> is the RDF graph of the named graph with name |x| in |D|.
+              </li>
+              <li>If |x| is an IRI
+                that is not a <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a> in |D|,
+                <div class="indentedFormula">
+                  <a href="#defn_eval" class="evalFct">eval</a>( |D|(|G|), Graph(|x|, |P|) )
+                  is the empty multiset.
+                </div>
+              </li>
+              <li>If |x| is a variable,
+                <div class="indentedFormula">
+                  <a href="#defn_eval" class="evalFct">eval</a>( |D|(|G|), Graph(|x|, |P|) )
+                  =
+                  <var>Ω</var>,
+                </div>
+                where <var>Ω</var> is the multiset of solution mappings produced by the following algorithm:
+                <pre class="code nohighlight" style="font-family: sans-serif;">
+<var>Ω</var> := the empty multiset
+foreach <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a> <var>gn</var> in <var>D</var>
+    <var>G'</var> := the RDF graph of the named graph with name <var>gn</var> in <var>D</var>
+    <var>Ω'</var> := <a href="#defn_eval" class="evalFct">eval</a>( <var>D</var>(<var>G'</var>), <var>P</var> )
+    <var>Ω</var> := <a href="#defn_algUnion" class="algFct">Union</a>( <var>Ω</var>, <a href="#defn_algJoin" class="algFct">Join</a>(<var>Ω'</var>, <var>μ</var>) ), where <var>μ</var> = {<var>x</var> → <var>gn</var>}
+the result is <var>Ω</var>
+                </pre>
+              </li>
+            </ul>
           </div>
-          <p>The evaluation of graph uses the <a href="#defn_algUnion" class="algFct">Union</a> operator. The multiplicity of a
-            solution mapping is the sum of the multiplicities of that solution mapping in each <a href="#defn_algJoin" class="algFct">Join</a>
-            operation.</p>
           <div class="defn">
             <div id="defn_evalGroup">
               <b>Definition: Evaluation of Group</b>

--- a/spec/index.html
+++ b/spec/index.html
@@ -10373,7 +10373,7 @@ Let x and y be variables or RDF terms, and S a set of IRIs:
                 where <var>Ω</var> is the multiset of solution mappings produced by the following algorithm:
                 <pre class="code nohighlight" style="font-family: sans-serif;">
 <var>Ω</var> := the empty multiset
-foreach <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a> <var>gn</var> in <var>D</var> (recall that a graph name may be an IRI or a blank node)
+for each <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a> <var>gn</var> in <var>D</var> (recall that a graph name may be an IRI or a blank node)
     <var>G'</var> := the RDF graph of the named graph with name <var>gn</var> in <var>D</var>
     <var>Ω'</var> := <a href="#defn_eval" class="evalFct">eval</a>( <var>D</var>(<var>G'</var>), <var>P</var> )
     <var>Ω</var> := <a href="#defn_algUnion" class="algFct">Union</a>( <var>Ω</var>, <a href="#defn_algJoin" class="algFct">Join</a>(<var>Ω'</var>, <var>μ</var>) ), where <var>μ</var> = {<var>x</var> → <var>gn</var>}


### PR DESCRIPTION
This PR addresses #217 by extending the [definition of how to evaluate GRAPH patterns](https://www.w3.org/TR/sparql12-query/#defn_evalGraph) such that it now also considers blank nodes as possible graph names in an RDF dataset.

Additionally, the PR:
* changes the layout style of the changed definition such that it is consistent with the style of the other definitions in this part of the spec
* removes the introduction of the notation _Ω_(_x_) from the beginning of Section [18.3 Basic Graph Patterns](https://www.w3.org/TR/sparql12-query/#BasicGraphPattern)
  * (this notation was used only in the definition that this PR changes and it was also not really clear; I have replaced it by something better directly in the changed definition now)
* removes the notation _D_[_i_] from the beginning of Section [18.5.2 Evaluation Semantics](https://www.w3.org/TR/sparql12-query/#sparqlAlgebraEval)
  * (this notation was also used only in the definition that this PR changes)
* removes the following paragraph which was placed directly below the changed definition but, in my opinion, doesn't really add anything (in fact, it is not even relevant because there can be no solution mapping that is in the result of more than one of the joins that feed into the union in the given algorithm)---but if you think it is useful to keep that paragraph, let me know and I will restore it!
> The evaluation of graph uses the [Union](https://www.w3.org/TR/sparql12-query/#defn_algUnion) operator. The multiplicity of a solution mapping is the sum of the multiplicities of that solution mapping in each [Join](https://www.w3.org/TR/sparql12-query/#defn_algJoin) operation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/221.html" title="Last updated on Jun 5, 2025, 8:13 AM UTC (7646624)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/221/5615dfa...7646624.html" title="Last updated on Jun 5, 2025, 8:13 AM UTC (7646624)">Diff</a>