### PR TITLE
Restrict `TripleTermDataSubject` to IRI

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -12109,7 +12109,7 @@ _:x rdf:type xsd:decimal .
                 <td><code>[123]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTripleTermDataSubject">TripleTermDataSubject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rTripleTermData">TripleTermData</a></code></td>
+                <td><code class="gRuleBody"><a href="#riri">iri</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">


### PR DESCRIPTION
Avoid allowing to write triple terms in VALUES blocks that are invalid

Close #282


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/329.html" title="Last updated on Dec 12, 2025, 8:41 PM UTC (ce2209e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/329/dddd137...ce2209e.html" title="Last updated on Dec 12, 2025, 8:41 PM UTC (ce2209e)">Diff</a>