### PR TITLE
Clarify that unaggregated variables in SELECT raise an error

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9540,7 +9540,7 @@ Global <var>i</var> := 1   # Initially 1 for each query processed
 
 For each (<var>X</var> AS <var>Var</var>) in SELECT, each HAVING(<var>X</var>), and each ORDER BY <var>X</var> in <var>Q</var>
   For each unaggregated variable <var>V</var> in <var>X</var>
-      Replace <var>V</var> with SAMPLE(<var>V</var>)
+      Raise an error
       End
   For each aggregate <var>R</var>(<var>args</var> ; <var>scalarvals</var>) now in <var>X</var>
       # note: <var>scalarvals</var> may be omitted; if so, it is equivalent to the empty function

--- a/spec/index.html
+++ b/spec/index.html
@@ -2929,8 +2929,8 @@ WHERE {
           <p>Note that it would not be legal to project <code>STR(?z)</code> as this is not a simple
             variable expression. However, with <code>GROUP BY (STR(?z) AS ?strZ)</code> it would be
             possible to project <code>?strZ</code>.</p>
-          <p>Other expressions, not using <code>GROUP BY</code> variables, or aggregates may have
-            non-deterministic values projected from their groups using the <code>SAMPLE</code>
+          <p>For other expressions (not using <code>GROUP BY</code> variables or aggregates),
+            non-deterministic values may be requested from their groups by using the <code>SAMPLE</code>
             aggregate function explicitly.</p>
         </div>
       </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2925,12 +2925,14 @@ WHERE {
     ?x :q ?z .
 } GROUP BY ?x (STR(?z))
         </pre>
-        <p>Note that it would not be legal to project <code>STR(?z)</code> as this is not a simple
-          variable expression. However, with <code>GROUP BY (STR(?z) AS ?strZ)</code> it would be
-          possible to project <code>?strZ</code>.</p>
-        <p>Other expressions, not using <code>GROUP BY</code> variables, or aggregates may have
-          non-deterministic values projected from their groups using the <code>SAMPLE</code>
-          aggregate.</p>
+        <div class="note">
+          <p>Note that it would not be legal to project <code>STR(?z)</code> as this is not a simple
+            variable expression. However, with <code>GROUP BY (STR(?z) AS ?strZ)</code> it would be
+            possible to project <code>?strZ</code>.</p>
+          <p>Other expressions, not using <code>GROUP BY</code> variables, or aggregates may have
+            non-deterministic values projected from their groups using the <code>SAMPLE</code>
+            aggregate function explicitly.</p>
+        </div>
       </section>
       <section id="aggregateExample2">
         <h3>Aggregate Example (with errors)</h3>


### PR DESCRIPTION
Makes it clear that inserting SAMPLE is something the user can do, not something SPARQL implementation should do automatically

Close #165


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/327.html" title="Last updated on Mar 18, 2026, 9:03 PM UTC (3f3e302)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/327/dddd137...3f3e302.html" title="Last updated on Mar 18, 2026, 9:03 PM UTC (3f3e302)">Diff</a>