### PR TITLE
GH-284: Align TRIPLE and expression <<( )>>

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -7954,9 +7954,10 @@ class="name">obj</span>)
               as corresponding to <a href="#sparqlTriplePatterns">SPARQL triple patterns</a>.
               The graph result from a 
               <a href="#constructGraph">CONSTRUCT</a> query form
-              allows <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triples</a>, and not
-              their generalization to
-              <a data-cite="RDF12-CONCEPTS#dfn-symmetric-rdf-triple">symmetric RDF triples</a>.
+              allows <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triples</a>.
+              Any other 
+              <a data-cite="RDF12-CONCEPTS#dfn-symmetric-rdf-triple">symmetric RDF triples</a>
+              will be omitted from the result.
             </p>
             <p>
               As a shorthand notation, the <code>TRIPLE</code> function 


### PR DESCRIPTION
This closes #284.

Discussion: https://github.com/w3c/sparql-query/issues/283#issuecomment-3271696970

Make writing `<<( ... )>>` the same as using `TRIPLE` with the same arguments.

(The inverse is not permitted by the grammar - `TRIPLE` can have expressions, but expressions are not allowed in `<<( ... )>>` because there are no comma separators.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/285.html" title="Last updated on Dec 19, 2025, 11:41 AM UTC (938c40a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/285/d650b65...938c40a.html" title="Last updated on Dec 19, 2025, 11:41 AM UTC (938c40a)">Diff</a>