### PR TITLE
Make literals-as-subject text into a note

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -8581,15 +8581,24 @@ WHERE {
             <p>Triple patterns do not permit cycles
               (i.e., a triple pattern cannot be contained within itself).</p>
           </div>
-          <p>This definition of Triple Pattern includes literal subjects. 
-            <a href="http://www.w3.org/2000/03/rdf-tracking/#rdfms-literalsubjects">
-              This has been noted by RDF-core</a>.
-          </p>
-          <pre>"[The RDF core Working Group] noted that it is aware of no reason why literals should
-            not be subjects and a future WG with a less restrictive charter may
-            extend the syntaxes to allow literals as the subjects of statements."</pre>
-          <p>Because RDF graphs may not contain literal subjects, any SPARQL triple pattern with a
-            literal as subject will fail to match on any RDF graph.</p>
+
+          <div class="note">
+            <p>This definition of Triple Pattern includes literal subjects. 
+              <a href="http://www.w3.org/2000/03/rdf-tracking/#rdfms-literalsubjects">
+                This has been noted by RDF-core</a>.
+            </p>
+
+            <div>
+              <blockquote>
+                "[The RDF core Working Group] noted that it is aware of no reason why literals should
+                not be subjects and a future WG with a less restrictive charter may
+                extend the syntaxes to allow literals as the subjects of statements."
+              </blockquote>
+            </div>
+            <p>Because RDF graphs may not contain literal subjects, any SPARQL triple pattern with a
+              literal as subject will fail to match on any RDF graph.</p>
+          </div>
+
           <p class="note">A triple pattern that has another triple pattern
             in its subject position will fail to match on any RDF graph 
             because an [=RDF triple=] cannot have


### PR DESCRIPTION
Change the text about literals-as-subjects into a class="note".

Change `<pre>` (which has a scroll bar) into `<blockquote>`.

No content changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/390.html" title="Last updated on Jun 15, 2026, 2:45 PM UTC (82c1443)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/390/9e11795...82c1443.html" title="Last updated on Jun 15, 2026, 2:45 PM UTC (82c1443)">Diff</a>