### PR TITLE
Replace markdown link with reSpec

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -7505,8 +7505,11 @@ WHERE {
             <pre class="prototype nohighlight"> <span class="return">xsd:boolean</span>  <span class="operator">langMatches</span> (<span class="type"><span class="type">xsd:string</span></span> <span class="name">language-tag</span>, <span class="type"><span class="type">xsd:string</span></span> <span class="name">language-range</span>)
             </pre>
 
-            <p>Returns `true` if the argument <code>language-tag</code> (a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>)
-               matches the argument <code>language-range</code> (a [basic language range](https://www.rfc-editor.org/rfc/rfc4647#section-2.1) per [[[RFC4647]]] [[RFC4647]] section 2.1)
+            <p>Returns `true` if the argument <code>language-tag</code>
+              (a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>)
+               matches the argument <code>language-range</code> 
+              (a <a data-cite="RFC4647#section-2.1">basic language range</a>
+              per [[RFC4647]] section 2.1 [[[RFC4647]]])
               according to the basic filtering scheme defined in
               [[RFC4647]] section 3.3.1. Otherwise, the function returns `false`.
             </p>


### PR DESCRIPTION
Replace markdown link `[]()` with `<a data-cite=`.
Shorten lines.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/371.html" title="Last updated on Apr 16, 2026, 1:27 PM UTC (b8b18f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/371/e949c26...b8b18f0.html" title="Last updated on Apr 16, 2026, 1:27 PM UTC (b8b18f0)">Diff</a>