### PR TITLE
Restrict `ExprTripleTermSubject` to VarOrIRI

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -12214,7 +12214,7 @@ _:x rdf:type xsd:decimal .
                 <td><code>[138]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rExprTripleTermSubject">ExprTripleTermSubject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprTripleTerm">ExprTripleTerm</a></code></td>
+                <td><code class="gRuleBody"><a href="#rVarOrIri">VarOrIri</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">


### PR DESCRIPTION
Avoid allowing to write triple terms in expressions that are always invalid

Close #283


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/330.html" title="Last updated on Dec 12, 2025, 8:39 PM UTC (dc9f530)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/330/dddd137...dc9f530.html" title="Last updated on Dec 12, 2025, 8:39 PM UTC (dc9f530)">Diff</a>