### PR TITLE
Fix triple patterns being acceptable in subject position of triple patterns

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -8568,9 +8568,8 @@ WHERE {
               that is defined inductively as follows:
               If</p>
             <ul style="list-style-type: none;">
-              <li>|s| is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>,
-                a <a href="#defn_QueryVariable">variable</a>,
-                or a triple pattern,</li>
+              <li>|s| is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>
+                or a <a href="#defn_QueryVariable">variable</a>,</li>
               <li>|p| is an <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>
                 or a <a href="#defn_QueryVariable">variable</a>, and</li>
               <li>|o| is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>,


### PR DESCRIPTION
This used to be allowed in SPARQL-star, but not anymore.

We should still allow it in property paths, as we can have inverse paths.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/388.html" title="Last updated on Jun 11, 2026, 12:58 PM UTC (fea6ecf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/388/7cee218...fea6ecf.html" title="Last updated on Jun 11, 2026, 12:58 PM UTC (fea6ecf)">Diff</a>