### PR TITLE
SPARQL logical-not

### DIFF
--- a/sparql-ns.ttl
+++ b/sparql-ns.ttl
@@ -79,11 +79,6 @@ sparql:less-than-or-equal rdf:type sparql:Function ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
     .
     
-sparql:logical-not rdf:type sparql:Functional ;
-    rdfs:comment "This form computes the logical NOT of a boolean expression." ;
-    rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/#func-logical-and> ;
-    .
-
 # Section: Functional Forms
 
 sparql:bound rdf:type sparql:FunctionalForm ;
@@ -119,6 +114,11 @@ sparql:logical-or rdf:type sparql:FunctionalForm ;
 sparql:logical-and rdf:type sparql:FunctionalForm ;
     rdfs:comment "This form computes the logical AND of two boolean expressions." ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/#func-logical-and> ;
+    .
+
+sparql:logical-not rdf:type sparql:FunctionalForm ;
+    rdfs:comment "This form computes the logical NOT of a boolean expression." ;
+    rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/#func-logical-not> ;
     .
 
 sparql:in rdf:type sparql:FunctionalForm ;

--- a/spec/index.html
+++ b/spec/index.html
@@ -4709,8 +4709,10 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
             <a href="#func-bound">BOUND</a>, <a href="#func-coalesce">COALESCE</a>,
             <a href="#func-if">IF</a>, <a href="#func-in">IN</a>, <a href="#func-not-in">NOT IN</a>, 
             <a href="#func-logical-or">logical-or</a> (<code>||</code>),
-            <a href="#func-logical-and">logical-and</a> (<code>&amp;&</code>),
-            <a href="#func-filter-not-exists">NOT EXISTS</a>, and <a href="#func-filter-exists">EXISTS</a>,
+            <a href="#func-logical-and">logical-and</a> (<code>&amp;&amp</code>),
+            <a href="#func-logical-not">logical-not</a> (<code>!</code>),
+            <a href="#func-filter-not-exists">NOT EXISTS</a>, 
+            and <a href="#func-filter-exists">EXISTS</a>,
             all functions operate on RDF Terms and will produce a type error if any
             arguments are unbound.
           </li>
@@ -4820,9 +4822,9 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
         <section id="ebv">
           <h4>Effective Boolean Value (EBV)</h4>
           <p>Effective boolean value is used to calculate the arguments to the logical functions
-            <a href="#func-logical-and">logical-and</a>, <a href="#func-logical-or">logical-or</a>, and
-            <a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>, as well as evaluate the result of a
-            <code>FILTER</code> expression.</p>
+            <a href="#func-logical-and">logical-and</a>, <a href="#func-logical-or">logical-or</a>,
+            and <a href="#func-logical-not">logical-not</a>,
+            as well as evaluate the result of a <code>FILTER</code> expression.</p>
           <p>The XQuery <a data-cite="XQUERY-31#id-ebv">Effective Boolean Value</a> rules rely on the
             definition of XPath's <a data-cite="XPATH-FUNCTIONS-31#func-boolean">fn:boolean</a>. The following
             rules reflect the rules for <code>fn:boolean</code> applied to the argument types present
@@ -4905,7 +4907,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
                 xsd:boolean <a href="#ebv-arg">(EBV)</a>
               </td>
               <td class="xpathOp">
-                <a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>(A)
+                <a href="#func-logical-not" class="SPARQLoperator">logical-not</a>(A)
               </td>
               <td>xsd:boolean</td>
             </tr>
@@ -5609,7 +5611,7 @@ class="expression">expression, ....</span>)
               The purpose of this function is to define the semantics of the "<code>||</code>" operator.</p>
             <p>The function returns a logical <code>OR</code> of <code>left</code> and <code>right</code>. 
               Note that <span class="SPARQLoperator">logical-or</span> operates on the 
-              <a href="#ebv">effective boolean value</a> of its arguments.</p>
+              <a href="#ebv">effective boolean value</a> of each of its arguments.</p>
             <p>Note: see section 17.2, <a href="#evaluation">Filter Evaluation</a>, for the
               <code>||</code> operator's treatment of errors.</p>
           </section>
@@ -5618,12 +5620,25 @@ class="expression">expression, ....</span>)
             <pre class="prototype nohighlight">
               <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">logical-and</span> (<span class="type">xsd:boolean</span> <span class="name">left</span>, <span class="type">xsd:boolean</span> <span class="name">right</span>)
             </pre>
-            <p>This function cannot be used directly in expressions. The purpose of this function is to define the semantics of the "<code>&amp;&amp;</code>" operator.</p>
+            <p>This function cannot be used directly in expressions. 
+              The purpose of this function is to define the semantics of the "<code>&amp;&amp;</code>" operator.</p>
             <p>The function returns a logical <code>AND</code> of <code>left</code> and <code>right</code>.
               Note that <span class="SPARQLoperator">logical-and</span> operates on the 
-              <a href="#ebv">effective boolean value</a> of its arguments.</p>
+              <a href="#ebv">effective boolean value</a> of each of its arguments.</p>
             <p>Note: see section 17.2, <a href="#evaluation">Filter Evaluation</a>, for the
-              <code>&amp;&</code> operator's treatment of errors.</p>
+              <code>&amp;&amp;</code> operator's treatment of errors.</p>
+          </section>
+          <section id="func-logical-not">
+            <h5>logical-not</h5>
+            <pre class="prototype nohighlight">
+              <span class="return">xsd:boolean</span> <span class="operator" style="text-transform: none;">logical-not</span> (<span class="type">xsd:boolean</span> <span class="name">arg</span>)
+            </pre>
+            <p>This function cannot be used directly in expressions.  The purpose of this
+              function is to define the semantics of the "<code>!</code>" operator.</p>
+            <p>The function returns a logical <code>NOT</code> of <code>arg</code>.
+              Note that <span class="SPARQLoperator">logical-not</span> operates on the 
+              <a href="#ebv">effective boolean value</a> of its argument.
+            </p>
           </section>
           <section id="func-in">
             <h5>IN</h5>
@@ -10825,7 +10840,7 @@ _:x rdf:type xsd:decimal .
           <p><code>?a&lt;?b&amp;&amp;?c&gt;?d</code></p>
         </blockquote>
         <p>is the token sequence variable '<code>?a</code>', an IRI
-          '<code>&lt;?b&amp;&amp;?c&gt;</code>', and variable '<code>?d</code>', not a expression
+          '<code>&lt;?b&amp;&amp;?c&gt;</code>', and variable '<code>?d</code>', not an expression
           involving the operator '<code>&amp;&</code>' connecting two expression using
           '<code>&lt;</code>' (less than) and '<code>&gt;</code>' (greater than).</p>
       </section>


### PR DESCRIPTION
Closes #261

This PR adds `logical-not` in the same style as `logical-and` and `logical-or` and uses that for the `!` operator.

While `logical-not` and `fn:not` are similar, the domain of `logical-not` is not a restriction of `fn:not` because of non-literals ([Effective Boolean Value](https://www.w3.org/TR/sparql12-query/#ebv)).

Other uses of `fn:not` in the document are not changed - they are applied to only boolean values.

The PR also corrects the NS document (#261).

See also other issues in this area:
* #263 
* #264


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/262.html" title="Last updated on Aug 19, 2025, 9:53 AM UTC (95749e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/262/a81b291...95749e0.html" title="Last updated on Aug 19, 2025, 9:53 AM UTC (95749e0)">Diff</a>