### PR TITLE
Clarify LANGMATCHES handling of empty strings.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -7459,7 +7459,7 @@ WHERE {
               [[RFC4647]] section 3.3.1. Otherwise, the function returns `false`.
             </p>
               
-            <p>If either <code>language-tag</code> or <code>language-range</code> are empty
+            <p>If <code>language-tag</code>, <code>language-range</code>, or both are empty
               (and thus not a valid language tag or language range, respectively),
               the function returns `false`.
             </p>


### PR DESCRIPTION
Updated wording for the `LANGMATCHES` definition that attempts to clarify behavior on non-valid inputs. This makes clear that `false` should be returned on an empty-string tag or range.

It does **not** add any text about what should happen on tags or ranges that conform to the SPARQL grammar, but which do not conform to the more strict RFC grammar. That seems more fraught, since existing systems may support such tags, and may rely on matching behavior that does not fully conform to the RFC.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/316.html" title="Last updated on Nov 21, 2025, 10:30 PM UTC (b1424c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/316/46e5ac5...b1424c0.html" title="Last updated on Nov 21, 2025, 10:30 PM UTC (b1424c0)">Diff</a>