### PR TITLE
Remove extra definition of filter set FS in Translate Graph Patterns.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9284,7 +9284,6 @@ If the form is GRAPH Var GroupGraphPattern
               <p>If the form is <code><a href="#rGroupGraphPattern">GroupGraphPattern</a></code>:</p>
             </blockquote>
 <pre class="code nohighlight">
-Let FS := the empty set
 Let <var>G</var> := <a href="#defn_absContextSolution" class="absOp">ContextSolution</a>
 
 For each element <var>E</var> in the sequence of elements in the GroupGraphPattern


### PR DESCRIPTION
In [18.3.2.2 Collect FILTER Elements](https://w3c.github.io/sparql-query/spec/#sparqlCollectFilters) the pseudocode starts with:

```
Let FS := empty set
```

with the comment "The set of filter expressions FS is used later." That "later" is in [18.3.2.7 Filters of Group](https://w3c.github.io/sparql-query/spec/#sparqlAddFilters). However, in between these two places, there is [18.3.2.6 Translate Graph Patterns](https://w3c.github.io/sparql-query/spec/#sparqlTranslateGraphPatterns) where in the subsection "If the form is GroupGraphPattern:" we get another:

```
Let FS := the empty set
```

This seems like it would remove any filters collected in FS in 18.3.2.2, and the fix is simply to remove the second definition, as `FS` is not actually used in 18.3.2.6.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/372.html" title="Last updated on May 4, 2026, 9:00 PM UTC (b5f2519)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/372/67c4682...b5f2519.html" title="Last updated on May 4, 2026, 9:00 PM UTC (b5f2519)">Diff</a>