### PR TITLE
Mention base direction with language tags

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -701,6 +701,14 @@ PREFIX xsd:  &lt;http://www.w3.org/2001/XMLSchema#&gt;
               </table>
             </div>
           </div>
+          <p>
+            SPARQL also supports matching a given
+            <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.
+            Like Turtle, it is written following the language tag, for example,
+            <code>@en--ltr</code>.
+            The base direction is restricted to either `ltr` or `rtl`.
+            Unlike a language tag, it is always lower case.
+          </p>
         </section>
         <section id="matchNumber">
           <h4>Matching Literals with Numeric Types</h4>


### PR DESCRIPTION
This PR puts in a mention of text direction into the "Making Simple Queries" subsection about language tags.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/397.html" title="Last updated on Jun 24, 2026, 7:48 AM UTC (a8b11bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/397/2762075...a8b11bb.html" title="Last updated on Jun 24, 2026, 7:48 AM UTC (a8b11bb)">Diff</a>