### PR TITLE
GH-382: Move numeric escape sequences into the grammar

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -11521,7 +11521,7 @@ _:x rdf:type xsd:decimal .
                 <td><code>[12]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rConstructQuery">ConstructQuery</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'CONSTRUCT'</span> ( <a href="#rConstructTemplate">ConstructTemplate</a> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a> | <a href="#rDatasetClause">DatasetClause</a>* <span class="token">'WHERE'</span> <span class="token">'{'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? <span class="token">'}'</span> <a href="#rSolutionModifier">SolutionModifier</a> )</code></td>
+                <td><code class="gRuleBody"><span class="token">'CONSTRUCT'</span> ( <a href="#rConstructTemplate">ConstructTemplate</a> <a href="#rDatasetClause">DatasetClause</a>* <a href="#rWhereClause">WhereClause</a> <a href="#rSolutionModifier">SolutionModifier</a> | <a href="#rDatasetClause">DatasetClause</a>* <span class="token">'WHERE'</span> <a href="#rConstructTemplate">ConstructTemplate</a> <a href="#rSolutionModifier">SolutionModifier</a> )</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
@@ -12555,7 +12555,7 @@ _:x rdf:type xsd:decimal .
                 <td><code>[159]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rIRIREF">IRIREF</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'&lt;' ([^&lt;&gt;"{}|^`\]-[#x00-#x20])* '&gt;'</span></code></td>
+                <td><code class="gRuleBody"><span class="token">'&lt;' [^&lt;&gt;"{}|^`\]-[#x00-#x20] | <a href="#rUCHAR">UCHAR</a> ) * '&gt;'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
@@ -12674,28 +12674,28 @@ _:x rdf:type xsd:decimal .
                 <td><code>[176]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL1">STRING_LITERAL1</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">"'" ( ([^#x27#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* "'"</code></td>
+                <td><code class="gRuleBody">"'" ( ([^#x27#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> | <a href="#rUCHAR">UCHAR</a> )* "'"</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
                 <td><code>[177]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL2">STRING_LITERAL2</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'"' ( ([^#x22#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* '"'</code></td>
+                <td><code class="gRuleBody">'"' ( ([^#x22#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> | <a href="#rUCHAR">UCHAR</a> )* '"'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
                 <td><code>[178]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">"'''" ( ( "'" | "''" )? ( [^'\] | <a href="#rECHAR">ECHAR</a> ) )* "'''"</code></td>
+                <td><code class="gRuleBody">"'''" ( ( "'" | "''" )? ( [^'\] | <a href="#rECHAR">ECHAR</a> | <a href="#rUCHAR">UCHAR</a> ) )* "'''"</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
                 <td><code>[179]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'"""' ( ( '"' | '""' )? ( [^"\] | <a href="#rECHAR">ECHAR</a> ) )* '"""'</code></td>
+                <td><code class="gRuleBody">'"""' ( ( '"' | '""' )? ( [^"\] | <a href="#rECHAR">ECHAR</a> | <a href="#rUCHAR">UCHAR</a> ) )* '"""'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
@@ -12707,90 +12707,97 @@ _:x rdf:type xsd:decimal .
 
               <tr style="vertical-align: baseline">
                 <td><code>[181]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rUCHAR">UCHAR</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody">('\u' HEX HEX HEX HEX) | ('\U' HEX HEX HEX HEX HEX HEX HEX HEX)</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[182]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNIL">NIL</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'(' <a href="#rWS">WS</a>* ')'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[182]&nbsp;&nbsp;</code></td>
+                <td><code>[183]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rWS">WS</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">#x20 | #x9 | #xD | #xA</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[183]&nbsp;&nbsp;</code></td>
+                <td><code>[184]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rANON">ANON</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'['  <a href="#rWS">WS</a>* ']'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[184]&nbsp;&nbsp;</code></td>
+                <td><code>[185]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_CHARS_BASE">PN_CHARS_BASE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[A-Z] | [a-z] | [#x00C0-#x00D6] | [#x00D8-#x00F6] | [#x00F8-#x02FF] | [#x0370-#x037D] | [#x037F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[185]&nbsp;&nbsp;</code></td>
+                <td><code>[186]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_CHARS_U">PN_CHARS_U</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> | '_'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[186]&nbsp;&nbsp;</code></td>
+                <td><code>[187]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVARNAME">VARNAME</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">( <a href="#rPN_CHARS_U">PN_CHARS_U</a>  | [0-9] ) ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[187]&nbsp;&nbsp;</code></td>
+                <td><code>[188]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_CHARS">PN_CHARS</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPN_CHARS_U">PN_CHARS_U</a> | '-' | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040]</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[188]&nbsp;&nbsp;</code></td>
+                <td><code>[189]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_PREFIX">PN_PREFIX</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[189]&nbsp;&nbsp;</code></td>
+                <td><code>[190]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_LOCAL">PN_LOCAL</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">(<a href="#rPN_CHARS_U">PN_CHARS_U</a> | ':' | [0-9] | <a href="#rPLX">PLX</a> ) ((<a href="#rPN_CHARS">PN_CHARS</a> | '.' | ':' | <a href="#rPLX">PLX</a>)* (<a href="#rPN_CHARS">PN_CHARS</a> | ':' | <a href="#rPLX">PLX</a>) )?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[190]&nbsp;&nbsp;</code></td>
+                <td><code>[191]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPLX">PLX</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPERCENT">PERCENT</a> | <a href="#rPN_LOCAL_ESC">PN_LOCAL_ESC</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[191]&nbsp;&nbsp;</code></td>
+                <td><code>[192]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPERCENT">PERCENT</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'%' <a href="#rHEX">HEX</a> <a href="#rHEX">HEX</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[192]&nbsp;&nbsp;</code></td>
+                <td><code>[193]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rHEX">HEX</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[0-9] | [A-F] | [a-f]</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[193]&nbsp;&nbsp;</code></td>
+                <td><code>[194]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_LOCAL_ESC">PN_LOCAL_ESC</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )</code></td>

--- a/spec/sparql.bnf
+++ b/spec/sparql.bnf
@@ -1,6 +1,6 @@
-QueryUnit                 ::= Query 
+QueryUnit                 ::= Query
 Query                     ::= Prologue ( SelectQuery | ConstructQuery | DescribeQuery | AskQuery ) ValuesClause
-UpdateUnit                ::= Update 
+UpdateUnit                ::= Update
 Prologue                  ::= ( BaseDecl | PrefixDecl | VersionDecl )*
 BaseDecl                  ::= 'BASE' IRIREF
 PrefixDecl                ::= 'PREFIX' PNAME_NS IRIREF
@@ -9,7 +9,7 @@ VersionSpecifier          ::= STRING_LITERAL1 | STRING_LITERAL2
 SelectQuery               ::= SelectClause DatasetClause* WhereClause SolutionModifier
 SubSelect                 ::= SelectClause WhereClause SolutionModifier ValuesClause
 SelectClause              ::= 'SELECT' ( 'DISTINCT' | 'REDUCED' )? ( ( Var | ( '(' Expression 'AS' Var ')' ) )+ | '*' )
-ConstructQuery            ::= 'CONSTRUCT' ( ConstructTemplate DatasetClause* WhereClause SolutionModifier | DatasetClause* 'WHERE' '{' TriplesTemplate? '}' SolutionModifier )
+ConstructQuery            ::= 'CONSTRUCT' ( ConstructTemplate DatasetClause* WhereClause SolutionModifier | DatasetClause* 'WHERE' ConstructTemplate SolutionModifier )
 DescribeQuery             ::= 'DESCRIBE' ( VarOrIri+ | '*' ) DatasetClause* WhereClause? SolutionModifier
 AskQuery                  ::= 'ASK' DatasetClause* WhereClause SolutionModifier
 DatasetClause             ::= 'FROM' ( DefaultGraphClause | NamedGraphClause )
@@ -66,7 +66,7 @@ InlineData                ::= 'VALUES' DataBlock
 DataBlock                 ::= InlineDataOneVar | InlineDataFull
 InlineDataOneVar          ::= Var '{' DataBlockValue* '}'
 InlineDataFull            ::= ( NIL | '(' Var* ')' ) '{' ( '(' DataBlockValue* ')' | NIL )* '}'
-DataBlockValue            ::= iri |	RDFLiteral |	NumericLiteral |	BooleanLiteral |	'UNDEF' |	TripleTermData
+DataBlockValue            ::= iri | RDFLiteral | NumericLiteral | BooleanLiteral | 'UNDEF' | TripleTermData
 Reifier                   ::= '~' VarOrReifierId?
 VarOrReifierId            ::= Var | iri | BlankNode
 MinusGraphPattern         ::= 'MINUS' GroupGraphPattern
@@ -78,13 +78,13 @@ ArgList                   ::= NIL | '(' 'DISTINCT'? Expression ( ',' Expression 
 ExpressionList            ::= NIL | '(' Expression ( ',' Expression )* ')' 
 ConstructTemplate         ::= '{' ConstructTriples? '}'
 ConstructTriples          ::= TriplesSameSubject ( '.' ConstructTriples? )?
-TriplesSameSubject        ::= VarOrTerm PropertyListNotEmpty |	TriplesNode PropertyList |	ReifiedTripleBlock
+TriplesSameSubject        ::= VarOrTerm PropertyListNotEmpty | TriplesNode PropertyList | ReifiedTripleBlock
 PropertyList              ::= PropertyListNotEmpty?
 PropertyListNotEmpty      ::= Verb ObjectList ( ';' ( Verb ObjectList )? )*
 Verb                      ::= VarOrIri | 'a'
 ObjectList                ::= Object ( ',' Object )*
 Object                    ::= GraphNode Annotation
-TriplesSameSubjectPath    ::= VarOrTerm PropertyListPathNotEmpty |	TriplesNodePath PropertyListPath |	ReifiedTripleBlockPath
+TriplesSameSubjectPath    ::= VarOrTerm PropertyListPathNotEmpty | TriplesNodePath PropertyListPath | ReifiedTripleBlockPath
 PropertyListPath          ::= PropertyListPathNotEmpty?
 PropertyListPathNotEmpty  ::= ( VerbPath | VerbSimple ) ObjectListPath ( ';' ( ( VerbPath | VerbSimple ) ObjectListPath )? )*
 VerbPath                  ::= Path
@@ -100,9 +100,9 @@ PathMod                   ::= '?' | '*' | '+'
 PathPrimary               ::= iri | 'a' | '!' PathNegatedPropertySet | '(' Path ')' 
 PathNegatedPropertySet    ::= PathOneInPropertySet | '(' ( PathOneInPropertySet ( '|' PathOneInPropertySet )* )? ')' 
 PathOneInPropertySet      ::= iri | 'a' | '^' ( iri | 'a' ) 
-TriplesNode               ::= Collection |	BlankNodePropertyList
+TriplesNode               ::= Collection | BlankNodePropertyList
 BlankNodePropertyList     ::= '[' PropertyListNotEmpty ']'
-TriplesNodePath           ::= CollectionPath |	BlankNodePropertyListPath
+TriplesNodePath           ::= CollectionPath | BlankNodePropertyListPath
 BlankNodePropertyListPath ::= '[' PropertyListPathNotEmpty ']'
 Collection                ::= '(' GraphNode+ ')'
 CollectionPath            ::= '(' GraphNodePath+ ')'
@@ -110,8 +110,8 @@ AnnotationPath            ::= ( Reifier | AnnotationBlockPath )*
 AnnotationBlockPath       ::= '{|' PropertyListPathNotEmpty '|}'
 Annotation                ::= ( Reifier | AnnotationBlock )*
 AnnotationBlock           ::= '{|' PropertyListNotEmpty '|}'
-GraphNode                 ::= VarOrTerm |	TriplesNode |	ReifiedTriple
-GraphNodePath             ::= VarOrTerm |	TriplesNodePath |	ReifiedTriple
+GraphNode                 ::= VarOrTerm | TriplesNode | ReifiedTriple
+GraphNodePath             ::= VarOrTerm | TriplesNodePath | ReifiedTriple
 VarOrTerm                 ::= Var | iri | RDFLiteral | NumericLiteral | BooleanLiteral | BlankNode | NIL | TripleTerm
 ReifiedTriple             ::= '<<' ReifiedTripleSubject Verb ReifiedTripleObject Reifier? '>>'
 ReifiedTripleSubject      ::= Var | iri | RDFLiteral | NumericLiteral | BooleanLiteral | BlankNode | ReifiedTriple | TripleTerm
@@ -150,8 +150,7 @@ BuiltInCall               ::= Aggregate
                           |   'BOUND' '(' Var ')' 
                           |   'IRI' '(' Expression ')' 
                           |   'URI' '(' Expression ')' 
-                          |   'BNODE' ( '(' Expression ')' 
-                          |   NIL ) 
+                          |   'BNODE' ( '(' Expression ')' | NIL ) 
                           |   'RAND' NIL 
                           |   'ABS' '(' Expression ')' 
                           |   'CEIL' '(' Expression ')' 
@@ -222,18 +221,18 @@ Aggregate                 ::= ( 'COUNT' '(' 'DISTINCT'? ( '*'
 iriOrFunction             ::= iri ArgList?
 RDFLiteral                ::= String ( LANG_DIR | '^^' iri )?
 NumericLiteral            ::= NumericLiteralUnsigned | NumericLiteralPositive | NumericLiteralNegative
-NumericLiteralUnsigned    ::= INTEGER |	DECIMAL |	DOUBLE
-NumericLiteralPositive    ::= INTEGER_POSITIVE |	DECIMAL_POSITIVE |	DOUBLE_POSITIVE
-NumericLiteralNegative    ::= INTEGER_NEGATIVE |	DECIMAL_NEGATIVE |	DOUBLE_NEGATIVE
-BooleanLiteral            ::= 'true' |	'false'
+NumericLiteralUnsigned    ::= INTEGER | DECIMAL | DOUBLE
+NumericLiteralPositive    ::= INTEGER_POSITIVE | DECIMAL_POSITIVE | DOUBLE_POSITIVE
+NumericLiteralNegative    ::= INTEGER_NEGATIVE | DECIMAL_NEGATIVE | DOUBLE_NEGATIVE
+BooleanLiteral            ::= 'true' | 'false'
 String                    ::= STRING_LITERAL1 | STRING_LITERAL2 | STRING_LITERAL_LONG1 | STRING_LITERAL_LONG2
-iri                       ::= IRIREF |	PrefixedName
+iri                       ::= IRIREF | PrefixedName
 PrefixedName              ::= PNAME_LN | PNAME_NS
-BlankNode                 ::= BLANK_NODE_LABEL |	ANON
+BlankNode                 ::= BLANK_NODE_LABEL | ANON
 
 @terminals
 
-IRIREF                    ::= '<' ([^<>"{}|^`\]-[#x00-#x20])* '>'
+IRIREF                    ::= '<' [^<>"{}|^`\]-[#x00-#x20] | UCHAR ) * '>'
 PNAME_NS                  ::= PN_PREFIX? ':'
 PNAME_LN                  ::= PNAME_NS PN_LOCAL
 BLANK_NODE_LABEL          ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
@@ -250,11 +249,12 @@ DOUBLE_POSITIVE           ::= '+' DOUBLE
 INTEGER_NEGATIVE          ::= '-' INTEGER
 DECIMAL_NEGATIVE          ::= '-' DECIMAL
 DOUBLE_NEGATIVE           ::= '-' DOUBLE
-STRING_LITERAL1           ::= "'" ( ([^#x27#x5C#xA#xD]) | ECHAR )* "'"
-STRING_LITERAL2           ::= '"' ( ([^#x22#x5C#xA#xD]) | ECHAR )* '"'
-STRING_LITERAL_LONG1      ::= "'''" ( ( "'" | "''" )? ( [^'\] | ECHAR ) )* "'''"
-STRING_LITERAL_LONG2      ::= '"""' ( ( '"' | '""' )? ( [^"\] | ECHAR ) )* '"""'
+STRING_LITERAL1           ::= "'" ( ([^#x27#x5C#xA#xD]) | ECHAR | UCHAR )* "'"
+STRING_LITERAL2           ::= '"' ( ([^#x22#x5C#xA#xD]) | ECHAR | UCHAR )* '"'
+STRING_LITERAL_LONG1      ::= "'''" ( ( "'" | "''" )? ( [^'\] | ECHAR | UCHAR ) )* "'''"
+STRING_LITERAL_LONG2      ::= '"""' ( ( '"' | '""' )? ( [^"\] | ECHAR | UCHAR ) )* '"""'
 ECHAR                     ::= '\' [tbnrf\"']
+UCHAR                     ::= ('\u' HEX HEX HEX HEX) | ('\U' HEX HEX HEX HEX HEX HEX HEX HEX)
 NIL                       ::= '(' WS* ')'
 WS                        ::= #x20 | #x9 | #xD | #xA
 ANON                      ::= '['  WS* ']'


### PR DESCRIPTION
Part of https://github.com/w3c/sparql-query/issues/382

The first commit changing the grammar table and BNF file, nothing else.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/383.html" title="Last updated on Jun 3, 2026, 4:34 PM UTC (ec7894c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/383/277a285...ec7894c.html" title="Last updated on Jun 3, 2026, 4:34 PM UTC (ec7894c)">Diff</a>