### PR TITLE
Restrict use of SELECT * in queries with implicit grouping.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -12891,7 +12891,7 @@ _:x rdf:type xsd:decimal .
                   `LANGDIR`, `hasLANG`, hasLANGDIR, and `STRLANGDIR`</li>
                 <li>Define parser input as being an 
                   <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a>. 
-                  Exclude Unicode surrogates from Unicode escape sequences.</li>
+                  Exclude Unicode surrogates from Unicode escape sequences</li>
                 <li>Remove concepts of plain and simple literals, in favor of explicit mentions of `xsd:string`</li>
                 <li>Migrate XML Schema references to 1.1. 
                 Note that for datatypes involving years, the year 1 BCE is represented by `0000` and not as `-0001`.
@@ -12900,13 +12900,14 @@ _:x rdf:type xsd:decimal .
                 for details.
                 </li>
                 <li>Update references to XPath from 2.0 to 3.1</li>
-                <li>Define `EBV` as a functional form.</li>
-                <li>Forbid duplicated variables in `VALUES`.</li>
-                <li>Add in-between term type ORDER BY support for triple terms in <a href="#modOrderBy" class="sectionRef"></a>.</li>
-                <li>Fixes the previously informal definition of `EXISTS` by adding a formal definition in <a href="#func-filter-exists" class="sectionRef"></a>, which includes extending the <a href="#defn_eval" class="evalFct">eval</a> function with a solution mapping <var>μ<sub>ctx</sub></var> as third argument.</li>
+                <li>Define `EBV` as a functional form</li>
+                <li>Forbid duplicated variables in `VALUES`</li>
+                <li>Add in-between term type ORDER BY support for triple terms in <a href="#modOrderBy" class="sectionRef"></a></li>
+                <li>Fixes the previously informal definition of `EXISTS` by adding a formal definition in <a href="#func-filter-exists" class="sectionRef"></a>, which includes extending the <a href="#defn_eval" class="evalFct">eval</a> function with a solution mapping <var>μ<sub>ctx</sub></var> as third argument</li>
                 <li>Rename function `RDFterm-equal` as <a href="#func-sameValue"></a> and
                   expand the definition to cover literal arguments of differing datatypes where the
-                  values are known to be equal or to be not equal.</li>
+                  values are known to be equal or to be not equal</li>
+                <li>Expand the restriction on the use of `*` projection on queries that have implicit grouping</li>
             </ul>
         </li>
         <li>
@@ -12940,15 +12941,15 @@ _:x rdf:type xsd:decimal .
                   as links to their respective definition</li>
                 <li>Rename the function used to define the evaluation of property path expressions
                   in <a href="#PropertyPathPatterns" class="sectionRef"></a>
-                  from <i>eval</i> to <i>ppeval</i>.</li>
+                  from <i>eval</i> to <i>ppeval</i></li>
                 <li>Rename the function used within the definition of
                   the <a href="#defn_evalALP">ALP</a> function
-                  from <i>eval</i> to <i>reachableTerms</i>.</li>
-                <li>Add section <a href="#sparql-error" class="sectionRef"></a> about SPARQL expression evaluation errors.</li>
-                <li>Rename section "Filter evaluation" as <a href="#expression-evaluation" class="sectionRef"></a>.</li>
+                  from <i>eval</i> to <i>reachableTerms</i></li>
+                <li>Add section <a href="#sparql-error" class="sectionRef"></a> about SPARQL expression evaluation errors</li>
+                <li>Rename section "Filter evaluation" as <a href="#expression-evaluation" class="sectionRef"></a></li>
                 <li>Improve definitions of all algebra operators that involve expressions
                   (<a href="#defn_algFilter" class="algFct">Filter</a>, <a href="#defn_algDiff" class="algFct">Diff</a>,
-                  <a href="#defn_algLeftJoin" class="algFct">LeftJoin</a>, and <a href="#defn_algExtend" class="algFct">Extend</a>).</li>
+                  <a href="#defn_algLeftJoin" class="algFct">LeftJoin</a>, and <a href="#defn_algExtend" class="algFct">Extend</a>)</li>
             </ul>
         </li>
         <li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -4042,8 +4042,9 @@ LIMIT 20
             selects all of the variables that are <a href="#variableScope">in-scope</a> at that point
             in the query. It excludes variables only used in <code>FILTER</code>, in the right-hand
             side of <code>MINUS</code>, and takes account of subqueries.</p>
-          <p>Use of <code>SELECT *</code> is only permitted when the query does not have a
-            <code>GROUP BY</code> clause.</p>
+          <p>Use of <code>SELECT *</code> is only permitted when the query does not use grouping
+            (either through the use of a <code>GROUP BY</code> clause, or due to the presence of aggregates
+            in <code>HAVING</code> or <code>ORDER BY</code> clauses).</p>
           <div class="exampleGroup">
             <pre class="data nohighlight">
 PREFIX  foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
@@ -11419,6 +11420,12 @@ _:x rdf:type xsd:decimal .
             is only permitted after a triple when the property position is
             a simple path (an IRI, the keyword `a`, or a variable),
             and not for other path expressions.
+          </li>
+          <li>
+            The use of `*` in a <a href="#rSelectClause">SELECT</a> clause
+            is not allowed in a <a href="#rQueryUnit">query</a> containing a <a href="#rGroupClause"><code>GROUP BY</code></a> clause
+            or when <a href="#rAggregate">aggregates</a> appear in either <a href="#rHavingClause"><code>HAVING</code></a> or
+            <a href="#rOrderClause"><code>ORDER BY</code></a> clauses.
           </li>
         </ol>
 


### PR DESCRIPTION
Closes #378.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/379.html" title="Last updated on May 20, 2026, 5:08 PM UTC (fe9a7bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/379/af0ed0f...fe9a7bb.html" title="Last updated on May 20, 2026, 5:08 PM UTC (fe9a7bb)">Diff</a>