### PR TITLE
Add version labels table

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1428,8 +1428,8 @@ _:b0  :p        "v" .
           </table>
 
           <p>
-            A query conforming to version "1.1" is valid as a query with version "1.2-basic", 
-            and a query conforming to version "1.2-basic" is valid as a query with version "1.2".
+            If a query conforms to version "1.1", it also conforms to version "1.2-basic", 
+            and if a query conforms to version "1.2-basic", it also conforms to version "1.2".
           </p>
           <p>
             While "1.1" is an acceptable version label,

--- a/spec/index.html
+++ b/spec/index.html
@@ -1398,7 +1398,7 @@ _:b0  :p        "v" .
             for the SPARQL query.
           </p>
           <p class="note">
-            Even though the version labels strings in SPARQL are the same as those in <a data-cite="RDF12-CONCEPTS#defined-version-labels">the version labels defined by RDF</a>, their meaning is different. Namely, the SPARQL version labels refer to SPARQL syntax and semantics, while the RDF version labels refer to RDF syntax and semantics.
+            Even though the version label strings in SPARQL are the same as <a data-cite="RDF12-CONCEPTS#defined-version-labels">the version labels defined by RDF</a>, their meaning is different. Namely, the SPARQL version labels refer to SPARQL syntax and semantics, while the RDF version labels refer to RDF syntax and semantics.
           </p>
           <table id="tab-version-labels" class="simple">
             <caption>SPARQL Version Labels</caption>
@@ -1417,7 +1417,7 @@ _:b0  :p        "v" .
               </tr>
               <tr>
                 <td>"1.2-basic"</td>
-                <td>SPARQL 1.2 query or update syntax, without triple terms</td>
+                <td>SPARQL 1.2 query or update syntax, without triple terms and without triple patterns that have a triple pattern in their subject or object position</td>
                 <td>[[[SPARQL12-Query]]], [[[SPARQL12-Update]]]</td>
               </tr>
               <tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1386,6 +1386,48 @@ _:b0  :p        "v" .
                   :myreifier :tripleAdded ?date .
               }
 </pre>
+        <section id="versionLabels">
+          <h4>Version Labels</h4>
+          <p>
+            A <dfn class="export">SPARQL version label</dfn> is a string that identifies the syntax and semantics conformance
+            for the SPARQL query.
+          </p>
+          <p class="note">
+            Even though the version labels strings in SPARQL are the same as those in <a data-cite="RDF12-CONCEPTS#defined-version-labels">the version labels defined by RDF</a>, their meaning is different. Namely, the SPARQL version labels refer to SPARQL syntax and semantics, while the RDF version labels refer to RDF syntax and semantics.
+          </p>
+          <table id="tab-version-labels" class="simple">
+            <caption>SPARQL Version Labels</caption>
+            <thead>
+              <tr>
+                <th style="text-align: center">Version Label</th>
+                <th style="text-align: center">Syntax</th>
+                <th style="text-align: center">Semantics</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>"1.2"</td>
+                <td>SPARQL 1.2 query or update syntax</td>
+                <td>[[[SPARQL12-Query]]], [[[SPARQL12-Update]]]</td>
+              </tr>
+              <tr>
+                <td>"1.2-basic"</td>
+                <td>SPARQL 1.2 query or update syntax, without triple terms</td>
+                <td>[[[SPARQL12-Query]]], [[[SPARQL12-Update]]]</td>
+              </tr>
+              <tr>
+                <td>"1.1"</td>
+                <td>SPARQL 1.1 query or update syntax, except for use of a version directive</td>
+                <td>[[[SPARQL11-Query]]], [[[SPARQL11-Update]]]</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p>
+            A query conforming to version "1.1" is valid as a query with version "1.2-basic", 
+            and a query conforming to version "1.2-basic" is valid as a query with version "1.2".
+          </p>
+        </section>
       </section>
     </section>
     <section id="GraphPattern">

--- a/spec/index.html
+++ b/spec/index.html
@@ -1374,6 +1374,10 @@ _:b0  :p        "v" .
           or <a href="#func-triple-terms">functions on triple terms</a>,
           authors MAY announce the use of the new syntax forms by including this directive.
         </p>
+        <p>
+          Version labels are defined in the following section.
+          Processors may treat unrecognized labels as an error or as a warning.
+        </p>
         <pre class="query nohighlight">
               VERSION "1.2"
               PREFIX : &lt;http://example/&gt;
@@ -1426,6 +1430,11 @@ _:b0  :p        "v" .
           <p>
             A query conforming to version "1.1" is valid as a query with version "1.2-basic", 
             and a query conforming to version "1.2-basic" is valid as a query with version "1.2".
+          </p>
+          <p>
+            While "1.1" is an acceptable version label,
+            its use in a <code>VERSION</code> directive is discouraged,
+            as it would needlessly cause SPARQL 1.1 parsers to fail.
           </p>
         </section>
       </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1372,7 +1372,8 @@ _:b0  :p        "v" .
           When writing SPARQL queries with new features such as
           <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>
           or <a href="#func-triple-terms">functions on triple terms</a>,
-          authors MAY announce the use of the new syntax forms by including this directive.
+          authors MAY announce the use of the new syntax forms by including this directive
+          followed by a version label indicating the version required to process the included features.
         </p>
         <p>
           Version labels are defined in the following section.


### PR DESCRIPTION
Similar to [RDF version labels](https://w3c.github.io/rdf-concepts/spec/#defined-version-labels), this PR adds an overview of version labels to SPARQL (which have a different meaning).

Closes https://github.com/w3c/sparql-query/issues/353


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/374.html" title="Last updated on May 15, 2026, 2:00 PM UTC (9bec78e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/374/2fed72d...9bec78e.html" title="Last updated on May 15, 2026, 2:00 PM UTC (9bec78e)">Diff</a>