### PR TITLE
GH-375: In-scope for GROUP BY variable

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -8974,7 +8974,11 @@ WHERE {
                 <td>`v` is in-scope</td>
               </tr>
               <tr>
-                <td>`GROUP BY (expr AS v)`</td>
+                <td>`GROUP BY ... v`</td>
+                <td>`v` is in-scope</td>
+              </tr>
+              <tr>
+                <td>`GROUP BY ... (expr AS v)`</td>
                 <td>`v` is in-scope</td>
               </tr>
               <tr>


### PR DESCRIPTION
This closes #375.

Add a scope rule for `GROUP BY ?v`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/376.html" title="Last updated on May 13, 2026, 8:45 PM UTC (0c15ff8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/376/2fed72d...0c15ff8.html" title="Last updated on May 13, 2026, 8:45 PM UTC (0c15ff8)">Diff</a>