### PR TITLE
Fix Encoding considerations description of codepoint escape sequences.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -12678,7 +12678,8 @@ _:x rdf:type xsd:decimal .
           <dd>The syntax of the SPARQL Query Language is expressed over code points in Unicode
             [[UNICODE]]. The encoding is always UTF-8 [[RFC3629]].</dd>
           <dd>Unicode code points may also be expressed using an \uXXXX (U+0 to U+FFFF) or
-            \UXXXXXXXX syntax (for U+10000 onwards) where X is a hexadecimal digit [0-9A-F]</dd>
+            \UXXXXXXXX syntax (U+0 to U+10FFFF), where X is a hexadecimal digit [0-9A-Fa-f],
+            excluding U+D800 to U+DFFF, the <a data-cite="I18N-GLOSSARY#dfn-surrogate">surrogate code points</a>.</dd>
           <dt>Security considerations:</dt>
           <dd>
             See SPARQL Query appendix C, <a href="#security">Security Considerations</a> as well as


### PR DESCRIPTION
The previous text suggested that the \U escape sequence form could only be used with codepoints starting at U+10000, and that both \u and \U forms had to use uppercase hexadecimal characters. This commit updates to correctly reflect that \U escapes can use any codepoint (U+0 to U+10FFFF) and the hexadecimal characters are case-insensitive.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/339.html" title="Last updated on Jan 6, 2026, 5:43 PM UTC (4f027ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/339/6878281...4f027ae.html" title="Last updated on Jan 6, 2026, 5:43 PM UTC (4f027ae)">Diff</a>