### PR TITLE
Add missing comparison operators for triple terms

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -12695,7 +12695,7 @@ _:x rdf:type xsd:decimal .
                 <li>Update references to XPath from 2.0 to 3.1</li>
                 <li>Define `EBV` as a functional form.</li>
                 <li>Forbid duplicated variables in `VALUES`.</li>
-                <li>Add in-between ORDER BY support for triple terms in <a href="#modOrderBy" class="sectionRef"></a>.</li>
+                <li>Add in-between term type ORDER BY support for triple terms in <a href="#modOrderBy" class="sectionRef"></a>.</li>
             </ul>
         </li>
         <li>


### PR DESCRIPTION
While https://github.com/w3c/sparql-query/pull/194 introduced sameValue and sameTerm support for triple terms, but `<`, `<=`, `>`, and `>=` were missing, so this PR adds them.
It also adds ORDER BY support for triple terms.

The same approach as the [RDF-star spec](https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#rdf-star-operator-mapping) was followed here, with some small tweaks.

Thanks to the keen eye of @jitsedesmet for noticing this was missing!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/289.html" title="Last updated on Dec 5, 2025, 1:54 PM UTC (2ccda34)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/289/77a17f6...2ccda34.html" title="Last updated on Dec 5, 2025, 1:54 PM UTC (2ccda34)">Diff</a>