### PR TITLE
change equivalent to renaming blank nodes in scoping graph definition

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9858,9 +9858,9 @@ The set <var>PV</var> is used later for projection (see Section&nbsp;<a href="#s
             pattern solutions are therefore understood to be not from the active graph of DS itself,
             but from an RDF graph, called the <i>scoping graph</i>. This graph is the
             active graph of DS but with its blank nodes uniformly replaced by new blank nodes
-	    that are neither in DS nor in the BGP, much as is done when 
-	    <a data-cite="RDF12-SEMANTICS#dfn-merging">merging</a> RDF graphs.
-	    The same scoping graph is
+            that are neither in DS nor in the BGP, much as is done when 
+            <a data-cite="RDF12-SEMANTICS#dfn-merging">merging</a> RDF graphs.
+            The same scoping graph is
             used for all solutions to a single query. The scoping graph is purely a theoretical
             construct; in practice, the effect is obtained simply by the document scope conventions for
             blank node identifiers.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9856,8 +9856,11 @@ The set <var>PV</var> is used later for projection (see Section&nbsp;<a href="#s
             [[[SPARQL11-RESULTS-CSV-TSV]]]) as scoped to the document, they cannot be understood as
             identifying nodes in the active graph of the dataset. If DS is the dataset of a query,
             pattern solutions are therefore understood to be not from the active graph of DS itself,
-            but from an RDF graph, called the <i>scoping graph,</i> which is graph-equivalent to the
-            active graph of DS but shares no blank nodes with DS or with BGP. The same scoping graph is
+            but from an RDF graph, called the <i>scoping graph,</i> which is the
+            active graph of DS but with its blank nodes uniformly replaced by new blank nodes
+	    that are in neither DS nor the BGP, much as is done when 
+	    <a data-cite="RDF12-SEMANTICS#dfn-merging">merging</a> RDF graphs.
+	    The same scoping graph is
             used for all solutions to a single query. The scoping graph is purely a theoretical
             construct; in practice, the effect is obtained simply by the document scope conventions for
             blank node identifiers.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -9856,9 +9856,9 @@ The set <var>PV</var> is used later for projection (see Section&nbsp;<a href="#s
             [[[SPARQL11-RESULTS-CSV-TSV]]]) as scoped to the document, they cannot be understood as
             identifying nodes in the active graph of the dataset. If DS is the dataset of a query,
             pattern solutions are therefore understood to be not from the active graph of DS itself,
-            but from an RDF graph, called the <i>scoping graph,</i> which is the
+            but from an RDF graph, called the <i>scoping graph</i>. This graph is the
             active graph of DS but with its blank nodes uniformly replaced by new blank nodes
-	    that are in neither DS nor the BGP, much as is done when 
+	    that are neither in DS nor in the BGP, much as is done when 
 	    <a data-cite="RDF12-SEMANTICS#dfn-merging">merging</a> RDF graphs.
 	    The same scoping graph is
             used for all solutions to a single query. The scoping graph is purely a theoretical


### PR DESCRIPTION
Fixes #366


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/368.html" title="Last updated on Apr 9, 2026, 4:43 PM UTC (5159017)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/368/11482c5...5159017.html" title="Last updated on Apr 9, 2026, 4:43 PM UTC (5159017)">Diff</a>