### PR TITLE
Removes obsolete artifacts of the previous definition of EXISTS

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -12712,6 +12712,7 @@ _:x rdf:type xsd:decimal .
                 <li>Define `EBV` as a functional form.</li>
                 <li>Forbid duplicated variables in `VALUES`.</li>
                 <li>Add in-between term type ORDER BY support for triple terms in <a href="#modOrderBy" class="sectionRef"></a>.</li>
+                <li>Fixes the previously informal definition of `EXISTS` by adding a formal definition in <a href="#func-filter-exists" class="sectionRef"></a>, which includes extending the <a href="#defn_eval" class="evalFct">eval</a> function with a solution mapping <var>μ<sub>ctx</sub></var> as third argument.</li>
             </ul>
         </li>
         <li>


### PR DESCRIPTION
This PR implements the remaining two steps of #302. That is, it removes all artifacts of the previous definition of EXISTS (which have become obsolete now) and it mentions the changes related to EXISTS in the change log.

Merging this PR will close #302


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/336.html" title="Last updated on Dec 28, 2025, 11:46 AM UTC (54efd4e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/336/6878281...54efd4e.html" title="Last updated on Dec 28, 2025, 11:46 AM UTC (54efd4e)">Diff</a>