### PR TITLE
Use same formatting for filter collecting

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9079,7 +9079,7 @@ WHERE {
               from group, then <a href="#sparqlAddFilters">apply them to the whole translated group
                 graph pattern</a>.</p>
 
-            <pre class="code nohighlightBlock">
+            <pre class="code nohighlight">
 Let FS := empty set
 For each form FILTER(expr) in the group graph pattern
     FS := FS ∪ {expr}


### PR DESCRIPTION
The code in [18.3.2.2 Collect FILTER Elements](https://www.w3.org/TR/sparql12-query/#sparqlCollectFilters) was different to the rest of section 18.3.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/373.html" title="Last updated on May 5, 2026, 8:14 AM UTC (808ad85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/373/67c4682...808ad85.html" title="Last updated on May 5, 2026, 8:14 AM UTC (808ad85)">Diff</a>