### PR TITLE
Add IRIs for versions to sparql-ns.ttl

### DIFF
--- a/sparql-ns.ttl
+++ b/sparql-ns.ttl
@@ -543,12 +543,12 @@ sparql:version-1.1 a rdfs:Resource ;
     rdfs:label "1.1" ;
     rdfs:comment "Version 1.1" ;
     rdfs:isDefinedBy <https://www.w3.org/ns/sparql> ;
-    rdfs:seeAlso <http://www.w3.org/TR/sparql12-query/> ;
+    dc:conformsTo <http://www.w3.org/TR/sparql11-query/> ;
     .
 
 sparql:version-1.0 a rdfs:Resource ;
     rdfs:label "1.0" ;
     rdfs:comment "Version 1.0" ;
     rdfs:isDefinedBy <https://www.w3.org/ns/sparql> ;
-    rdfs:seeAlso <http://www.w3.org/TR/sparql12-query/> ;
+    dc:conformsTo <http://www.w3.org/TR/sparql10-query/> ;
     .


### PR DESCRIPTION
As discussed in last week's SPARQL TF meeting and https://github.com/w3c/sparql-query/issues/241, this PR adds IRIs for language versions to the SPARQL NS, so we can evolve it independently from the RDF NS. (as SPARQL may evolve more quickly than RDF)

As a next step, we will need a section in the SPARQL Query spec to list version labels (similar to the one in RDF Concepts).
We can then also allow these versions to be mentioned in the SPARQL service description, to enable discovery.