### PR TITLE
Evaluation of property path patterns that contain triple patterns

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -10205,6 +10205,28 @@ ppeval(<var>vx</var>:var, <a href="#defn_ppeZeroOrMorePath" class="ppeOp">ZeroOr
 ppeval(<var>x</var>:term, <a href="#defn_ppeZeroOrMorePath" class="ppeOp">ZeroOrMorePath</a>(<var>ppe</var>), <var>y</var>:term) = 
     { { } } if { (<var>vy</var>:var,<var>y</var>) } in ppeval(<var>x</var>, <a href="#defn_ppeZeroOrMorePath" class="ppeOp">ZeroOrMorePath</a>(<var>ppe</var>), <var>vy</var>)
     { } otherwise
+
+ppeval(<var>X</var>:TP, <a href="#defn_ppeZeroOrMorePath" class="ppeOp">ZeroOrMorePath</a>(<var>ppe</var>), <var>vy</var>:var) =
+    { <var>μ</var> &cup; {(<var>vy</var>, <var>n</var>)} |
+         <var>μ</var> is a <a href="#defn_sparqlSolutionMapping">solution mapping</a> with dom(<var>μ</var>) = vars(<var>X</var>) and
+         (<var>vy</var>, <var>n</var>) in ppeval(<var>P</var>(<var>X</var>), <a href="#defn_ppeZeroOrMorePath" class="ppeOp">ZeroOrMorePath</a>(<var>ppe</var>), <var>vy</var>),
+         where vars(<var>X</var>) is the set of all variables in <var>X</var> and
+               <var>P</var> = <var>μ</var>(<var>σ</var>) is a <a href="#defn_PatternInstanceMapping">pattern instance mapping</a>
+               with an arbitrary <a data-cite="RDF12-SEMANTICS#dfn-instance">RDF instance mapping</a>&nbsp;<var>σ</var>
+               such that <var>P</var>(<var>X</var>) is a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a> in <a href="#defn_nodeSet">nodes</a>(<var>G</var>)
+               and {(<var>vy</var>, <var>n</var>)} and <var>μ</var> are <a href="#defn_algCompatibleMapping">compatible</a> }
+
+ppeval(<var>X</var>:TP, <a href="#defn_ppeZeroOrMorePath" class="ppeOp">ZeroOrMorePath</a>(<var>ppe</var>), <var>Y</var>:term) = ? <em>(TODO)</em>
+
+ppeval(<var>vx</var>:var, <a href="#defn_ppeZeroOrMorePath" class="ppeOp">ZeroOrMorePath</a>(<var>ppe</var>), <var>Y</var>:TP) = ? <em>(TODO)</em>
+
+ppeval(<var>X</var>:term, <a href="#defn_ppeZeroOrMorePath" class="ppeOp">ZeroOrMorePath</a>(<var>ppe</var>), <var>Y</var>:TP) =
+    { <var>μ</var> | <var>μ</var> is a <a href="#defn_sparqlSolutionMapping">solution mapping</a> with dom(<var>μ</var>) = vars(<var>Y</var>)
+          such that <var>μ</var>(<var>σ</var>(<var>Y</var>)) in <a href="#defn_evalALP">ALP</a>(<var>X</var>, <var>ppe</var>)
+              where <var>σ</var> is an arbitrary <a data-cite="RDF12-SEMANTICS#dfn-instance">RDF instance mapping</a>
+              and vars(<var>Y</var>) is the set of all variables in <var>Y</var> }
+
+ppeval(<var>X</var>:TP, <a href="#defn_ppeZeroOrMorePath" class="ppeOp">ZeroOrMorePath</a>(<var>ppe</var>), <var>Y</var>:TP) = ? <em>(TODO)</em>
           </pre>
         </div>
 <div class="issue">

--- a/spec/index.html
+++ b/spec/index.html
@@ -8756,8 +8756,8 @@ WHERE {
             <a href="#defn_absPath" class="absOp">Path</a>(|x|, |ppe|, |y|)
             is an algebraic query expression if
             |ppe| is an <a href="#defn_AlgebraicPropertyPathExpression">algebraic property path expression</a>,
-            |x| is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a> or a <a href="#defn_QueryVariable">variable</a>, and
-            |y| is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a> or a <a href="#defn_QueryVariable">variable</a>.</li>
+            |x| is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>, a <a href="#defn_QueryVariable">variable</a>, or a <a href="#defn_TriplePattern">triple pattern</a>, and
+            so is |y|.</li>
           <li id="defn_absUnion">
             <a href="#defn_absUnion" class="absOp">Union</a>(<var>A<sub>1</sub></var>, <var>A<sub>2</sub></var>)
             is an algebraic query expression if
@@ -9247,7 +9247,8 @@ For each form FILTER(expr) in the group graph pattern
               of the form <a href="#defn_absPath" class="absOp">Path</a>(...).</p>
             <p>Notes:</p>
             <ul>
-              <li>|x| and |y| are <a data-cite="RDF12-CONCEPTS#dfn-rdf-terms">RDF terms</a> or <a href="#defn_QueryVariable">variables</a>.</li>
+              <li>|x| is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-terms">RDF term</a>, a <a href="#defn_QueryVariable">variable</a>, or a <a href="#defn_TriplePattern">triple pattern</a>.</li>
+              <li>|y| is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-terms">RDF term</a>, a <a href="#defn_QueryVariable">variable</a>, or a <a href="#defn_TriplePattern">triple pattern</a>.</li>
               <li>|var| is a fresh <a href="#defn_QueryVariable">variable</a>.</li>
               <li>|ppe|, <var>ppe<sub>1</sub></var>, and <var>ppe<sub>2</sub></var> are <a href="#defn_AlgebraicPropertyPathExpression">algebraic property path expressions</a>.</li>
               <li>These are only applied to property path patterns, not within property path
@@ -10008,6 +10009,10 @@ The set <var>PV</var> is used later for projection (see Section&nbsp;<a href="#s
                 <td><code>|x|:var</code></td>
                 <td>a variable</td>
               </tr>
+              <tr>
+                <td><code>|x|:TP</code></td>
+                <td>a triple pattern</td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -10047,6 +10052,30 @@ ppeval(<var>X</var>:term, <a href="#defn_ppeLink" class="ppeOp">Link</a>(<var>ir
 ppeval(<var>X</var>:term, <a href="#defn_ppeLink" class="ppeOp">Link</a>(<var>iri</var>), <var>Y</var>:term) =
      { } if triple (<var>X</var>, <var>iri</var>, <var>Y</var>) is not in the active graph
         </pre>
+        <p>If |X| is a triple pattern:</p>
+        <pre class="nohighlight">
+ppeval(<var>X</var>:TP, <a href="#defn_ppeLink" class="ppeOp">Link</a>(<var>iri</var>), <var>Y</var>:term) = { }</pre>
+        <pre class="nohighlight">
+ppeval(<var>X</var>:TP, <a href="#defn_ppeLink" class="ppeOp">Link</a>(<var>iri</var>), <var>Y</var>:var) = { }</pre>
+        <pre class="nohighlight">
+ppeval(<var>X</var>:TP, <a href="#defn_ppeLink" class="ppeOp">Link</a>(<var>iri</var>), <var>Y</var>:TP) = { }</pre>
+        <p>If |X| is a variable and |Y| a triple pattern:</p>
+        <pre class="nohighlight">
+ppeval(<var>X</var>:var, <a href="#defn_ppeLink" class="ppeOp">Link</a>(<var>iri</var>), <var>Y</var>:TP) =
+    { (<var>X</var>, <var>xn</var>:term) &cup; <var>μ</var> | triple (<var>xn</var>, <var>iri</var>, <var>P</var>({<var>Y</var>}) ) is in the active graph,
+                         where <var>P</var> = <var>μ</var>(<var>σ</var>) is a <a href="#defn_PatternInstanceMapping">pattern instance mapping</a>
+                         with an <a data-cite="RDF12-SEMANTICS#dfn-instance">RDF instance mapping</a>&nbsp;<var>σ</var>
+                         and a <a href="#defn_sparqlSolutionMapping">solution mapping</a>&nbsp;<var>μ</var>
+                         such that dom(<var>μ</var>) is the set of all variables in <var>Y</var>
+                         and {(<var>X</var>, <var>xn</var>:term)} and <var>μ</var> are <a href="#defn_algCompatibleMapping">compatible</a> }</pre>
+        <p>If |X| is an RDF term and |Y| a triple pattern:</p>
+        <pre class="nohighlight">
+ppeval(<var>X</var>:term, <a href="#defn_ppeLink" class="ppeOp">Link</a>(<var>iri</var>), <var>Y</var>:TP) =
+    { <var>μ</var> | triple (<var>X</var>, <var>iri</var>, <var>P</var>({<var>Y</var>}) ) is in the active graph,
+          where <var>P</var> = <var>μ</var>(<var>σ</var>) is a <a href="#defn_PatternInstanceMapping">pattern instance mapping</a>
+          with an <a data-cite="RDF12-SEMANTICS#dfn-instance">RDF instance mapping</a>&nbsp;<var>σ</var>
+          and a <a href="#defn_sparqlSolutionMapping">solution mapping</a>&nbsp;<var>μ</var>
+          such that dom(<var>μ</var>) is the set of all variables in <var>Y</var> }</pre>
         <p>Informally, evaluating a Predicate Property Path is the same as executing a subquery
           <code>SELECT&nbsp;*&nbsp;{&nbsp;|X|&nbsp;|iri|&nbsp;|Y|&nbsp;}</code> at that point in the query evaluation.</p>
         <div class="defn">
@@ -10167,6 +10196,10 @@ ppeval(<var>x</var>:term, <a href="#defn_ppeZeroOrMorePath" class="ppeOp">ZeroOr
     { } otherwise
           </pre>
         </div>
+<div class="issue">
+  The previous definition needs to be extended to cover cases in which |X| or |Y| is a triple pattern.
+  Notice that this will add five more cases to the definition!
+</div>
         <div class="defn">
           <p><b>Definition: <span id="defn_evalOneOrMorePath">Evaluation of OneOrMorePath</span></b></p>
           <p>Let <var>ppe</var> be an <a href="#defn_AlgebraicPropertyPathExpression">algebraic property path expression</a>.
@@ -10198,6 +10231,10 @@ ppeval(<var>x</var>:term, <a href="#defn_ppeOneOrMorePath" class="ppeOp">OneOrMo
     { } otherwise
 </pre>
         </div>
+<div class="issue">
+  The previous definition needs to be extended to cover cases in which |x| or |y| is a triple pattern.
+  Notice that this will add five more cases to the definition!
+</div>
         <div class="defn">
           <p><b>Definition: <span id="eval_negatedPropertySet">Evaluation of NegatedPropertySet</span></b></p>
           <pre class="nohighlight">
@@ -10213,6 +10250,9 @@ and <var>G</var> the <a href="#defn_ActiveGraph">active graph</a>.
        { <var>μ</var> | ∃ triple(<var>μ'</var>(<var>μ</var>, <var>x</var>), <var>p</var>, <var>μ'</var>(<var>μ</var>, <var>y</var>)) in <var>G</var>, such that the IRI of <var>p</var> ∉ <var>S</var> }
           </pre>
         </div>
+<div class="issue">
+  The previous definition needs to be extended to cover cases in which |x| or |y| is a triple pattern.
+</div>
       </section>
       <section id="sparqlAlgebra">
         <h3>SPARQL Algebra</h3>
@@ -13035,6 +13075,8 @@ _:x rdf:type xsd:decimal .
             <ul>
                 <li>Update grammar for triple terms, reifiers, reified triples, annotation syntax, and triple term functions
                   in <a href="#sparqlGrammar" class="sectionRef"></a></li>
+                <li>Extend the <a href="#PropertyPathPatterns">evaluation of property path patterns</a>
+                  to cover <a href="#defn_PropertyPathPattern">property path patterns</a> that contain triple patterns.</li>
                 <li>Add functions related to <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> to
                   <a href="#func-triple-terms" class="sectionRef"></a>:
                   `TRIPLE`, `isTRIPLE`, `SUBJECT`, `PREDICATE`, `OBJECT`</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -10076,6 +10076,10 @@ ppeval(<var>X</var>:term, <a href="#defn_ppeLink" class="ppeOp">Link</a>(<var>ir
           with an <a data-cite="RDF12-SEMANTICS#dfn-instance">RDF instance mapping</a>&nbsp;<var>σ</var>
           and a <a href="#defn_sparqlSolutionMapping">solution mapping</a>&nbsp;<var>μ</var>
           such that dom(<var>μ</var>) is the set of all variables in <var>Y</var> }</pre>
+<div class="issue" data-number="393">
+  All of these cases above are incomplete in the sense that they do not mention the multiplicities of the solution mappings.
+  Moreover, for cases in which |X| or |Y| is a blank node, the formulas are even wrong.
+</div>
         <p>Informally, evaluating a Predicate Property Path is the same as executing a subquery
           <code>SELECT&nbsp;*&nbsp;{&nbsp;|X|&nbsp;|iri|&nbsp;|Y|&nbsp;}</code> at that point in the query evaluation.</p>
         <div class="defn">
@@ -10143,6 +10147,13 @@ ppeval(<var>X</var>:var, <a href="#defn_ppeZeroOrOnePath" class="ppeOp">ZeroOrOn
         either (<var>yn</var> in <a href="#defn_nodeSet">nodes</a>(<var>G</var>) and <var>xn</var> = <var>yn</var>)
         or {(<var>X</var>, <var>xn</var>), (<var>Y</var>, <var>yn</var>)} in ppeval(<var>X</var>, <var>ppe</var>, <var>Y</var>) }</pre>
         </div>
+<div class="issue" data-number="394">
+  <p>The previous definition does not correctly cover cases in which |X| or |Y| are a blank node.</p>
+  <p>Moreover, the definition needs to be explicit about the multiplicity of the resulting solution mappings.
+    Is the result of `ppeval`(<var>X</var>, <a href="#defn_ppeZeroOrOnePath" class="ppeOp">ZeroOrOnePath</a>(<var>ppe</var>), <var>Y</var>)
+    just a set of solution mappings?
+    The question is relevant because `ppeval`(<var>X</var>, <var>ppe</var>, <var>Y</var>) may produce a multiset of solution mappings.</p>
+</div>
         <p>We define an auxiliary function, <a href="#defn_evalALP">ALP</a>, used in the definitions of <a href="#defn_evalZeroOrMorePath">ZeroOrMorePath</a> and
           <a href="#defn_evalOneOrMorePath">OneOrMorePath</a>. Note that the algorithm given here serves to specify the feature. An
           implementor is free to implement evaluation by any method that produces the same results
@@ -10252,6 +10263,13 @@ and <var>G</var> the <a href="#defn_ActiveGraph">active graph</a>.
         </div>
 <div class="issue">
   The previous definition needs to be extended to cover cases in which |x| or |y| is a triple pattern.
+</div>
+<div class="issue" data-number="395">
+  <p>The previous definition does not correctly cover cases in which |x| or |y| are a blank node.</p>
+  <p>Moreover, the definition needs to be explicit about the multiplicity of the resulting solution mappings.
+    Is the result of `ppeval`(<var>x</var>, <a href="#defn_ppeNPS" class="ppeOp">NPS</a>(<var>S</var>), <var>y</var>)
+    just a set of solution mappings?
+    The question is relevant because there may be multiple such <var>p</var> ∉ <var>S</var> (and, also, |x| or |y| may be a blank node).</p>
 </div>
       </section>
       <section id="sparqlAlgebra">


### PR DESCRIPTION
When discussing Ruben's recent PR #388, I realized that [algebraic query expression](https://www.w3.org/TR/sparql12-query/#defn_AlgebraicQueryExpression) of the form [Path](https://www.w3.org/TR/sparql12-query/#defn_absPath)(_x_, _ppe_, _y_) need to be extended such that both _x_ and _y_ may be a triple pattern. But then I also realized that we actually need to extend the whole [evaluation of property path pattern](https://www.w3.org/TR/sparql12-query/#PropertyPathPatterns) to cover property path patterns that contain triple patterns. This PR enters that rabbit hole.

The PR is still incomplete: the [evaluation of ZeroOrMorePath](https://www.w3.org/TR/sparql12-query/#defn_evalZeroOrMorePath) still needs to be extended, and so does the evaluation of [evaluation of OneOrMorePath](https://www.w3.org/TR/sparql12-query/#defn_evalOneOrMorePath) and the [evaluation of NegatedPropertySet](https://www.w3.org/TR/sparql12-query/#eval_negatedPropertySet). But maybe some of you want to take a look already?

When working on this PR, I also discovered issues #393, #394, and #395. This PR adds notes for these issues into the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/396.html" title="Last updated on Jun 26, 2026, 7:13 AM UTC (5f5d67d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/396/2762075...5f5d67d.html" title="Last updated on Jun 26, 2026, 7:13 AM UTC (5f5d67d)">Diff</a>