### PR TITLE
Adds explicit definition of the algebraic syntax

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -8423,8 +8423,11 @@ WHERE {
       </section>
       <section id="algebraicSyntax">
         <h3>Algebraic Syntax</h3>
-        <p>To define the evaluation semantics of SPARQL query strings
-          these strings are first translated into a more abstract, algebraic syntax.
+        <p>To define the evaluation semantics of a SPARQL query,
+          the abstract syntax tree of the SPARQL query string
+          (as defined by the <a href="#sparqlGrammar">SPARQL grammar</a>)
+          is first translated into a syntax that resembles the
+          <a href="#sparqlAlgebra">SPARQL algebra</a>.
           This section defines the expressions that can be formed in this algebraic syntax,
           and the translation of SPARQL query strings into this algebraic syntax is then defined
           in Section&nbsp;<a href="#sparqlQuery" class="sectionRef"></a>.</p>


### PR DESCRIPTION
This PR is the next step towards addressing the issue that the spec represents the operators of the algebraic syntax of SPARQL in exactly the same way as it represents the algebra functions used to define the evaluation semantics. See the previous PR for a description of the issue: #216

One aspect of the issue is that the algebraic syntax is not actually defined explicitly. Instead, the possible expressions of the algebraic syntax are introduced only implicitly as part of the translation procedure defined in Section [18.2 Translation to the SPARQL Algebra](https://www.w3.org/TR/sparql12-query/#sparqlQuery).

This PR focuses on that aspect by adding a new section that provides an explicit definition of the algebraic syntax, added directly before Section [18.2 Translation to the SPARQL Algebra](https://www.w3.org/TR/sparql12-query/#sparqlQuery). This definition includes `id` anchors for all operators of the algebraic syntax. These anchors can be used in the next step (future PR) to link all mentions of these operators to their definition, similar to how PR #216 linked the algebra operators to their definitions. In fact, as a second part of this PR, Sections [18.2.2.3 Translate Property Path Expressions](https://www.w3.org/TR/sparql12-query/#sparqlTranslatePathExpressions) and [18.2.2.4 Translate Property Path Patterns](https://www.w3.org/TR/sparql12-query/#sparqlTranslatePathPatterns) are already changed to use such links.

I am leaving it to a future PR to do the same (i.e., using such links) everywhere else in Section [18.2 Translation to the SPARQL Algebra](https://www.w3.org/TR/sparql12-query/#sparqlQuery) and also in Section [18.5.2 Evaluation Semantics](https://www.w3.org/TR/sparql12-query/#sparqlAlgebraEval). I chose not to include all these changes already in this PR to make it easier to review this step first.
 (Section 18.3 after this PR)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/227.html" title="Last updated on Jun 27, 2025, 2:11 PM UTC (c945fed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/227/5615dfa...c945fed.html" title="Last updated on Jun 27, 2025, 2:11 PM UTC (c945fed)">Diff</a>