### PR TITLE
Fix typo in STRLANG/STRLANGDIR

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -6722,7 +6722,7 @@ WHERE {
             </p>
             <p>
               The argument `langTag` MUST not be an empty string and SHOULD be a
-              a valid <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>.
+              valid <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>.
             </p>
             <div class="result">
               <table>
@@ -6761,7 +6761,7 @@ WHERE {
             </p>
             <p>
               The argument `langTag` MUST NOT be an empty string and SHOULD be a
-              a valid <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>.
+              valid <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>.
               The argument `baseDirection` MUST be either `"ltr"` or `"rtl"`.
             </p>
             <div class="result">


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/311.html" title="Last updated on Nov 14, 2025, 10:28 AM UTC (59b8320)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/311/e134b8d...59b8320.html" title="Last updated on Nov 14, 2025, 10:28 AM UTC (59b8320)">Diff</a>