### PR TITLE
Grammar: UnaryExpression production for `!` should allow `!!`.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -11970,7 +11970,7 @@ _:x rdf:type xsd:decimal .
                 <td><code>[135]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rUnaryExpression">UnaryExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'!'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'+'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'-'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<a href="#rPrimaryExpression">PrimaryExpression</a></code></td>
+                <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'!'</span> <a href="#rUnaryExpression">UnaryExpression</a> <br/>|	<span class="token">'+'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'-'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<a href="#rPrimaryExpression">PrimaryExpression</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
@@ -12535,7 +12535,9 @@ _:x rdf:type xsd:decimal .
               <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-13">errata-query-13</a>: Fix definition of Project cardinality in <a href="#sparqlAlgebra" class="sectionRef"></a></li>
               <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-18">errata-query-18</a>: Fix table in <a href="#sparqlTranslatePathPatterns" class="sectionRef"></a></li>
               <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-19">errata-query-19</a>: Fix translation in <a href="#sparqlTranslateGraphPatterns" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-23">errata-query-23</a>: Fix inconsistenties between <a href="#defn_aggMin">MIN</a> and <a href="#defn_aggMax">MAX</a></li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-23">errata-query-23</a>: Fix inconsistenties between <a href="#defn_aggMin">MIN</a> and <a
+href="#defn_aggMax">MAX</a></li>
+              <li>Grammar rule `UnaryExpression` to allow `!!`</li>
             </ul>
         </li>
       </ul>

--- a/spec/sparql.bnf
+++ b/spec/sparql.bnf
@@ -132,7 +132,7 @@ RelationalExpression      ::= NumericExpression ( '=' NumericExpression | '!=' N
 NumericExpression         ::= AdditiveExpression
 AdditiveExpression        ::= MultiplicativeExpression ( '+' MultiplicativeExpression | '-' MultiplicativeExpression | ( NumericLiteralPositive | NumericLiteralNegative ) ( ( '*' UnaryExpression ) | ( '/' UnaryExpression ) )* )*
 MultiplicativeExpression  ::= UnaryExpression ( '*' UnaryExpression | '/' UnaryExpression )*
-UnaryExpression           ::= '!' PrimaryExpression 
+UnaryExpression           ::= '!' UnaryExpression 
                           |   '+' PrimaryExpression 
                           |   '-' PrimaryExpression 
                           |   PrimaryExpression


### PR DESCRIPTION
This closes: #279

The UnaryExpression production for `!` should allow `!!`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/281.html" title="Last updated on Sep 4, 2025, 8:05 PM UTC (136da5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/281/a4c493b...136da5c.html" title="Last updated on Sep 4, 2025, 8:05 PM UTC (136da5c)">Diff</a>