### PR TITLE
Update names of referenced XPath functions and operators.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4605,7 +4605,7 @@ WHERE { ?annot  a:annotates  &lt;http://www.w3.org/TR/rdf-sparql-query/&gt; .
         functions are invoked by name (an IRI) within a SPARQL query. For example:</p>
       <pre class="query nohighlight">
         ... FILTER ( xsd:dateTime(?date) &lt; xsd:dateTime("2005-01-01T00:00:00Z") ) ...</pre>
-      <p>Typographical convention in this section: XPath operators are labeled with the prefix
+      <p>Typographical convention: XPath operators are labeled with the prefix
         <code>op:</code>. XPath operators have no namespace; <code>op:</code> is a labeling
         convention.</p>
       <section id="operandDataTypes">


### PR DESCRIPTION
In defining SPARQL functions, we often say "This function is the same as" and link to an XPath definition. However, several of the XPath functions are misnamed in this linking. This PR fixes the function and operator names for:

* `fn:numeric-equal` -> `op:numeric-equal`
* `fn:numeric-abs` -> `fn:abs`
* `fn:numeric-round` -> `fn:round`
* `fn:numeric-ceil` -> `fn:ceiling`
* `fn:numeric-floor` -> `fn:floor`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/304.html" title="Last updated on Nov 13, 2025, 5:37 PM UTC (e3f08c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/304/78a901a...e3f08c3.html" title="Last updated on Nov 13, 2025, 5:37 PM UTC (e3f08c3)">Diff</a>