### PR TITLE
Minor edit suggestions by @TallTed

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -8619,7 +8619,7 @@ WHERE {
         <p>This section defines the process of converting graph patterns and solution modifiers in a
           SPARQL query string into an <a href="#defn_AlgebraicQueryExpression">algebraic
           query expression</a>. The process described converts one
-          level of query nesting, as formed by subqueries using the nested <code>SELECT</code> syntax and
+          level of query nesting as formed by subqueries using the nested <code>SELECT</code> syntax, and
           is applied recursively on subqueries. Each level consists of graph pattern matching and
           filtering, followed by the application of solution modifiers.</p>
         <p>The SPARQL query string is parsed and the abbreviations for IRIs and triple patterns given
@@ -8715,10 +8715,10 @@ WHERE {
             query. The definition below provides a way of determining this from the
             abstract syntax tree of a query.</p>
           <p>Note that a subquery with a projection can hide variables; use of a variable in
-            <code>FILTER</code>, or in <code>MINUS</code> does not cause the variable to be in-scope
+            <code>FILTER</code> or in <code>MINUS</code> does not cause the variable to be in-scope
             outside of those forms.</p>
-          <p>Let <b>P</b>, <b>P1</b>, <b>P2</b> be graph patterns and <b>E</b>,
-            <b>E1</b>,...<b>En</b> be expressions. A variable <code>v</code> is in-scope if:</p>
+          <p>Let <b>P</b>, <b>P1</b>, and <b>P2</b> be graph patterns, and <b>E</b>,
+            <b>E1</b>,..., through <b>En</b> be expressions. A variable <code>v</code> is in-scope if:</p>
           <table style="border-collapse: collapse; border-color: #000000; border-spacing:5px; border-width: 1px">
             <tbody>
               <tr>


### PR DESCRIPTION
This PR implements a few edit suggestions that @TallTed had on commit https://github.com/w3c/sparql-query/commit/f4977cecbcc42fbfb28ea77a728aaddaffe6a70c in PR #245 after the PR was already merged.

@TallTed, I included all your suggestions except for [the one about code-fencing the keyword SELECT](https://github.com/w3c/sparql-query/commit/f4977cecbcc42fbfb28ea77a728aaddaffe6a70c#r163944096). That one I left out because, in this part of the spec, there are a lot of mentions of SPARQL keyword and none of them is code-fenced. Thus, code-fencing just this one mention of "SELECT" would be inconsistent with respect to the rest of this part of the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/259.html" title="Last updated on Aug 15, 2025, 12:28 PM UTC (7f23944)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/259/a81b291...7f23944.html" title="Last updated on Aug 15, 2025, 12:28 PM UTC (7f23944)">Diff</a>