### PR TITLE
vocab: rename `sparql:plus` into `sparql:add`

### DIFF
--- a/sparql-ns.ttl
+++ b/sparql-ns.ttl
@@ -19,7 +19,7 @@ sparql:Aggregate rdf:type rdfs:Class .
 
 ## Operators
 
-sparql:plus rdf:type sparql:Function ;
+sparql:add rdf:type sparql:Function ;
     rdfs:comment "This operator adds two numeric expressions and returns their sum." ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
     .


### PR DESCRIPTION
We already have `sparql:substract`, `sparql:multiply`... and XPath also uses "add". Having "plus" here sounds a bit weird to me.