### PR TITLE
GH-382: Escape sequences section

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -69,6 +69,8 @@ pre		           { margin: 1em 4em 1em 2.5em ; /* Top Right Bottom Left */
                    page-break-inside: avoid ; }
 
 /* Tables */
+
+table { border-collapse: collapse }
 table, td	      { text-align: left; }
 td, th          { border-style: solid;
                   border-width: 1px;
@@ -201,6 +203,8 @@ div.grammarTable table * { border-left-width: 0px ;
 div.grammarTable table * tr   { border-top-style: solid ;
 			  border-top-width: 1px ;
 			  border-top-color: #AAA ; } 
+
+monoplain { font-family: monospace ; font-size: 100% ; }
 
 .grammar	{ text-align: left ;
                   vertical-align: top ; }
@@ -11133,66 +11137,256 @@ _:x rdf:type xsd:decimal .
         </p>
       </section>
 
-      <section id="codepointEscape">
-        <h3>Codepoint Escape Sequences</h3>
+      <section id="sec-escapes">
+        <h3>Escape Sequences</h3>
+
+        <p>There are three forms of escapes used in SPARQL documents:</p>
+
+        <ul>
+          <li>
+            <p>
+              A <dfn>numeric escape sequence</dfn> represents the value of
+              a <a data-cite="I18N-GLOSSARY#dfn-code-point">Unicode code point</a>.
+              <span id="codepointEscape"><!--legacy--></span>
+            </p>
+            <p>
+              A <a>numeric escape sequence</a> MUST NOT produce a code point value
+              in the range <span class="monoplain">U+D800</span> to <span class="monoplain">U+DFFF</span>,
+              which is the range for Unicode 
+              <a data-cite="I18N-GLOSSARY#dfn-surrogate" class="lint-ignore">surrogates</a>.
+            </p>
+
+            <table id="tab-uchar" title="Numeric escape sequences">
+              <colgroup>
+                <col style="width: 40%">
+                <col>
+              </colgroup>
+              <tbody>
+                <tr>
+                  <th class="major">Escape sequence</th>
+                  <th class="major">Unicode code point</th>
+                </tr>
+                <tr>
+                  <td>
+                    <span class="monoplain">'\u'</span> 
+                    <a href="#HEX">HEX</a> 
+                    <a href="#HEX">HEX</a>
+                    <a href="#HEX">HEX</a>
+                    <a href="#HEX">HEX</a>
+                  </td>
+                  <td>A Unicode code point in the ranges 
+                    <span class="monoplain">U+0000</span> to <span class="monoplain">U+D7FF</span>
+                    and <span class="monoplain">U+E000<span> to <span class="monoplain">U+FFFF</span>
+                    corresponding to the value encoded by the four hexadecimal digits 
+                    interpreted from most significant to least significant digit.
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <span class="monoplain">'\U'</span> 
+                    <a href="#HEX">HEX</a> 
+                    <a href="#HEX">HEX</a>
+                    <a href="#HEX">HEX</a> 
+                    <a href="#HEX">HEX</a> 
+                    <a href="#HEX">HEX</a>
+                    <a href="#HEX">HEX</a>
+                    <a href="#HEX">HEX</a>
+                    <a href="#HEX">HEX</a>
+                  </td>         
+                  <td>string 
+                    A Unicode code point in the ranges 
+                    <span class="monoplain">U+0000</span> to <span class="monoplain">U+D7FF</span>
+                    and <span class="monoplain">U+E000<span> to <span class="monoplain">U+10FFFF</span>
+                    corresponding to the value encoded by the eight hexadecimal digits 
+                    interpreted from most significant to least significant digit.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <p>where <a href="#HEX">HEX</a> is a hexadecimal character</p>
+            <blockquote>
+              <p><code><span class="doc-ref" id="HEX">HEX</span> ::= [0-9] | [A-F] | [a-f]</code></p>
+            </blockquote>
+          </li>
+
+          <li>
+            <p>
+              A <dfn>string escape sequence</dfn> represents a character traditionally
+              escaped in string literals:
+              <span id="grammarEscapes"><!--legacy--></span>
+            </p>
+
+            <table title="String escapes">
+              <colgroup>
+                <col style="width: 40%">
+                <col>
+              </colgroup>
+              <tbody>
+                <tr>
+                  <th class="major">Escape</th>
+                  <th class="major">Unicode code point</th>
+                </tr>
+                <tr>
+                  <td><span class="monoplain">'\t'</span></td>
+                  <td>U+0009 (tab)</td>
+                </tr>
+                <tr>
+                  <td><span class="monoplain">'\n'</span></td>
+                  <td>U+000A (line feed)</td>
+                </tr>
+                <tr>
+                  <td><span class="monoplain">'\r'</span></td>
+                  <td>U+000D (carriage return)</td>
+                </tr>
+                <tr>
+                  <td><span class="monoplain">'\b'</span></td>
+                  <td>U+0008 (backspace)</td>
+                </tr>
+                <tr>
+                  <td><span class="monoplain">'\f'</span></td>
+                  <td>U+000C (form feed)</td>
+                </tr>
+                <tr>
+                  <td><span class="monoplain">'\"'</span></td>
+                  <td>U+0022 (quotation mark, double quote mark)</td>
+                </tr>
+                <tr>
+                  <td><span class="monoplain">"\'"</span></td>
+                  <td>U+0027 (apostrophe-quote, single quote mark)</td>
+                </tr>
+                <tr>
+                  <td><span class="monoplain">'\\'</span></td>
+                  <td>U+005C (backslash)</td>
+                </tr>
+              </tbody>
+            </table>
+          </li>
+          <li> 
+            <p>
+              A <dfn>reserved character escape sequence</dfn> consists of a
+              <code class="monoplain">\</code>
+              followed by one of these characters <code>~.-!$&amp;'()*+,;=/?#@%_</code>,
+              and represents the character to the right of the  
+              <code class="monoplain">\</code>.
+            </p>
+          </li>
+        </ul>
+
         <p>
-          A <a>SPARQL string</a> is processed for codepoint escape sequences before parsing by the
-          grammar defined in EBNF below. The codepoint escape sequences for a SPARQL query string
-          are:
+          Escape sequences may be used in the following places:
         </p>
-        <span class="doc-ref" id="table68"></span>
-        <table title="Codepoint escapes">
-          <colgroup>
-            <col style="width: 40%">
-            <col>
-          </colgroup>
+
+        <table id="term2escape" class="separated last-center">
+          <thead>
+            <tr>
+              <th></th>
+              <th><a data-lt="numeric escape sequence">numeric<br/>escapes</a></th>
+              <th><a data-lt="string escape sequence">string<br/>escapes</a></th>
+              <th><a data-lt="reserved character escape sequence">reserved character<br/>escapes</a></th>
+            </tr>
+          </thead>
           <tbody>
             <tr>
-              <th class="major">Escape</th>
-              <th class="major">Unicode code point</th>
+              <td>
+                <b><a href="#rIRIREF">IRIs</a></b>,
+                used as <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a>
+                or as in
+                <a href="#rPrefixDecl" class="monoplain">PREFIX</a>,
+                or <a href="#rPrefixDecl" class="monoplain">BASE</a> declarations
+              </td>
+              <td>yes</td>
+              <td>no</td>
+              <td>no</td>
             </tr>
             <tr>
               <td>
-                <span class="token">'\u'</span> <a href="#HEX">HEX</a> <a href="#HEX">HEX</a>
-                <a href="#HEX">HEX</a> <a href="#HEX">HEX</a>
+                <b><a href="#rPN_LOCAL">local names</a></b>
               </td>
-              <td>A Unicode code point in the range U+0 to U+FFFF inclusive corresponding to the
-                encoded hexadecimal value, excluding U+D800 to U+DFFF, the 
-                <a data-cite="I18N-GLOSSARY#dfn-surrogate">surrogate code points</a>.
-              </td>
+              <td>no</td>
+              <td>no</td>
+              <td>yes</td>
             </tr>
             <tr>
               <td>
-                <span class="token">'\U'</span> <a href="#HEX">HEX</a> <a href="#HEX">HEX</a>
-                <a href="#HEX">HEX</a> <a href="#HEX">HEX</a> <a href="#HEX">HEX</a> <a href="#HEX">HEX</a> <a href="#HEX">HEX</a> <a href="#HEX">HEX</a>
+                <b><a href="#rString">Strings</a></b>
               </td>
-              <td>A Unicode code point in the range U+0 to U+10FFFF inclusive corresponding to the
-                encoded hexadecimal value, excluding U+D800 to U+DFFF, the 
-                <a data-cite="I18N-GLOSSARY#dfn-surrogate">surrogate code points</a>.
-                
+              <td>yes</td>
+              <td>yes</td>
+              <td>no</td>
             </tr>
           </tbody>
         </table>
-        <p>where <a href="#HEX">HEX</a> is a hexadecimal character</p>
-        <blockquote>
-          <p><code><span class="doc-ref" id="HEX">HEX</span> ::= [0-9] | [A-F] | [a-f]</code></p>
-        </blockquote>
-        <p>Examples:</p>
-        <pre class="query nohighlight">
-          &lt;ab\u00E9xy&gt;        # Codepoint 00E9 is Latin small e with acute - é
-          \u03B1:a            # Codepoint x03B1 is Greek small alpha - α
-          a\u003Ab            # a:b -- codepoint x3A is colon</pre>
+
         <p>
-          Codepoint escape sequences can appear anywhere in the query string. They are processed
-          before parsing based on the grammar rules and so may be replaced by codepoints with
-          significance in the grammar, such as "<code>:</code>" marking a prefixed name.
+          Escape sequences are processed by taking the sequence of Unicode code points
+          matching the relevant grammar production, then applying the following steps.
         </p>
-        <p>These escape sequences are not included in the grammar below. Only escape sequences for
-          characters that would be legal at that point in the grammar may be given. For example, the
-          variable "<code>?x\u0020y</code>" is not legal (<code>\u0020</code> is a space and is not
-          permitted in a variable name).
-        </p>
+        <ol>
+          <li>
+            The sequence of Unicode code points is scanned left-to-right for the
+            first matching escape sequence.
+          </li>
+          <li>
+            When an escape sequence is found, the code point(s) corresponding to that escape sequence
+            are substituted for the escape sequence.
+          </li>
+          <li>
+            Scanning of the sequence of Unicode code points continues from the code point 
+            immediately following the substituted escape sequence.
+          </li>
+        </ol>
+
+        <table class="separated last-center">
+          <caption>Examples of processed escape sequences</caption>
+          <thead>
+            <tr>
+              <th>Input Codepoints</th><th>Output Codepoints</th><th>Number of codepoints</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>`abc\u005Cdef`</td><td>`abc\def`</td><td>7</td>
+            </tr>
+            <tr>
+              <td>`abc\u005Ctuv`</td><td>`abc\tuv`</td><td>7</td>
+            </tr>
+            <tr>
+              <td>`\u005CA`</td><td>`\A`</td><td>2</td>
+            </tr>
+            <tr>
+              <td>`\\u005C`</td><td>`\u005C`</td><td>6</td>
+            </tr>
+            <tr>
+              <td>`\u005C\u005C`</td><td>`\\`</td><td>2</td>
+            </tr>
+            <tr>
+              <td>`\\\u005C`</td><td>`\\`</td><td>2</td>
+            </tr>
+            <tr>
+              <td>`\\\\`</td><td>`\\`</td><td>2</td>
+            </tr>
+            <tr>
+              <td>`\u005Cn`</td><td>`\n`</td><td>2</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p class="note">%-encoded sequences are in the
+          <a href="#rIRIREF">character range for IRIs</a>
+          and are <a href="#rPERCENT">explicitly allowed</a> in local names.
+          These appear as a `%`
+          followed by two hex characters and represent that
+          same sequence of three characters. These sequences are <em>not</em>
+          decoded during processing.
+          A term written as <code>&lt;http://a.example/%66oo-bar&gt;</code>
+          in Turtle designates the IRI <code>http://a.example/%66oo-bar</code>
+          and not IRI <code>http://a.example/foo-bar</code>.
+          A term written as <code>ex:%66oo-bar</code> with a prefix
+          <code>PREFIX ex: &lt;http://a.example/&gt;</code>
+          also designates the IRI <code>http://a.example/%66oo-bar</code>.</p>
       </section>
+
       <section id="whitespace">
         <h3>White Space</h3>
         <p>White space (production <code><a href="#rWS">WS</a></code>) is used to separate two
@@ -11259,65 +11453,7 @@ _:x rdf:type xsd:decimal .
         <p>Note that the same blank node identifier can occur in different
           <a href="#rQuadPattern">QuadPattern</a> clauses in a [[[SPARQL11-UPDATE]]] request.</p>
       </section>
-      <section id="grammarEscapes">
-        <h3>Escape sequences in strings</h3>
-        <p>In addition to the <a href="#codepointEscape">codepoint escape sequences</a>, the
-          following escape sequences apply to any <code><a href="#rString">string</a></code> production (e.g.
-          <code><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a></code>,
-          <code><a href="#rSTRING_LITERAL2">STRING_LITERAL2</a></code>,
-          <code><a href="#rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</a></code>,
-          <code><a href="#rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</a></code>):</p>
-        <table title="String escapes">
-          <colgroup>
-            <col style="width: 40%">
-            <col>
-          </colgroup>
-          <tbody>
-            <tr>
-              <th class="major">Escape</th>
-              <th class="major">Unicode code point</th>
-            </tr>
-            <tr>
-              <td><span class="token">'\t'</span></td>
-              <td>U+0009 (tab)</td>
-            </tr>
-            <tr>
-              <td><span class="token">'\n'</span></td>
-              <td>U+000A (line feed)</td>
-            </tr>
-            <tr>
-              <td><span class="token">'\r'</span></td>
-              <td>U+000D (carriage return)</td>
-            </tr>
-            <tr>
-              <td><span class="token">'\b'</span></td>
-              <td>U+0008 (backspace)</td>
-            </tr>
-            <tr>
-              <td><span class="token">'\f'</span></td>
-              <td>U+000C (form feed)</td>
-            </tr>
-            <tr>
-              <td><span class="token">'\"'</span></td>
-              <td>U+0022 (quotation mark, double quote mark)</td>
-            </tr>
-            <tr>
-              <td><span class="token">"\'"</span></td>
-              <td>U+0027 (apostrophe-quote, single quote mark)</td>
-            </tr>
-            <tr>
-              <td><span class="token">'\\'</span></td>
-              <td>U+005C (backslash)</td>
-            </tr>
-          </tbody>
-        </table>
-        <p>Examples:</p>
-        <pre class="query nohighlight">
-          "abc\n"
-          "xy\rz"
-          'xy\tz'
-        </pre>
-      </section>
+
       <section id="sparqlGrammar">
         <h3>Grammar</h3>
         <p>The EBNF notation used in the grammar is defined in 
@@ -12922,6 +13058,11 @@ _:x rdf:type xsd:decimal .
                   expand the definition to cover literal arguments of differing datatypes where the
                   values are known to be equal or to be not equal</li>
                 <li>Expand the restriction on the use of `*` projection on queries that have implicit grouping</li>
+                <li>
+                  Escape sequence processing has been changed to be processed during parsing, not before. 
+                  This aligns SPARQL with 
+                  <a data-cite="RDF12-TURTLE#sec-escapes">escape sequences in Turtle</a>.
+                </li>
             </ul>
         </li>
         <li>


### PR DESCRIPTION
This closes #382.

This PR changes the escape sequence sections and adds a change entry.

The text and structure is taken from Turtle.

The PR is based on the grammar change PR #383. When that merges, this PR can be aligned with `main`, and the grammar commit will go away.

The diff display gets confused, showing a block of text deleted in 19.6 but it is actually part of a section that has been moved and replaced with Turtle content in an earlier section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/384.html" title="Last updated on Jun 4, 2026, 6:04 PM UTC (844c867)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/384/a8f6255...844c867.html" title="Last updated on Jun 4, 2026, 6:04 PM UTC (844c867)">Diff</a>