### PR TITLE
Remove Macintosh File Type from media type entry

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -12964,13 +12964,11 @@ _:x rdf:type xsd:decimal .
     </section>
 
     <section id="mediaType">
-      <h2>Internet Media Type, File Extension and Macintosh File Type</h2>
+      <h2>Internet Media Type and File Extension</h2>
       <p>The Internet Media Type (formerly known as MIME Type) for the SPARQL Query Language is
         "<code>application/sparql-query</code>".</p>
       <p>It is recommended that sparql query files have the extension ".rq" (lowercase) on all
         platforms.</p>
-      <p>It is recommended that sparql query files stored on Macintosh HFS file systems be given a
-        file type of "TEXT".</p>
       <div class="mediatype"><div id="mime"></div>
         <dl>
           <dt>Type name:</dt>
@@ -13007,8 +13005,6 @@ _:x rdf:type xsd:decimal .
           <dt>Base URI:</dt>
           <dd>The SPARQL 'BASE &lt;IRIref&gt;' term can change the current base URI for relative
             IRIrefs in the query language that are used sequentially later in the document.</dd>
-          <dt>Macintosh file type code(s):</dt>
-          <dd>"TEXT"</dd>
           <dt>Person & email address to contact for further information:</dt>
           <dd>public-rdf-dawg-comments@w3.org</dd>
           <dt>Intended usage:</dt>


### PR DESCRIPTION
Part of  https://github.com/w3c/rdf-star-wg/issues/194


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/389.html" title="Last updated on Jun 11, 2026, 8:53 PM UTC (5316d91)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/389/7cee218...5316d91.html" title="Last updated on Jun 11, 2026, 8:53 PM UTC (5316d91)">Diff</a>