### PR TITLE
Update Aggregate Projection Restrictions.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2960,8 +2960,8 @@ HAVING(AVG(?size) &gt; 10)
       </section>
       <section id="aggregateRestrictions">
         <h3>Aggregate Projection Restrictions</h3>
-        <p>In a query level which uses grouping (either through the explicit use of aggregates in projection,
-          <code>HAVING</code>, or <code>ORDER BY</code> clauses, or by the use of a <code>GROUP BY</code> clause),
+        <p>In a query level which uses grouping (either by the explicit use of a <code>GROUP BY</code> clause
+          or through the use of aggregates in projection, <code>HAVING</code>, or <code>ORDER BY</code> clauses),
           all variables appearing in projection or SELECT expressions MUST satisfy exactly one of the following conditions:</p>
         <ul>
         <li>the variable is aggregated</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2960,10 +2960,16 @@ HAVING(AVG(?size) &gt; 10)
       </section>
       <section id="aggregateRestrictions">
         <h3>Aggregate Projection Restrictions</h3>
-        <p>In a query level which uses aggregates, only expressions consisting of aggregates and
-          constants may be projected, with one exception. When <code>GROUP BY</code> is given with one
-          or more simple expressions consisting of just a variable, those variables may be projected
-          from the level.</p>
+        <p>In a query level which uses grouping (either through the explicit use of aggregates in projection,
+          <code>HAVING</code>, or <code>ORDER BY</code> clauses, or by the use of a <code>GROUP BY</code> clause),
+          all variables appearing in projection or SELECT expressions MUST satisfy one of the following conditions:</p>
+        <ul>
+        <li>the variable is aggregated</li>
+        <li>the variable, <var>V</var>, appears as a named <code>GROUP BY</code> variable (with the <code>GROUP BY</code> expression consisting of just the variable <var>V</var>, or having the form <code>(expr AS <var>V</var>)</code>)</li>
+        <li>the variable is introduced by an earlier SELECT expression in the same SELECT clause</li>
+        </ul>
+        <p>If such a variable does not satisfy one of these conditions, the query is syntactically invalid.</p>
+
         <p>For example, the following query is legal as ?x is given as a <code>GROUP BY</code>
           term.</p>
         <pre class="query nohighlight">
@@ -2974,12 +2980,11 @@ WHERE {
     ?x :q ?z .
 } GROUP BY ?x (STR(?z))
         </pre>
-        <p>Note that it would not be legal to project <code>STR(?z)</code> as this is not a simple
-          variable expression. However, with <code>GROUP BY (STR(?z) AS ?strZ)</code> it would be
+        <p>Note that it would not be legal to project <code>STR(?z)</code> as this expression is neither a simple variable,
+          nor a named <code>GROUP BY</code> expression. However, with <code>GROUP BY (STR(?z) AS ?strZ)</code> it would be
           possible to project <code>?strZ</code>.</p>
-        <p>Other expressions, not using <code>GROUP BY</code> variables, or aggregates may have
-          non-deterministic values projected from their groups using the <code>SAMPLE</code>
-          aggregate.</p>
+        <p>Other expressions which use variables not satisfying the above conditions may be
+          projected from their groups using the <code>SAMPLE</code> aggregate.</p>
       </section>
       <section id="aggregateExample2">
         <h3>Aggregate Example (with errors)</h3>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2965,7 +2965,8 @@ HAVING(AVG(?size) &gt; 10)
           every variable that appears in projection or SELECT expressions of that query level
           MUST satisfy exactly one of the following conditions:</p>
         <ul>
-        <li>the variable is aggregated</li>
+        <li>the variable appears as part of a sub-expression within the SELECT expression and this sub-expression is used as an argument to an aggregate (e.g., <code>MIN(?v)</code> or <code>AVG(?v+2)</code>)
+        </li>
         <li>the variable, <var>V</var>, appears as a named <code>GROUP BY</code> variable (with the corresponding <code>GROUP BY</code> expression consisting of just the variable <var>V</var>, or having the form <code>(expr AS <var>V</var>)</code>)</li>
         <li>the variable is introduced by an earlier SELECT expression in the same SELECT clause</li>
         </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2962,7 +2962,7 @@ HAVING(AVG(?size) &gt; 10)
         <h3>Aggregate Projection Restrictions</h3>
         <p>In a query level which uses grouping (either through the explicit use of aggregates in projection,
           <code>HAVING</code>, or <code>ORDER BY</code> clauses, or by the use of a <code>GROUP BY</code> clause),
-          all variables appearing in projection or SELECT expressions MUST satisfy one of the following conditions:</p>
+          all variables appearing in projection or SELECT expressions MUST satisfy exactly one of the following conditions:</p>
         <ul>
         <li>the variable is aggregated</li>
         <li>the variable, <var>V</var>, appears as a named <code>GROUP BY</code> variable (with the <code>GROUP BY</code> expression consisting of just the variable <var>V</var>, or having the form <code>(expr AS <var>V</var>)</code>)</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2962,7 +2962,8 @@ HAVING(AVG(?size) &gt; 10)
         <h3>Aggregate Projection Restrictions</h3>
         <p>In a query level which uses grouping (either by the explicit use of a <code>GROUP BY</code> clause
           or through the use of aggregates in projection, <code>HAVING</code>, or <code>ORDER BY</code> clauses),
-          all variables appearing in projection or SELECT expressions MUST satisfy exactly one of the following conditions:</p>
+          every variable that appears in projection or SELECT expressions of that query level
+          MUST satisfy exactly one of the following conditions:</p>
         <ul>
         <li>the variable is aggregated</li>
         <li>the variable, <var>V</var>, appears as a named <code>GROUP BY</code> variable (with the <code>GROUP BY</code> expression consisting of just the variable <var>V</var>, or having the form <code>(expr AS <var>V</var>)</code>)</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2965,9 +2965,9 @@ HAVING(AVG(?size) &gt; 10)
           every occurrence of a variable that appears in projection or SELECT expressions of that query level
           MUST satisfy one of the following conditions:</p>
         <ul>
+        <li>the variable, <var>V</var>, appears as a named <code>GROUP BY</code> variable (with the corresponding <code>GROUP BY</code> expression consisting of just the variable <var>V</var>, or having the form <code>(expr AS <var>V</var>)</code>)</li>
         <li>the variable appears as part of a sub-expression within the SELECT expression and this sub-expression is used as an argument to an aggregate (e.g., <code>MIN(?v)</code> or <code>AVG(?v+2)</code>)
         </li>
-        <li>the variable, <var>V</var>, appears as a named <code>GROUP BY</code> variable (with the corresponding <code>GROUP BY</code> expression consisting of just the variable <var>V</var>, or having the form <code>(expr AS <var>V</var>)</code>)</li>
         <li>the variable is introduced by an earlier SELECT expression in the same SELECT clause</li>
         </ul>
         <p>If such a variable occurrence does not satisfy one of these conditions, the query is syntactically invalid.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2982,7 +2982,7 @@ WHERE {
 } GROUP BY ?x (STR(?z))
         </pre>
         <p>Note that it would not be legal to project <code>STR(?z)</code> as this expression is neither a simple variable,
-          nor a named <code>GROUP BY</code> expression. However, with <code>GROUP BY (STR(?z) AS ?strZ)</code> it would be
+          nor a named <code>GROUP BY</code> expression. However, with <code>GROUP BY ?x (STR(?z) AS ?strZ)</code> it would be
           possible to project <code>?strZ</code>.</p>
         <p>Other expressions which use variables not satisfying the above conditions may be
           projected from their groups using the <code>SAMPLE</code> aggregate.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2962,15 +2962,15 @@ HAVING(AVG(?size) &gt; 10)
         <h3>Aggregate Projection Restrictions</h3>
         <p>In a query level which uses grouping (either by the explicit use of a <code>GROUP BY</code> clause
           or through the use of aggregates in projection, <code>HAVING</code>, or <code>ORDER BY</code> clauses),
-          every variable that appears in projection or SELECT expressions of that query level
-          MUST satisfy exactly one of the following conditions:</p>
+          every occurrence of a variable that appears in projection or SELECT expressions of that query level
+          MUST satisfy one of the following conditions:</p>
         <ul>
         <li>the variable appears as part of a sub-expression within the SELECT expression and this sub-expression is used as an argument to an aggregate (e.g., <code>MIN(?v)</code> or <code>AVG(?v+2)</code>)
         </li>
         <li>the variable, <var>V</var>, appears as a named <code>GROUP BY</code> variable (with the corresponding <code>GROUP BY</code> expression consisting of just the variable <var>V</var>, or having the form <code>(expr AS <var>V</var>)</code>)</li>
         <li>the variable is introduced by an earlier SELECT expression in the same SELECT clause</li>
         </ul>
-        <p>If such a variable does not satisfy one of these conditions, the query is syntactically invalid.</p>
+        <p>If such a variable occurrence does not satisfy one of these conditions, the query is syntactically invalid.</p>
 
         <p>For example, the following query is legal as ?x is given as a <code>GROUP BY</code>
           term.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2966,7 +2966,7 @@ HAVING(AVG(?size) &gt; 10)
           MUST satisfy exactly one of the following conditions:</p>
         <ul>
         <li>the variable is aggregated</li>
-        <li>the variable, <var>V</var>, appears as a named <code>GROUP BY</code> variable (with the <code>GROUP BY</code> expression consisting of just the variable <var>V</var>, or having the form <code>(expr AS <var>V</var>)</code>)</li>
+        <li>the variable, <var>V</var>, appears as a named <code>GROUP BY</code> variable (with the corresponding <code>GROUP BY</code> expression consisting of just the variable <var>V</var>, or having the form <code>(expr AS <var>V</var>)</code>)</li>
         <li>the variable is introduced by an earlier SELECT expression in the same SELECT clause</li>
         </ul>
         <p>If such a variable does not satisfy one of these conditions, the query is syntactically invalid.</p>


### PR DESCRIPTION
Since there hasn't been any discussion on #377, I'm moving the proposed changes to this PR. Copying from that issue:

> The big changes here are:
> 
> * explicitly includes any query level that uses any of the aggregation mechanisms (spelled out by [18.3.4.1 Grouping and Aggregation](https://w3c.github.io/sparql-query/spec/#sparqlGroupAggregate) as the use of `GROUP BY` or "the use of aggregates in `HAVING` or `ORDER BY` clauses, or in the projection").
> * changes the language about the restriction on expressions from only "consisting of aggregates and constants" or simple `GROUP BY` variables to what I think is more explicit language about conditions that *every* variable used in SELECT expressions in these aggregating queries MUST satisfy
> * explicitly state that if the conditions on variables in SELECT expressions are not satisfied that the query is syntactically invalid



Closes #377


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/380.html" title="Last updated on May 28, 2026, 3:41 PM UTC (ba816b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/380/af0ed0f...ba816b8.html" title="Last updated on May 28, 2026, 3:41 PM UTC (ba816b8)">Diff</a>