### PR TITLE
Formal definition of the evaluation of EXISTS expressions

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -5692,7 +5692,7 @@ class="expression">expression, ....</span>)
               together with the solution mapping,
               matches the dataset.
               No additional binding of variables occurs. The `NOT EXISTS` form
-              translates into <code>fn:<a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>(EXISTS {...})</code>.</p>
+              translates into <code><a data-cite="XPATH-FUNCTIONS-31#func-not">fn:not</a>(EXISTS {...})</code>.</p>
             <pre class="prototype nohighlight"> 
 <span class="return">xsd:boolean</span>  <span class="operator">NOT EXISTS</span> { <span class="pattern">pattern</span> }
             </pre>


### PR DESCRIPTION
This PR implements step 5 of #302. That is, it adds the [formal definition of the evaluation of EXISTS expressions](https://github.com/w3c/sparql-query/blob/main/discussion/Defining_the_DEEP_INJECTION_approach_for_EXISTS.md#expr%CE%BC-d-g-for-exists-semantics-deep-injection-and-once-without-projection) into [Section 17.4.1.4 NOT EXISTS and EXISTS](https://www.w3.org/TR/sparql12-query/#func-filter-exists).

Additionally, the PR removes some text that is now obsolete in that section, and it adds a Note at the beginning of [Section 18.6.2 Evaluation Semantics](https://www.w3.org/TR/sparql12-query/#sparqlAlgebraEval) to clarify that the evaluation of EXISTS changes the context solution mapping _μ<sub>ctx</sub>_ that is passed to the [eval](https://www.w3.org/TR/sparql12-query/#defn_eval) function.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/325.html" title="Last updated on Dec 27, 2025, 8:53 PM UTC (c5dceb7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/325/1b85976...c5dceb7.html" title="Last updated on Dec 27, 2025, 8:53 PM UTC (c5dceb7)">Diff</a>