### PR TITLE
Fix spec text regarding implicit grouping during translation to algebraic syntax

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9507,7 +9507,7 @@ Replace <a href="#defn_absJoin" class="absOp">Join</a>(<var>A</var>, <var>Z</var
             <h5>Grouping and Aggregation</h5>
             <p>Step: GROUP BY</p>
             <p>If the <code>GROUP BY</code> keyword is used, or there is implicit grouping due to the
-              use of aggregates in <code>HAVING<code> or <code>ORDER BY</code> clauses, or in the
+              use of aggregates in <code>HAVING</code> or <code>ORDER BY</code> clauses, or in the
               projection, then grouping is performed by the <a href="#defn_algGroup">Group</a> function.
               In this case, before grouping, the solution set is converted into a solution
               sequence by applying the <a href="#defn_algToList">ToList</a> function.


### PR DESCRIPTION
Clarifies the language used in `18.3.4.1 Grouping and Aggregation` regarding the use of implicit grouping. The pseudocode in this section (and previous description in section 11.2) correctly handle implicit grouping if there is aggregation in projection, HAVING, or ORDER BY clauses, but this text previously only mentioned the projection case.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/331.html" title="Last updated on Dec 27, 2025, 8:33 PM UTC (e66c274)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/331/ece2ed7...e66c274.html" title="Last updated on Dec 27, 2025, 8:33 PM UTC (e66c274)">Diff</a>