### PR TITLE
Version from media type

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1403,14 +1403,27 @@ _:b0  :p        "v" .
                   :myreifier :tripleAdded ?date .
               }
 </pre>
+        <p>
+          <p>
+            The [[[SPARQL12-PROTOCOL]]] also provides a 
+            <a data-cite="sparql12-protocol/#section-version-announcement"
+               >version announcement</a> using the `version` parameter
+            of the <a href=#mediaType>Media Type</a>.
+            This is considered if there is no `VERSION` directive.
+        </p>
+
         <section id="versionLabels">
           <h4>Version Labels</h4>
           <p>
-            A <dfn class="export">SPARQL version label</dfn> is a string that identifies the syntax and semantics conformance
-            for the SPARQL query.
+            A <dfn class="export">SPARQL version label</dfn> is a string that identifies 
+            the syntax and semantics conformance for the SPARQL query.
           </p>
           <p class="note">
-            Even though the version label strings in SPARQL are the same as <a data-cite="RDF12-CONCEPTS#defined-version-labels">the version labels defined by RDF</a>, their meaning is different. Namely, the SPARQL version labels refer to SPARQL syntax and semantics, while the RDF version labels refer to RDF syntax and semantics.
+            Even though the version label strings in SPARQL are the same
+            as <a data-cite="RDF12-CONCEPTS#defined-version-labels">the version labels defined by
+            RDF</a>, their meaning is different. Specifically, the SPARQL version labels refer to
+            SPARQL syntax and semantics, while the RDF version labels refer to RDF syntax 
+            and semantics.
           </p>
           <table id="tab-version-labels" class="simple">
             <caption>SPARQL Version Labels</caption>


### PR DESCRIPTION
When `version=` applies.

Text based on the text in Turtle.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/399.html" title="Last updated on Jun 25, 2026, 10:41 AM UTC (f71a525)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/399/da3537b...f71a525.html" title="Last updated on Jun 25, 2026, 10:41 AM UTC (f71a525)">Diff</a>