### PR TITLE
adds ContextMapping to the algebraic syntax

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -8596,8 +8596,8 @@ WHERE {
             is an algebraic query expression.
 <div class="issue" data-number="231">Do we really need both of the previous two points?</div>
             </li>
-          <li id="defn_absContextMapping">
-            <a href="#defn_absContextMapping" class="absOp">ContextMapping</a>
+          <li id="defn_absContextSolution">
+            <a href="#defn_absContextSolution" class="absOp">ContextSolution</a>
             is an algebraic query expression.</li>
           <li id="defn_absPath">
             <a href="#defn_absPath" class="absOp">Path</a>(|x|, |ppe|, |y|)
@@ -9207,7 +9207,7 @@ If the form is GRAPH Var GroupGraphPattern
             </blockquote>
 <pre class="code nohighlight">
 Let FS := the empty set
-Let <var>G</var> := <a href="#defn_absContextMapping" class="absOp">ContextMapping</a>
+Let <var>G</var> := <a href="#defn_absContextSolution" class="absOp">ContextSolution</a>
 
 For each element <var>E</var> in the sequence of elements in the GroupGraphPattern
 
@@ -10684,8 +10684,8 @@ and <var>G</var> the <a href="#defn_ActiveGraph">active graph</a>.
             <p>See section <a href="#PropertyPathPatterns">Property Path Patterns</a></p>
           </div>
           <div class="defn">
-            <p><b>Definition: <span id="defn_evalContextMapping">Evaluation of ContextMapping</span></b></p>
-            <p><a href="#defn_eval" class="evalFct">eval</a>( |D|(|G|), <a href="#defn_absContextMapping" class="absOp">ContextMapping</a>, <var>μ<sub>ctx</sub></var> ) = multiset that contains only <var>μ<sub>ctx</sub></var>, with a multiplicity of 1</p>
+            <p><b>Definition: <span id="defn_evalContextSolution">Evaluation of ContextSolution</span></b></p>
+            <p><a href="#defn_eval" class="evalFct">eval</a>( |D|(|G|), <a href="#defn_absContextSolution" class="absOp">ContextSolution</a>, <var>μ<sub>ctx</sub></var> ) = multiset that contains only <var>μ<sub>ctx</sub></var>, with a multiplicity of 1</p>
           </div>
           <div class="defn">
             <p><b>Definition: <span id="defn_evalFilter">Evaluation of Filter</span></b></p>


### PR DESCRIPTION
This PR implements steps 2-4 of #302,
* adding the symbol `ContextMapping` to the algebraic syntax,
* using this symbol in the translation of GroupGraphPattern, and
* extending the eval function to cover this new symbol.

Additionally, the PR adds a clarification about the initial version of μ<sub>ctx</sub> to be used for the eval function.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/319.html" title="Last updated on Dec 1, 2025, 9:25 AM UTC (6d14906)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/319/17aa63f...6d14906.html" title="Last updated on Dec 1, 2025, 9:25 AM UTC (6d14906)">Diff</a>