### PR TITLE
Add SPARQL syntax sections on triple terms, reifiers, and annotations

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -13290,7 +13290,7 @@ _:x rdf:type xsd:decimal .
             Normative changes:
             <ul>
                 <li>Update grammar for triple terms, reifiers, reified triples, annotation syntax, and triple term functions
-                  in <a href="#sparqlGrammar" class="sectionRef"></a></li>
+                  in <a href="#sparqlGrammar" class="sectionRef"></a> and explain them in <a href="#syntaxTripleTerms" class="sectionRef"></a> and <a href="#syntaxReifyingTriples" class="sectionRef"></a></li>
                 <li>Add functions related to <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> to
                   <a href="#func-triple-terms" class="sectionRef"></a>:
                   `TRIPLE`, `isTRIPLE`, `SUBJECT`, `PREDICATE`, `OBJECT`</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1369,6 +1369,262 @@ _:b0  :p        "v" .
           </pre>
         </section>
       </section>
+      <section id="syntaxTripleTerms">
+        <h3>Triple Terms</h3>
+        <p>Within the object position of a <a href="#defn_TriplePattern">triple pattern</a>,
+          we may use a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a> or another <a href="#defn_TriplePattern">triple pattern</a>.
+        </p>
+        <p>Such a <a href="#defn_TriplePattern">triple pattern</a> or nested <a href="#defn_TriplePattern">triple pattern</a>
+          is represented as a <a href="#rTripleTerm"><code>TripleTerm</code></a> with
+          <a href="#rTripleTermSubject"><code>TripleTermSubject</code></a>,
+          <a href="#rVerb"><code>Verb</code></a>, and
+          <a href="#rTripleTermObject"><code>TripleTermObject</code></a>, all
+          preceded by <code>&lt;&lt;(</code>, and
+          followed by <code>)&gt;&gt;</code>.
+          Note that <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> and <a href="#defn_TriplePattern">triple patterns</a>
+          may be nested.
+        </p>
+        <p>The example below shows how a <a href="#defn_TriplePattern">triple pattern</a> is being used in the object position of another <a href="#defn_TriplePattern">triple pattern</a>.</p>
+        <pre class="query nohighlight">
+              VERSION "1.2"
+              PREFIX : &lt;http://example/&gt;
+              PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+
+              SELECT ?person ?authority {
+                  ?person :familyName "Smith" .
+                  _:anno rdf:reifies &lt;&lt;( ?person :jobTitle "Designer" )&gt;&gt; .
+                  _:anno :accordingTo ?authority .
+              }
+        </pre>
+      </section>
+      <section id="syntaxReifyingTriples">
+        <h3>Reifying Triples</h3>
+        <p><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple terms</a> are mostly used
+          as the <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of a <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>
+          using the `rdf:reifies` <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>.
+          Such a triple is called a <dfn data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</dfn>.
+          SPARQL provides a shorthand notation for writing <a>reifying triples</a>
+          using the <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> grammar production.</p>
+        </p>
+        <p>A <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
+          provides syntactic sugar to represent a <a>reifying triple</a>,
+          which defines a specific relationship between an
+          identifier (<dfn data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</dfn>)
+          and a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
+          The identifier becomes a way to indirectly refer
+          to a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>, which
+          may or may not be asserted within the query.
+        </p>
+        <p class="note">Reification using triple terms is a concept distinct from the
+          <a data-cite="RDF12-SEMANTICS#Reif">Reification vocabulary</a> originally
+          defined in <a data-cite="RDF-MT#Reif">RDF Semantics</a>.
+          While both terms describe a representation of an RDF triple using components,
+          RDF 1.2 and SPARQL 1.2 uses the term to identify a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
+          using the `rdf:reifies` predicate.
+        </p>
+        <p>A <a>reifying triple</a> is represented using the
+          <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> production
+          starting with <code>&lt;&lt;</code>,
+          followed by a <a href="#rReifiedTripleSubject"><code>ReifiedTripleSubject</code></a>,
+          a <a href="#rVerb"><code>Verb</code></a>, and
+          a <a href="#rReifiedTripleObject"><code>ReifiedTripleObject</code></a>,
+          followed by an optional <a href="#rReifier"><code>Reifier</code></a>,
+          and ending with <code>&gt;&gt;</code>.
+          This <a href="#rReifier"><code>Reifier</code></a> is composed of a <code title="tilde">~</code>
+          followed by an optional <a href="#rVarOrReifierId"><code>rVarOrReifierId</code></a> production.
+          This <a href="#rVarOrReifierId"><code>rVarOrReifierId</code></a> is composed of
+          a <a href="#rVar">variable</a>, <a href="#riri">IRI</a>, or <a href="#rBlankNode">blank node</a>.
+          For example, `&lt;&lt; :subject :predicate :object ~ :IRIREF &gt;&gt;`.
+          If no reifiers are present,
+          or the <code title="tilde">~</code>
+          is not immediately followed by <a href="#rVar">variable</a>, <a href="#riri">IRI</a>, or <a href="#rBlankNode">blank node</a>,
+          a fresh <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank node</a> is allocated,
+          as with `&lt;&lt; :subject :predicate :object &gt;&gt;`,
+          or `&lt;&lt; :subject :predicate :object ~ &gt;&gt;`.
+        </p>
+        <p class="note"><a href="#rReifiedTriple"><code>ReifiedTriple</code>'s</a> may be nested,
+          like
+          <br/>`&lt;&lt; ?subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~ :IRIREF1 &gt;&gt;`
+          or <br/>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 ?object3 ~ :IRIREF3 &gt;&gt; &gt;&gt;`.
+        </p>
+        <p>The example below shows a reifying triple with an implicit reifier.</p>
+        <pre class="query nohighlight">
+              VERSION "1.2"
+              PREFIX : &lt;http://example/&gt;
+              PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+
+              SELECT ?person ?authority {
+                  ?person :familyName "Smith" .
+                  &lt;&lt; ?person :jobTitle "Designer" &gt;&gt; :accordingTo ?authority .
+              }
+        </pre>
+        <p>The example below shows a reifying triple with an explicit reifier.</p>
+        <pre class="query nohighlight">
+              VERSION "1.2"
+              PREFIX : &lt;http://example/&gt;
+              PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+
+              SELECT ?person ?authority ?id {
+                  ?person :familyName "Smith" .
+                  &lt;&lt; ?person :jobTitle "Designer" ~ ?id &gt;&gt; :accordingTo ?authority .
+              }
+        </pre>
+        <p>The syntactic sugar of the example above expands to the following query.</p>
+        <pre class="query nohighlight">
+              VERSION "1.2"
+              PREFIX : &lt;http://example/&gt;
+              PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+
+              SELECT ?person ?authority ?id {
+                  ?person :familyName "Smith" .
+                  ?id rdf:reifies &lt;&lt;( ?person :jobTitle "Designer" )&gt;&gt; .
+                  ?id :accordingTo ?authority .
+              }
+        </pre>
+        <p class="note">Note the difference in syntax between the syntactic sugar of <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
+      (i.e., `&lt;&lt; ... >>`) and the regular <a href="#rTripleTerm"><code>TripleTerm</code></a> (i.e., `&lt;&lt;( ... )>>`).</p>
+
+        <section id="syntaxAnnotation">
+          <h3>Annotation Syntax</h3>
+          <p>SPARQL also defines an <dfn data-lt="annotation-syntax">annotation syntax</dfn>
+            to both reify and assert a <a href="#defn_TriplePattern">triple pattern</a>,
+            which provides a convenient shortcut.
+            An annotation can be used to simultaneously assert a triple pattern,
+            via an explicit or implicit identifier,
+            and have that triple pattern be the
+            <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
+            <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of further triple patterns.
+            If explicitly identified, the same <a>reifier</a> can then be used as the
+            <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
+            <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of additional
+            triple patterns and/or <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>.
+          </p>
+          <p>Like a <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>,
+            the annotation syntax uses a <a>reifier</a>, written as either an
+            <a href="#rVar">variable</a>, <a href="#riri">IRI</a>, or <a href="#rBlankNode">blank node</a>,
+            preceded by a tilde (<code title="tilde">~</code>),
+            to identify the
+            <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a> being reified.
+            However, while a
+            <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
+            may contain at most one <a>reifier</a>, the annotation syntax may contain
+            any number of <a>reifiers</a>. Each <a>reifier</a> causes a corresponding
+            reifying triple to be produced.
+          </p>
+          <p>A <a>reifier</a> may be followed by an annotation block.
+            If a <a>reifier</a> is not followed by an annotation block, it is treated
+            analogously to a
+            <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
+            without additional annotations.
+            If an annotation block is not immediately preceded by a <a>reifier</a>,
+            a fresh RDF blank node is allocated to serve as the <a>reifier</a> of the
+            <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
+          </p>
+          <p class="note">The annotation syntax is a syntactic shortcut in SPARQL.
+            The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
+            distinguish how the triples were written.</p>
+          <p>The example below shows an annotated triple pattern with an explicit reifier.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person ?authority {
+                    ?person :name "Alice" ~ :t {| :statedBy ?authority ; :recorded "2021-07-07"^^xsd:date |} .
+                }
+          </pre>
+          <p>The syntactic sugar of the annotation syntax in the example above expands to the following query.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person ?authority {
+                    ?person :name "Alice" .
+                    &lt;&lt; ?person :name "Alice" ~ :t &gt;&gt; :statedBy ?authority ;
+                                                    :recorded "2021-07-07"^^xsd:date .
+                }
+          </pre>
+          <p>And if we fully expand this query to use <a href="#rTripleTerm"><code>TripleTerm</code>'s</a> instead of reifiers, the query is expanded to the following.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person ?authority {
+                    ?person :name "Alice" .
+                    :t rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
+                    :t :statedBy ?authority .
+                    :t :recorded "2021-07-07"^^xsd:date .
+                }
+          </pre>
+          <p>The example below shows an annotated triple pattern with an implicit reifier, for which a fresh blank node is allocated.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person ?authority {
+                    ?person :name "Alice" ~ :t {| :statedBy ?authority ; :recorded "2021-07-07"^^xsd:date |} .
+                }
+          </pre>
+          <p>An <a href="#rAnnotation"><code>Annotation</code></a>
+            may include any number of annotation blocks. If such blocks are not
+            immediately preceded by explicit <a>reifiers</a>, each block is associated
+            with a fresh blank node allocated as its <a>reifier</a>, as seen in the example below.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person ?authority1 ?authority2 {
+                    ?person :name "Alice" 
+                      {| :statedBy ?authority1 ; :recorded "2021-02-01"^^xsd:date |}
+                      {| :statedBy ?authority2 ; :recorded "2021-07-07"^^xsd:date |} .
+                }
+          </pre>
+          <p>The query above will be fully expanded to the query below, where <code>_:b0</code> and <code>_:b1</code> stand for fresh RDF blank nodes.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person ?authority1 ?authority2 {
+                    ?person :name "Alice" .
+                    _:b0 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
+                    _:b0 :statedBy ?authority1 .
+                    _:b0 :recorded "2021-02-01"^^xsd:date .
+                    _:b1 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
+                    _:b1 :statedBy ?authority2 .
+                    _:b1 :recorded "2021-07-07"^^xsd:date .
+                }
+          </pre>
+          <p>The annotation syntax may also contain multiple explicit
+            <a>reifiers</a> without annotation blocks, as shown in the example below. Each such <a>reifier</a>
+            causes a corresponding reifying triple to be produced.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person {
+                    ?person :name "Alice" ~ :stmt1 ~ stmt2 .
+                }
+          </pre>
+          <p>The query above will be fully expanded to the query below.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person {
+                    ?person :name "Alice" .
+                    :stmt1 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
+                    :stmt2 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
+                }
+          </pre>
+        </section>
+      </section>
       <section id="syntaxVersionAnnouncement">
         <h3>Version Announcement</h3>
         <p>To cope with the language evolution of SPARQL,

--- a/spec/index.html
+++ b/spec/index.html
@@ -1491,7 +1491,8 @@ _:b0  :p        "v" .
         <section id="syntaxAnnotation">
           <h3>Annotation Syntax</h3>
           <p>SPARQL also defines an <dfn data-lt="annotation-syntax">annotation syntax</dfn>
-            that both reifies and asserts a <a href="#defn_TriplePattern">triple pattern</a>,
+            to represent <a href="#defn_TriplePattern">triple patterns</a> that simultaneously
+            match reified and asserted triples,
             which provides a convenient shortcut.
             An annotation can be used to simultaneously assert a triple pattern,
             via an explicit or implicit identifier,

--- a/spec/index.html
+++ b/spec/index.html
@@ -1372,7 +1372,8 @@ _:b0  :p        "v" .
       <section id="syntaxTripleTerms">
         <h3>Triple Terms</h3>
         <p>Within the object position of a <a href="#defn_TriplePattern">triple pattern</a>,
-          we may use a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a> or another <a href="#defn_TriplePattern">triple pattern</a>.
+          we can use a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
+          or another <a href="#defn_TriplePattern">triple pattern</a>.
         </p>
         <p>Such a <a href="#defn_TriplePattern">triple pattern</a> or nested <a href="#defn_TriplePattern">triple pattern</a>
           is represented as a <a href="#rTripleTerm"><code>TripleTerm</code></a> with
@@ -1382,9 +1383,10 @@ _:b0  :p        "v" .
           preceded by <code>&lt;&lt;(</code>, and
           followed by <code>)&gt;&gt;</code>.
           Note that <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> and <a href="#defn_TriplePattern">triple patterns</a>
-          may be nested.
+          can be nested.
         </p>
-        <p>The example below shows how a <a href="#defn_TriplePattern">triple pattern</a> is being used in the object position of another <a href="#defn_TriplePattern">triple pattern</a>.</p>
+        <p>The example below shows how a <a href="#defn_TriplePattern">triple pattern</a>
+          can be used in the object position of another <a href="#defn_TriplePattern">triple pattern</a>.</p>
         <pre class="query nohighlight">
               VERSION "1.2"
               PREFIX : &lt;http://example/&gt;
@@ -1401,9 +1403,9 @@ _:b0  :p        "v" .
         <h3>Reifying Triples</h3>
         <p><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple terms</a> are mostly used
           as the <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of a <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>
-          using the `rdf:reifies` <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>.
+          with a <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a> of `rdf:reifies`.
           Such a triple is called a <dfn data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</dfn>.
-          SPARQL provides a shorthand notation for writing <a>reifying triples</a>
+          SPARQL also provides a shorthand notation for writing <a>reifying triples</a>
           using the <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> grammar production.</p>
         </p>
         <p>A <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
@@ -1412,7 +1414,7 @@ _:b0  :p        "v" .
           identifier (<dfn data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</dfn>)
           and a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
           The identifier becomes a way to indirectly refer
-          to a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>, which
+          to the <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>, which
           may or may not be asserted within the query.
         </p>
         <p class="note">Reification using triple terms is a concept distinct from the
@@ -1433,14 +1435,15 @@ _:b0  :p        "v" .
           This <a href="#rReifier"><code>Reifier</code></a> is composed of a <code title="tilde">~</code>
           followed by an optional <a href="#rVarOrReifierId"><code>rVarOrReifierId</code></a> production.
           This <a href="#rVarOrReifierId"><code>rVarOrReifierId</code></a> is composed of
-          a <a href="#rVar">variable</a>, <a href="#riri">IRI</a>, or <a href="#rBlankNode">blank node</a>.
-          For example, `&lt;&lt; :subject :predicate :object ~ :IRIREF &gt;&gt;`.
-          If no reifiers are present,
+          a <a href="#rVar">variable</a>, an <a href="#riri">IRI</a>, or a <a href="#rBlankNode">blank node</a>;
+          for example, `&lt;&lt; :subject :predicate :object ~ :IRIREF &gt;&gt;`.
+          If no reifier is present,
           or the <code title="tilde">~</code>
-          is not immediately followed by <a href="#rVar">variable</a>, <a href="#riri">IRI</a>, or <a href="#rBlankNode">blank node</a>,
-          a fresh <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank node</a> is allocated,
-          as with `&lt;&lt; :subject :predicate :object &gt;&gt;`,
-          or `&lt;&lt; :subject :predicate :object ~ &gt;&gt;`.
+          is not immediately followed by <a href="#rVar">variable</a>,
+          an <a href="#riri">IRI</a>, or a <a href="#rBlankNode">blank node</a> —
+          as in `&lt;&lt; :subject :predicate :object &gt;&gt;`,
+          or `&lt;&lt; :subject :predicate :object ~ &gt;&gt;` —
+          a fresh <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank node</a> is allocated.
         </p>
         <p class="note"><a href="#rReifiedTriple"><code>ReifiedTriple</code>'s</a> may be nested,
           like
@@ -1469,7 +1472,7 @@ _:b0  :p        "v" .
                   &lt;&lt; ?person :jobTitle "Designer" ~ ?id &gt;&gt; :accordingTo ?authority .
               }
         </pre>
-        <p>The syntactic sugar of the example above expands to the following query.</p>
+        <p>The syntactic sugar of the example above expands to the following query:</p>
         <pre class="query nohighlight">
               VERSION "1.2"
               PREFIX : &lt;http://example/&gt;
@@ -1481,13 +1484,14 @@ _:b0  :p        "v" .
                   ?id :accordingTo ?authority .
               }
         </pre>
-        <p class="note">Note the difference in syntax between the syntactic sugar of <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
-      (i.e., `&lt;&lt; ... >>`) and the regular <a href="#rTripleTerm"><code>TripleTerm</code></a> (i.e., `&lt;&lt;( ... )>>`).</p>
+        <p class="note">Note the subtle difference in syntax between the syntactic sugar of
+          the <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> (i.e., `&lt;&lt; ... >>`)
+          and the regular <a href="#rTripleTerm"><code>TripleTerm</code></a> (i.e., `&lt;&lt;( ... )>>`).</p>
 
         <section id="syntaxAnnotation">
           <h3>Annotation Syntax</h3>
           <p>SPARQL also defines an <dfn data-lt="annotation-syntax">annotation syntax</dfn>
-            to both reify and assert a <a href="#defn_TriplePattern">triple pattern</a>,
+            that both reifies and asserts a <a href="#defn_TriplePattern">triple pattern</a>,
             which provides a convenient shortcut.
             An annotation can be used to simultaneously assert a triple pattern,
             via an explicit or implicit identifier,
@@ -1500,18 +1504,18 @@ _:b0  :p        "v" .
             triple patterns and/or <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>.
           </p>
           <p>Like a <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>,
-            the annotation syntax uses a <a>reifier</a>, written as either an
-            <a href="#rVar">variable</a>, <a href="#riri">IRI</a>, or <a href="#rBlankNode">blank node</a>,
-            preceded by a tilde (<code title="tilde">~</code>),
+            the annotation syntax uses a <a>reifier</a> — written as either a
+            <a href="#rVar">variable</a>, an <a href="#riri">IRI</a>, or a <a href="#rBlankNode">blank node</a>,
+            preceded by a tilde (<code title="tilde">~</code>) —
             to identify the
             <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a> being reified.
-            However, while a
-            <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
+            However, while the
+            <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> syntax
             may contain at most one <a>reifier</a>, the annotation syntax may contain
             any number of <a>reifiers</a>. Each <a>reifier</a> causes a corresponding
             reifying triple to be produced.
           </p>
-          <p>A <a>reifier</a> may be followed by an annotation block.
+          <p>A <a>reifier</a> can be followed by an annotation block.
             If a <a>reifier</a> is not followed by an annotation block, it is treated
             analogously to a
             <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
@@ -1533,7 +1537,7 @@ _:b0  :p        "v" .
                     ?person :name "Alice" ~ :t {| :statedBy ?authority ; :recorded "2021-07-07"^^xsd:date |} .
                 }
           </pre>
-          <p>The syntactic sugar of the annotation syntax in the example above expands to the following query.</p>
+          <p>The syntactic sugar of the annotation syntax in the example above expands to the following query:</p>
           <pre class="query nohighlight">
                 VERSION "1.2"
                 PREFIX : &lt;http://example/&gt;
@@ -1545,7 +1549,8 @@ _:b0  :p        "v" .
                                                     :recorded "2021-07-07"^^xsd:date .
                 }
           </pre>
-          <p>And if we fully expand this query to use <a href="#rTripleTerm"><code>TripleTerm</code>'s</a> instead of reifiers, the query is expanded to the following.</p>
+          <p>If we fully expand this query to use <a href="#rTripleTerm"><code>TripleTerm</code>'s</a> instead of reifiers,
+          the query is expanded to the following:</p>
           <pre class="query nohighlight">
                 VERSION "1.2"
                 PREFIX : &lt;http://example/&gt;
@@ -13290,7 +13295,9 @@ _:x rdf:type xsd:decimal .
             Normative changes:
             <ul>
                 <li>Update grammar for triple terms, reifiers, reified triples, annotation syntax, and triple term functions
-                  in <a href="#sparqlGrammar" class="sectionRef"></a> and explain them in <a href="#syntaxTripleTerms" class="sectionRef"></a> and <a href="#syntaxReifyingTriples" class="sectionRef"></a></li>
+                  in <a href="#sparqlGrammar" class="sectionRef"></a> and explain them
+                  in <a href="#syntaxTripleTerms" class="sectionRef"></a>
+                  and <a href="#syntaxReifyingTriples" class="sectionRef"></a></li>
                 <li>Add functions related to <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> to
                   <a href="#func-triple-terms" class="sectionRef"></a>:
                   `TRIPLE`, `isTRIPLE`, `SUBJECT`, `PREDICATE`, `OBJECT`</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1399,7 +1399,7 @@ _:b0  :p        "v" .
       </section>
       <section id="syntaxReifyingTriples">
         <h3>Reifying Triples</h3>
-        <p><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple terms</a> are mostly used
+        <p><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple terms</a> are used
           as the <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of a <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>
           with a <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a> of `rdf:reifies`.
           Such a triple is called a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a>.
@@ -1448,7 +1448,7 @@ _:b0  :p        "v" .
           <br/>`&lt;&lt; ?subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~ :IRIREF1 &gt;&gt;`<br/>
           or <br/>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 ?object3 ~ :IRIREF3 &gt;&gt; &gt;&gt;`.
         </p>
-        <p>The example below matches reifying triples with an implicit reifier.</p>
+        <p>The example below matches reifying triples without regard to the reifier.</p>
         <pre class="query nohighlight">
               VERSION "1.2"
               PREFIX : &lt;http://example/&gt;
@@ -1459,7 +1459,7 @@ _:b0  :p        "v" .
                   &lt;&lt; ?person :jobTitle "Designer" &gt;&gt; :accordingTo ?authority .
               }
         </pre>
-        <p>The example below matches reifying triples with an explicit reifier.</p>
+        <p>The example below matches reifying triples with a variable to match the reifier.</p>
         <pre class="query nohighlight">
               VERSION "1.2"
               PREFIX : &lt;http://example/&gt;

--- a/spec/index.html
+++ b/spec/index.html
@@ -1529,7 +1529,7 @@ _:b0  :p        "v" .
             preceded by a tilde (<code title="tilde">~</code>) —
             to identify the
             <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a> being reified.
-            The following query illustrates this use of the annotation syntax
+            The following query illustrates this use of the annotation syntax.
           </p>
           <pre class="query nohighlight">
                 VERSION "1.2"
@@ -1581,7 +1581,7 @@ _:b0  :p        "v" .
                       {| :statedBy ?authority2 ; :recorded "2021-07-07"^^xsd:date |} .
                 }
           </pre>
-          <p>The query above will be fully expanded to the query below, where <code>_:b0</code> and <code>_:b1</code> stand for fresh RDF blank nodes.</p>
+          <p>The query above will be fully expanded to the query below, where <code>_:b0</code> and <code>_:b1</code> stand for fresh blank nodes.</p>
           <pre class="query nohighlight">
                 VERSION "1.2"
                 PREFIX : &lt;http://example/&gt;

--- a/spec/index.html
+++ b/spec/index.html
@@ -1478,15 +1478,15 @@ _:b0  :p        "v" .
           <p>SPARQL also defines the so-called <dfn data-lt="annotation-syntax">annotation syntax</dfn>,
             which is a shorthand notation for matching the combination of
             a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a>
-            together with an <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triple</a>
+            together with both an <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triple</a>
             that corresponds to the <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
-            of the reifying triple.
-            An annotation can be used to simultaneously match an asserted triple,
-            and have that triple pattern be the
-            <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
-            <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of further triple patterns.
+            of the reifying triple and further triples that have the
+            <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> of the reifying triple
+            as their <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a>.
           </p>
-          <p>The example below shows an annotated triple pattern.</p>
+          <p>The following query is an example in which the annotation syntax is used
+            for a triple pattern.
+          </p>
           <pre class="query nohighlight">
                 VERSION "1.2"
                 PREFIX : &lt;http://example/&gt;
@@ -1508,35 +1508,29 @@ _:b0  :p        "v" .
                                                 :recorded "2021-07-07"^^xsd:date .
                 }
           </pre>
-          <p>Like a <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>,
-            the annotation syntax can also use a <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> — written as either a
-            <a href="#rVar">variable</a>, an <a href="#riri">IRI</a>, or a <a href="#rBlankNode">blank node</a>,
+          <p>This query expands further as per Section&nbsp;<a href="#syntaxReifyingTriples" class="sectionRef"></a>,
+            resulting in the following query.</p>
+          <pre>
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person ?authority {
+                    ?person :name "Alice" .
+                    :id rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; ;
+                        :statedBy ?authority ;
+                        :recorded "2021-07-07"^^xsd:date .
+                }
+          </pre>
+          <p>As in the shorthand notation for matching of reified triples
+            (Section&nbsp;<a href="#syntaxReifyingTriples" class="sectionRef"></a>),
+            the annotation syntax can also refer explicitly to the corresponding <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> — written as either a
+            <a href="#rVar">variable</a>, a <a href="#rBlankNode">blank node</a>, or an <a href="#riri">IRI</a>,
             preceded by a tilde (<code title="tilde">~</code>) —
             to identify the
             <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a> being reified.
-            However, while the
-            <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> syntax
-            may contain at most one <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>, the annotation syntax may contain
-            any number of <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifiers</a>. Each <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> causes a corresponding
-            reifying triple to be produced.
+            The following query illustrates this use of the annotation syntax
           </p>
-          <p>A <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> can be followed by an annotation block.
-            This <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> can be used as the
-            <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
-            <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of additional
-            triple patterns and/or <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>.
-            If a <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> is not followed by an annotation block, it is treated
-            analogously to a
-            <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
-            without additional annotations.
-            If an annotation block is not immediately preceded by a <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>,
-            a fresh RDF blank node is allocated to serve as the <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> of the
-            <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
-          </p>
-          <p class="note">The annotation syntax is a syntactic shortcut in SPARQL.
-            The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
-            distinguish how the triples were written.</p>
-          <p>The example below shows an annotated triple pattern with an explicit reifier.</p>
           <pre class="query nohighlight">
                 VERSION "1.2"
                 PREFIX : &lt;http://example/&gt;
@@ -1572,10 +1566,10 @@ _:b0  :p        "v" .
                     :t :recorded "2021-07-07"^^xsd:date .
                 }
           </pre>
-          <p>An annotation
-            may include any number of annotation blocks. If such blocks are not
-            immediately preceded by explicit <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifiers</a>, each block is associated
-            with a fresh blank node allocated as its <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>, as seen in the example below.</p>
+          <p>The annotation syntax can be used with multiple separate annotation blocks.
+            For each such block that is not immediately preceded by the tilde-based construct for matching the corresponding reifier,
+            a separate fresh blank node is allocated when expanding this shorthand notation.
+            The following example query illustrates such a case.</p>
           <pre class="query nohighlight">
                 VERSION "1.2"
                 PREFIX : &lt;http://example/&gt;
@@ -1595,17 +1589,19 @@ _:b0  :p        "v" .
           
                 SELECT ?person ?authority1 ?authority2 {
                     ?person :name "Alice" .
+
                     _:b0 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
                     _:b0 :statedBy ?authority1 .
                     _:b0 :recorded "2021-02-01"^^xsd:date .
+
                     _:b1 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
                     _:b1 :statedBy ?authority2 .
                     _:b1 :recorded "2021-07-07"^^xsd:date .
                 }
           </pre>
-          <p>The annotation syntax may also contain multiple explicit
-            <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifiers</a> without annotation blocks, as shown in the example below. Each such <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>
-            causes a corresponding reifying triple to be produced.</p>
+          <p>The annotation syntax may also contain multiple references to
+            <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifiers</a> without annotation blocks, as shown in the example below. Each such a tilde-based construct
+            causes a corresponding reifying triple to be matched.</p>
           <pre class="query nohighlight">
                 VERSION "1.2"
                 PREFIX : &lt;http://example/&gt;
@@ -1627,7 +1623,7 @@ _:b0  :p        "v" .
                     :stmt2 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
                 }
           </pre>
-          <p>The annotation syntax could also contain multiple explicit
+          <p>The annotation syntax could also contain multiple references to
             <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifiers</a> with annotation blocks, as shown in the example below.</p>
           <pre class="query nohighlight">
                 VERSION "1.2"

--- a/spec/index.html
+++ b/spec/index.html
@@ -1413,7 +1413,7 @@ _:b0  :p        "v" .
           and a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
           The identifier becomes a way to indirectly refer
           to the <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>, which
-          may or may not be asserted within the query.
+          may be used elsewhere within the query.
         </p>
         <p class="note">Reification using triple terms is a concept distinct from the
           <a data-cite="RDF12-SEMANTICS#Reif">Reification vocabulary</a> originally
@@ -1445,7 +1445,7 @@ _:b0  :p        "v" .
         </p>
         <p class="note"><a href="#rReifiedTriple"><code>ReifiedTriple</code>'s</a> may be nested,
           like
-          <br/>`&lt;&lt; ?subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~ :IRIREF1 &gt;&gt;`
+          <br/>`&lt;&lt; ?subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~ :IRIREF1 &gt;&gt;`<br/>
           or <br/>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 ?object3 ~ :IRIREF3 &gt;&gt; &gt;&gt;`.
         </p>
         <p>The example below shows a reifying triple with an implicit reifier.</p>
@@ -1488,10 +1488,9 @@ _:b0  :p        "v" .
 
         <section id="syntaxAnnotation">
           <h3>Annotation Syntax</h3>
-          <p>SPARQL also defines an <dfn data-lt="annotation-syntax">annotation syntax</dfn>
-            to represent <a href="#defn_TriplePattern">triple patterns</a> that simultaneously
-            match reified and asserted triples,
-            which provides a convenient shortcut.
+          <p>SPARQL also defines <dfn data-lt="annotation-syntax">annotation syntax</dfn>
+            as a shortcut form for matching both reified and asserted triples with a
+            <a href="#defn_TriplePattern">triple pattern</a>.
             An annotation can be used to simultaneously assert a triple pattern,
             via an explicit or implicit identifier,
             and have that triple pattern be the

--- a/spec/index.html
+++ b/spec/index.html
@@ -1403,16 +1403,16 @@ _:b0  :p        "v" .
           as the <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of a <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>
           with a <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a> of `rdf:reifies`.
           Such a triple is called a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a>.
-          SPARQL provides a shorthand notation for writing triple patterns that are meant to match such <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a>
+          SPARQL provides a shorthand notation for writing triple patterns that are meant to match such <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a> and reifying triple patterns
           using the <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> grammar production.</p>
         </p>
         <p>A <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
-          provides syntactic sugar to represent a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a>,
-          which defines a specific relationship between an
-          identifier (<dfn data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</dfn>)
-          and a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
+          provides syntactic sugar to represent a triple pattern that can match <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a>.
+          It defines a specific relationship between an
+          identifier (<a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>)
+          and a <a href="#defn_TriplePattern">triple pattern</a>.
           The identifier becomes a way to indirectly refer
-          to the <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>, which
+          to the <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> matched by the <a href="#defn_TriplePattern">triple pattern</a>, which
           may be used elsewhere within the query.
         </p>
         <p class="note">Reification using triple terms is a concept distinct from the
@@ -1448,7 +1448,7 @@ _:b0  :p        "v" .
           <br/>`&lt;&lt; ?subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~ :IRIREF1 &gt;&gt;`<br/>
           or <br/>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 ?object3 ~ :IRIREF3 &gt;&gt; &gt;&gt;`.
         </p>
-        <p>The example below shows a reifying triple with an implicit reifier.</p>
+        <p>The example below matches reifying triples with an implicit reifier.</p>
         <pre class="query nohighlight">
               VERSION "1.2"
               PREFIX : &lt;http://example/&gt;
@@ -1459,7 +1459,7 @@ _:b0  :p        "v" .
                   &lt;&lt; ?person :jobTitle "Designer" &gt;&gt; :accordingTo ?authority .
               }
         </pre>
-        <p>The example below shows a reifying triple with an explicit reifier.</p>
+        <p>The example below matches reifying triples with an explicit reifier.</p>
         <pre class="query nohighlight">
               VERSION "1.2"
               PREFIX : &lt;http://example/&gt;
@@ -1496,30 +1496,30 @@ _:b0  :p        "v" .
             and have that triple pattern be the
             <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
             <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of further triple patterns.
-            If explicitly identified, the same <a>reifier</a> can then be used as the
+            If explicitly identified, the same <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> can then be used as the
             <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
             <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of additional
             triple patterns and/or <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>.
           </p>
           <p>Like a <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>,
-            the annotation syntax uses a <a>reifier</a> — written as either a
+            the annotation syntax uses a <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> — written as either a
             <a href="#rVar">variable</a>, an <a href="#riri">IRI</a>, or a <a href="#rBlankNode">blank node</a>,
             preceded by a tilde (<code title="tilde">~</code>) —
             to identify the
             <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a> being reified.
             However, while the
             <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> syntax
-            may contain at most one <a>reifier</a>, the annotation syntax may contain
-            any number of <a>reifiers</a>. Each <a>reifier</a> causes a corresponding
+            may contain at most one <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>, the annotation syntax may contain
+            any number of <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifiers</a>. Each <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> causes a corresponding
             reifying triple to be produced.
           </p>
-          <p>A <a>reifier</a> can be followed by an annotation block.
-            If a <a>reifier</a> is not followed by an annotation block, it is treated
+          <p>A <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> can be followed by an annotation block.
+            If a <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> is not followed by an annotation block, it is treated
             analogously to a
             <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
             without additional annotations.
-            If an annotation block is not immediately preceded by a <a>reifier</a>,
-            a fresh RDF blank node is allocated to serve as the <a>reifier</a> of the
+            If an annotation block is not immediately preceded by a <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>,
+            a fresh RDF blank node is allocated to serve as the <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> of the
             <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
           </p>
           <p class="note">The annotation syntax is a syntactic shortcut in SPARQL.
@@ -1573,8 +1573,8 @@ _:b0  :p        "v" .
           </pre>
           <p>An <a href="#rAnnotation"><code>Annotation</code></a>
             may include any number of annotation blocks. If such blocks are not
-            immediately preceded by explicit <a>reifiers</a>, each block is associated
-            with a fresh blank node allocated as its <a>reifier</a>, as seen in the example below.</p>
+            immediately preceded by explicit <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifiers</a>, each block is associated
+            with a fresh blank node allocated as its <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>, as seen in the example below.</p>
           <pre class="query nohighlight">
                 VERSION "1.2"
                 PREFIX : &lt;http://example/&gt;
@@ -1603,7 +1603,7 @@ _:b0  :p        "v" .
                 }
           </pre>
           <p>The annotation syntax may also contain multiple explicit
-            <a>reifiers</a> without annotation blocks, as shown in the example below. Each such <a>reifier</a>
+            <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifiers</a> without annotation blocks, as shown in the example below. Each such <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>
             causes a corresponding reifying triple to be produced.</p>
           <pre class="query nohighlight">
                 VERSION "1.2"

--- a/spec/index.html
+++ b/spec/index.html
@@ -1403,7 +1403,7 @@ _:b0  :p        "v" .
           as the <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of a <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>
           with a <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a> of `rdf:reifies`.
           Such a triple is called a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a>.
-          SPARQL also provides a shorthand notation for writing <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a>
+          SPARQL provides a shorthand notation for writing triple patterns that are meant to match such <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a>
           using the <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> grammar production.</p>
         </p>
         <p>A <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1394,7 +1394,7 @@ _:b0  :p        "v" .
               }
         </pre>
         <section id="syntaxReifyingTriples">
-          <h3>Shorthand to Match Reifying Triples</h3>
+          <h4>Shorthand to Match Reifying Triples</h4>
           <p><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple terms</a> are used
             as the <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of a <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>
             with a <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a> of `rdf:reifies`.
@@ -1510,16 +1510,16 @@ _:b0  :p        "v" .
           </pre>
           <p>This query expands further as per Section&nbsp;<a href="#syntaxReifyingTriples" class="sectionRef"></a>,
             resulting in the following query.</p>
-          <pre>
+          <pre class="query nohighlight">
                 VERSION "1.2"
                 PREFIX : &lt;http://example/&gt;
                 PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
           
                 SELECT ?person ?authority {
                     ?person :name "Alice" .
-                    :id rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; ;
-                        :statedBy ?authority ;
-                        :recorded "2021-07-07"^^xsd:date .
+                    _:id rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; ;
+                         :statedBy ?authority ;
+                         :recorded "2021-07-07"^^xsd:date .
                 }
           </pre>
           <p>As in the shorthand notation for matching of reified triples
@@ -1537,7 +1537,8 @@ _:b0  :p        "v" .
                 PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
           
                 SELECT ?person ?authority {
-                    ?person :name "Alice" ~ :t {| :statedBy ?authority ; :recorded "2021-07-07"^^xsd:date |} .
+                    ?person :name "Alice" ~ :t {| :statedBy ?authority ;
+                                                  :recorded "2021-07-07"^^xsd:date |}
                 }
           </pre>
           <p>The syntactic sugar of the annotation syntax in the example above expands to the following query:</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1371,19 +1371,16 @@ _:b0  :p        "v" .
       </section>
       <section id="syntaxNestedTriplePatterns">
         <h3>Nested Triple Patterns</h3>
-        <p> <a href="#defn_TriplePattern">Triple patterns</a> can be nested, as their subject or object can be
-          another <a href="#defn_TriplePattern">triple patterns</a>.
-          These nested triple patterns are meant to match triples that contain <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>.
+        <p> <a href="#defn_TriplePattern">Triple patterns</a> can be nested; that is, their subject or object can be
+          another <a href="#defn_TriplePattern">triple pattern</a>.
+          Such nested triple patterns are meant to match triples that contain <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>.
         </p>
-        <p>Such a nested <a href="#defn_TriplePattern">triple pattern</a>
-          is represented as a <a href="#rTripleTerm"><code>TripleTerm</code></a> with
-          <a href="#rTripleTermSubject"><code>TripleTermSubject</code></a>,
-          <a href="#rVerb"><code>Verb</code></a>, and
-          <a href="#rTripleTermObject"><code>TripleTermObject</code></a>, all
+        <p>To write a nested <a href="#defn_TriplePattern">triple pattern</a>
+          the triple pattern that it contains must be
           preceded by <code>&lt;&lt;(</code>, and
           followed by <code>)&gt;&gt;</code>.
         </p>
-        <p>The example below shows how a <a href="#defn_TriplePattern">triple pattern</a>
+        <p>The example below illustrates how a <a href="#defn_TriplePattern">triple pattern</a>
           can be used in the object position of another <a href="#defn_TriplePattern">triple pattern</a>.</p>
         <pre class="query nohighlight">
               VERSION "1.2"
@@ -1396,96 +1393,83 @@ _:b0  :p        "v" .
                   _:anno :accordingTo ?authority .
               }
         </pre>
-      </section>
-      <section id="syntaxReifyingTriples">
-        <h3>Reifying Triples</h3>
-        <p><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple terms</a> are used
-          as the <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of a <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>
-          with a <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a> of `rdf:reifies`.
-          Such a triple is called a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a>.
-          SPARQL provides a shorthand notation for writing triple patterns that are meant to match such <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a> and reifying triple patterns
-          using the <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> grammar production.</p>
-        </p>
-        <p>A <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
-          provides syntactic sugar to represent a triple pattern that can match <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a>.
-          It defines a specific relationship between an
-          identifier (<a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>)
-          and a <a href="#defn_TriplePattern">triple pattern</a>.
-          The identifier becomes a way to indirectly refer
-          to the <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> matched by the <a href="#defn_TriplePattern">triple pattern</a>, which
-          may be used elsewhere within the query.
-        </p>
-        <p class="note">Reification using triple terms is a concept distinct from the
-          <a data-cite="RDF12-SEMANTICS#Reif">Reification vocabulary</a> originally
-          defined in <a data-cite="RDF-MT#Reif">RDF Semantics</a>.
-          While both terms describe a representation of an RDF triple using components,
-          RDF 1.2 and SPARQL 1.2 uses the term to identify a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
-          using the `rdf:reifies` predicate.
-        </p>
-        <p>A <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a> is represented using the
-          <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> production
-          starting with <code>&lt;&lt;</code>,
-          followed by a <a href="#rReifiedTripleSubject"><code>ReifiedTripleSubject</code></a>,
-          a <a href="#rVerb"><code>Verb</code></a>, and
-          a <a href="#rReifiedTripleObject"><code>ReifiedTripleObject</code></a>,
-          followed by an optional <a href="#rReifier"><code>Reifier</code></a>,
-          and ending with <code>&gt;&gt;</code>.
-          This <a href="#rReifier"><code>Reifier</code></a> is composed of a <code title="tilde">~</code>
-          followed by an optional <a href="#rVarOrReifierId"><code>rVarOrReifierId</code></a> production.
-          This <a href="#rVarOrReifierId"><code>rVarOrReifierId</code></a> is composed of
-          a <a href="#rVar">variable</a>, an <a href="#riri">IRI</a>, or a <a href="#rBlankNode">blank node</a>;
-          for example, `&lt;&lt; :subject :predicate :object ~ :IRIREF &gt;&gt;`.
-          If no reifier is present,
-          or the <code title="tilde">~</code>
-          is not immediately followed by <a href="#rVar">variable</a>,
-          an <a href="#riri">IRI</a>, or a <a href="#rBlankNode">blank node</a> —
-          as in `&lt;&lt; :subject :predicate :object &gt;&gt;`,
-          or `&lt;&lt; :subject :predicate :object ~ &gt;&gt;` —
-          a fresh <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank node</a> is allocated.
-        </p>
-        <p class="note"><a href="#rReifiedTriple"><code>ReifiedTriple</code>'s</a> may be nested,
-          like
-          <br/>`&lt;&lt; ?subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~ :IRIREF1 &gt;&gt;`<br/>
-          or <br/>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 ?object3 ~ :IRIREF3 &gt;&gt; &gt;&gt;`.
-        </p>
-        <p>The example below matches reifying triples without regard to the reifier.</p>
-        <pre class="query nohighlight">
-              VERSION "1.2"
-              PREFIX : &lt;http://example/&gt;
-              PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
-
-              SELECT ?person ?authority {
-                  ?person :familyName "Smith" .
-                  &lt;&lt; ?person :jobTitle "Designer" &gt;&gt; :accordingTo ?authority .
-              }
-        </pre>
-        <p>The example below matches reifying triples with a variable to match the reifier.</p>
-        <pre class="query nohighlight">
-              VERSION "1.2"
-              PREFIX : &lt;http://example/&gt;
-              PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
-
-              SELECT ?person ?authority ?id {
-                  ?person :familyName "Smith" .
-                  &lt;&lt; ?person :jobTitle "Designer" ~ ?id &gt;&gt; :accordingTo ?authority .
-              }
-        </pre>
-        <p>The syntactic sugar of the example above expands to the following query:</p>
-        <pre class="query nohighlight">
-              VERSION "1.2"
-              PREFIX : &lt;http://example/&gt;
-              PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
-
-              SELECT ?person ?authority ?id {
-                  ?person :familyName "Smith" .
-                  ?id rdf:reifies &lt;&lt;( ?person :jobTitle "Designer" )&gt;&gt; .
-                  ?id :accordingTo ?authority .
-              }
-        </pre>
-        <p class="note">Note the subtle difference in syntax between the syntactic sugar of
-          the <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> (i.e., `&lt;&lt; ... >>`)
-          and the regular <a href="#rTripleTerm"><code>TripleTerm</code></a> (i.e., `&lt;&lt;( ... )>>`).</p>
-
+        <section id="syntaxReifyingTriples">
+          <h3>Shorthand to Match Reifying Triples</h3>
+          <p><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple terms</a> are used
+            as the <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of a <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>
+            with a <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a> of `rdf:reifies`.
+            Such a triple is called a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a>.
+            SPARQL provides a shorthand notation for writing triple patterns that are meant to match such <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a>.</p>
+          </p>
+          <p class="note">Reification using triple terms is a concept distinct from the
+            <a data-cite="RDF12-SEMANTICS#Reif">Reification vocabulary</a> originally
+            defined in <a data-cite="RDF-MT#Reif">RDF Semantics</a>.
+            While both concepts describe a representation of an RDF triple using components,
+            RDF 1.2 and SPARQL 1.2 have a dedicated <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>,
+            which can be used with the `rdf:reifies` predicate.
+          </p>
+          <p>The example below matches reifying triples.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+  
+                SELECT ?person ?authority {
+                    ?person :familyName "Smith" .
+                    &lt;&lt; ?person :jobTitle "Designer" &gt;&gt; :accordingTo ?authority .
+                }
+          </pre>
+          <p>The syntactic sugar of the example above expands to the following query:</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+  
+                SELECT ?person ?authority ?id {
+                    ?person :familyName "Smith" .
+                    _:id rdf:reifies &lt;&lt;( ?person :jobTitle "Designer" )&gt;&gt; .
+                    _:id :accordingTo ?authority .
+                }
+          </pre>
+          <p>This shorthand notation for matching reifying triples
+            also allows the <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>
+            of these reifying triples to be matched. This is done by placing
+            a variable, IRI, or blank node after a tilde (<code title="tilde">~</code>).
+            As shown in the example above; if no reifier is explicitly mentioned,
+            then a new blank node is minted for as reifier within the scope of this query.
+          </p>
+          <p class="note"><a href="#rReifiedTriple"><code>ReifiedTriple</code>'s</a> may be nested,
+            like
+            <br/>`&lt;&lt; ?subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~ :IRIREF1 &gt;&gt;`<br/>
+            or <br/>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 ?object3 ~ :IRIREF3 &gt;&gt; &gt;&gt;`.
+          </p>
+          <p>The example below matches reifying triples with a variable to match the reifier.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+  
+                SELECT ?person ?authority ?id {
+                    ?person :familyName "Smith" .
+                    &lt;&lt; ?person :jobTitle "Designer" ~ ?id &gt;&gt; :accordingTo ?authority .
+                }
+          </pre>
+          <p>The syntactic sugar of the example above expands to the following query:</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+  
+                SELECT ?person ?authority ?id {
+                    ?person :familyName "Smith" .
+                    ?id rdf:reifies &lt;&lt;( ?person :jobTitle "Designer" )&gt;&gt; .
+                    ?id :accordingTo ?authority .
+                }
+          </pre>
+          <p class="note">Note the subtle difference in syntax between the syntactic sugar of
+            the <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> (i.e., `&lt;&lt; ... >>`)
+            and the regular <a href="#rTripleTerm"><code>TripleTerm</code></a> (i.e., `&lt;&lt;( ... )>>`).</p>
+        </section>
         <section id="syntaxAnnotation">
           <h3>Annotation Syntax</h3>
           <p>SPARQL also defines <dfn data-lt="annotation-syntax">annotation syntax</dfn>
@@ -1568,7 +1552,7 @@ _:b0  :p        "v" .
                 PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
           
                 SELECT ?person ?authority {
-                    ?person :name "Alice" ~ :t {| :statedBy ?authority ; :recorded "2021-07-07"^^xsd:date |} .
+                    ?person :name "Alice" {| :statedBy ?authority ; :recorded "2021-07-07"^^xsd:date |} .
                 }
           </pre>
           <p>An <a href="#rAnnotation"><code>Annotation</code></a>
@@ -1611,7 +1595,7 @@ _:b0  :p        "v" .
                 PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
           
                 SELECT ?person {
-                    ?person :name "Alice" ~ :stmt1 ~ stmt2 .
+                    ?person :name "Alice" ~ :stmt1 ~ :stmt2 .
                 }
           </pre>
           <p>The query above will be fully expanded to the query below.</p>
@@ -1624,6 +1608,33 @@ _:b0  :p        "v" .
                     ?person :name "Alice" .
                     :stmt1 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
                     :stmt2 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
+                }
+          </pre>
+          <p>The annotation syntax could also contain multiple explicit
+            <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifiers</a> with annotation blocks, as shown in the example below.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person {
+                    ?person :name "Alice"
+                      ~ :stmt1 {| :statedBy ?authority1 |}
+                      ~ :stmt2 {| :statedBy ?authority2 |} .
+                }
+          </pre>
+          <p>The query above will be fully expanded to the query below.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person {
+                    ?person :name "Alice" .
+                    :stmt1 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
+                    :stmt1 :statedBy ?authority1 .
+                    :stmt2 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
+                    :stmt2 :statedBy ?authority2 .
                 }
           </pre>
         </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1419,7 +1419,8 @@ _:b0  :p        "v" .
                     &lt;&lt; ?person :jobTitle "Designer" &gt;&gt; :accordingTo ?authority .
                 }
           </pre>
-          <p>The syntactic sugar of the example above expands to the following query:</p>
+          <p>The syntactic sugar of the example above expands to the following query,
+            in which `_:id` represents a fresh blank node that is not used anywhere else in the query (and every such expansion has to use a different fresh blank node).</p>
           <pre class="query nohighlight">
                 VERSION "1.2"
                 PREFIX : &lt;http://example/&gt;
@@ -1431,17 +1432,11 @@ _:b0  :p        "v" .
                     _:id :accordingTo ?authority .
                 }
           </pre>
-          <p>This shorthand notation for matching reifying triples
+          <p>The shorthand notation for matching reifying triples
             also allows the <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>
             of these reifying triples to be matched. This is done by placing
-            a variable, IRI, or blank node after a tilde (<code title="tilde">~</code>).
-            As shown in the example above; if no reifier is explicitly mentioned,
-            then a new blank node is minted for as reifier within the scope of this query.
-          </p>
-          <p class="note"><a href="#rReifiedTriple"><code>ReifiedTriple</code>'s</a> may be nested,
-            like
-            <br/>`&lt;&lt; ?subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~ :IRIREF1 &gt;&gt;`<br/>
-            or <br/>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 ?object3 ~ :IRIREF3 &gt;&gt; &gt;&gt;`.
+            an IRI, a variable, or a blank node after a tilde (<code title="tilde">~</code>),
+            as demonstrated by the following query.
           </p>
           <p>The example below matches reifying triples with a variable to match the reifier.</p>
           <pre class="query nohighlight">
@@ -1466,15 +1461,26 @@ _:b0  :p        "v" .
                     ?id :accordingTo ?authority .
                 }
           </pre>
+          <p class="note">The grammar production for this shorthand notation,
+            <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>,
+            permits nesting.
+            For instance, it is possible to write
+            <br/>`&lt;&lt; ?subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~ :IRIREF1 &gt;&gt;`<br/>
+            and <br/>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 ?object3 ~ :IRIREF3 &gt;&gt; &gt;&gt;`<br/>
+            in which cases the expansion is applied recursively.
+          </p>
           <p class="note">Note the subtle difference in syntax between the syntactic sugar of
-            the <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> (i.e., `&lt;&lt; ... >>`)
-            and the regular <a href="#rTripleTerm"><code>TripleTerm</code></a> (i.e., `&lt;&lt;( ... )>>`).</p>
+            the <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> rule (i.e., `&lt;&lt; ... >>`)
+            and the regular <a href="#rTripleTerm"><code>TripleTerm</code></a> rule (i.e., `&lt;&lt;( ... )>>`).</p>
         </section>
         <section id="syntaxAnnotation">
           <h3>Annotation Syntax</h3>
-          <p>SPARQL also defines <dfn data-lt="annotation-syntax">annotation syntax</dfn>
-            as a shortcut form for matching both reified and asserted triples with a
-            <a href="#defn_TriplePattern">triple pattern</a>.
+          <p>SPARQL also defines the so-called <dfn data-lt="annotation-syntax">annotation syntax</dfn>,
+            which is a shorthand notation for matching the combination of
+            a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a>
+            together with an <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triple</a>
+            that corresponds to the <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
+            of the reifying triple.
             An annotation can be used to simultaneously match an asserted triple,
             via an explicit or implicit identifier,
             and have that triple pattern be the

--- a/spec/index.html
+++ b/spec/index.html
@@ -1482,17 +1482,34 @@ _:b0  :p        "v" .
             that corresponds to the <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
             of the reifying triple.
             An annotation can be used to simultaneously match an asserted triple,
-            via an explicit or implicit identifier,
             and have that triple pattern be the
             <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
             <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of further triple patterns.
-            If explicitly identified, the same <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> can then be used as the
-            <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
-            <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of additional
-            triple patterns and/or <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>.
           </p>
+          <p>The example below shows an annotated triple pattern.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person ?authority {
+                    ?person :name "Alice" {| :statedBy ?authority ; :recorded "2021-07-07"^^xsd:date |} .
+                }
+          </pre>
+          <p>The syntactic sugar of the example above expands to the following query.</p>
+          <pre class="query nohighlight">
+                VERSION "1.2"
+                PREFIX : &lt;http://example/&gt;
+                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
+          
+                SELECT ?person ?authority {
+                    ?person :name "Alice" .
+                    &lt;&lt; ?person :name "Alice" &gt;&gt; :statedBy ?authority ;
+                                                :recorded "2021-07-07"^^xsd:date .
+                }
+          </pre>
           <p>Like a <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>,
-            the annotation syntax uses a <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> — written as either a
+            the annotation syntax can also use a <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> — written as either a
             <a href="#rVar">variable</a>, an <a href="#riri">IRI</a>, or a <a href="#rBlankNode">blank node</a>,
             preceded by a tilde (<code title="tilde">~</code>) —
             to identify the
@@ -1504,6 +1521,10 @@ _:b0  :p        "v" .
             reifying triple to be produced.
           </p>
           <p>A <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> can be followed by an annotation block.
+            This <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> can be used as the
+            <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
+            <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of additional
+            triple patterns and/or <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>.
             If a <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a> is not followed by an annotation block, it is treated
             analogously to a
             <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
@@ -1534,10 +1555,10 @@ _:b0  :p        "v" .
                 SELECT ?person ?authority {
                     ?person :name "Alice" .
                     &lt;&lt; ?person :name "Alice" ~ :t &gt;&gt; :statedBy ?authority ;
-                                                    :recorded "2021-07-07"^^xsd:date .
+                                                     :recorded "2021-07-07"^^xsd:date .
                 }
           </pre>
-          <p>If we fully expand this query to use <a href="#rTripleTerm"><code>TripleTerm</code>'s</a> instead of reifiers,
+          <p>If we fully expand this query to not use the shorthand for matching reifying triples,
           the query is expanded to the following:</p>
           <pre class="query nohighlight">
                 VERSION "1.2"
@@ -1551,17 +1572,7 @@ _:b0  :p        "v" .
                     :t :recorded "2021-07-07"^^xsd:date .
                 }
           </pre>
-          <p>The example below shows an annotated triple pattern with an implicit reifier, for which a fresh blank node is allocated.</p>
-          <pre class="query nohighlight">
-                VERSION "1.2"
-                PREFIX : &lt;http://example/&gt;
-                PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
-          
-                SELECT ?person ?authority {
-                    ?person :name "Alice" {| :statedBy ?authority ; :recorded "2021-07-07"^^xsd:date |} .
-                }
-          </pre>
-          <p>An <a href="#rAnnotation"><code>Annotation</code></a>
+          <p>An annotation
             may include any number of annotation blocks. If such blocks are not
             immediately preceded by explicit <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifiers</a>, each block is associated
             with a fresh blank node allocated as its <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>, as seen in the example below.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1402,12 +1402,12 @@ _:b0  :p        "v" .
         <p><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple terms</a> are mostly used
           as the <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of a <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>
           with a <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a> of `rdf:reifies`.
-          Such a triple is called a <dfn data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</dfn>.
-          SPARQL also provides a shorthand notation for writing <a>reifying triples</a>
+          Such a triple is called a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a>.
+          SPARQL also provides a shorthand notation for writing <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a>
           using the <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> grammar production.</p>
         </p>
         <p>A <a href="#rReifiedTriple"><code>ReifiedTriple</code></a>
-          provides syntactic sugar to represent a <a>reifying triple</a>,
+          provides syntactic sugar to represent a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a>,
           which defines a specific relationship between an
           identifier (<dfn data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</dfn>)
           and a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
@@ -1422,7 +1422,7 @@ _:b0  :p        "v" .
           RDF 1.2 and SPARQL 1.2 uses the term to identify a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
           using the `rdf:reifies` predicate.
         </p>
-        <p>A <a>reifying triple</a> is represented using the
+        <p>A <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a> is represented using the
           <a href="#rReifiedTriple"><code>ReifiedTriple</code></a> production
           starting with <code>&lt;&lt;</code>,
           followed by a <a href="#rReifiedTripleSubject"><code>ReifiedTripleSubject</code></a>,

--- a/spec/index.html
+++ b/spec/index.html
@@ -1369,21 +1369,19 @@ _:b0  :p        "v" .
           </pre>
         </section>
       </section>
-      <section id="syntaxTripleTerms">
-        <h3>Triple Terms</h3>
-        <p>Within the object position of a <a href="#defn_TriplePattern">triple pattern</a>,
-          we can use a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
-          or another <a href="#defn_TriplePattern">triple pattern</a>.
+      <section id="syntaxNestedTriplePatterns">
+        <h3>Nested Triple Patterns</h3>
+        <p> <a href="#defn_TriplePattern">Triple patterns</a> can be nested, as their subject or object can be
+          another <a href="#defn_TriplePattern">triple patterns</a>.
+          These nested triple patterns are meant to match triples that contain <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>.
         </p>
-        <p>Such a <a href="#defn_TriplePattern">triple pattern</a> or nested <a href="#defn_TriplePattern">triple pattern</a>
+        <p>Such a nested <a href="#defn_TriplePattern">triple pattern</a>
           is represented as a <a href="#rTripleTerm"><code>TripleTerm</code></a> with
           <a href="#rTripleTermSubject"><code>TripleTermSubject</code></a>,
           <a href="#rVerb"><code>Verb</code></a>, and
           <a href="#rTripleTermObject"><code>TripleTermObject</code></a>, all
           preceded by <code>&lt;&lt;(</code>, and
           followed by <code>)&gt;&gt;</code>.
-          Note that <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> and <a href="#defn_TriplePattern">triple patterns</a>
-          can be nested.
         </p>
         <p>The example below shows how a <a href="#defn_TriplePattern">triple pattern</a>
           can be used in the object position of another <a href="#defn_TriplePattern">triple pattern</a>.</p>
@@ -13297,7 +13295,7 @@ _:x rdf:type xsd:decimal .
             <ul>
                 <li>Update grammar for triple terms, reifiers, reified triples, annotation syntax, and triple term functions
                   in <a href="#sparqlGrammar" class="sectionRef"></a> and explain them
-                  in <a href="#syntaxTripleTerms" class="sectionRef"></a>
+                  in <a href="#syntaxNestedTriplePatterns" class="sectionRef"></a>
                   and <a href="#syntaxReifyingTriples" class="sectionRef"></a></li>
                 <li>Add functions related to <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> to
                   <a href="#func-triple-terms" class="sectionRef"></a>:

--- a/spec/index.html
+++ b/spec/index.html
@@ -1491,7 +1491,7 @@ _:b0  :p        "v" .
           <p>SPARQL also defines <dfn data-lt="annotation-syntax">annotation syntax</dfn>
             as a shortcut form for matching both reified and asserted triples with a
             <a href="#defn_TriplePattern">triple pattern</a>.
-            An annotation can be used to simultaneously assert a triple pattern,
+            An annotation can be used to simultaneously match an asserted triple,
             via an explicit or implicit identifier,
             and have that triple pattern be the
             <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or

--- a/spec/index.html
+++ b/spec/index.html
@@ -1426,7 +1426,7 @@ _:b0  :p        "v" .
                 PREFIX : &lt;http://example/&gt;
                 PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
   
-                SELECT ?person ?authority ?id {
+                SELECT ?person ?authority {
                     ?person :familyName "Smith" .
                     _:id rdf:reifies &lt;&lt;( ?person :jobTitle "Designer" )&gt;&gt; .
                     _:id :accordingTo ?authority .
@@ -1496,7 +1496,7 @@ _:b0  :p        "v" .
                     ?person :name "Alice" {| :statedBy ?authority ; :recorded "2021-07-07"^^xsd:date |} .
                 }
           </pre>
-          <p>The syntactic sugar of the example above expands to the following query.</p>
+          <p>The annotation syntax used in the previous query expands as illustrated in the following query.</p>
           <pre class="query nohighlight">
                 VERSION "1.2"
                 PREFIX : &lt;http://example/&gt;
@@ -1631,7 +1631,7 @@ _:b0  :p        "v" .
                 PREFIX : &lt;http://example/&gt;
                 PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
           
-                SELECT ?person {
+                SELECT ?person ?authority1 ?authority2 {
                     ?person :name "Alice"
                       ~ :stmt1 {| :statedBy ?authority1 |}
                       ~ :stmt2 {| :statedBy ?authority2 |} .
@@ -1643,7 +1643,7 @@ _:b0  :p        "v" .
                 PREFIX : &lt;http://example/&gt;
                 PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
           
-                SELECT ?person {
+                SELECT ?person ?authority1 ?authority2 {
                     ?person :name "Alice" .
                     :stmt1 rdf:reifies &lt;&lt;( ?person :name "Alice" )&gt;&gt; .
                     :stmt1 :statedBy ?authority1 .


### PR DESCRIPTION
The text and structure of these new sections are mostly based on the text in the Turtle 1.2 spec, with the necessary changes to the interpretation, grammar, and examples.

Closes #176
Closes #398


One discussion point I want to raise here (which I did not incorporate yet into this PR), is the following:
Similar to how a "Triple Term" is a "Triple" that can be placed in the object position, do we need a concept "Triple Term Pattern" to refer to a "Triple Pattern" that can be placed in the object position? IMO, the text in this PR works without such a concept, but perhaps someone else has a different view on it. If we do this, we may also have to do this for Reifying Triple (Patterns). We may also consider grammar renames for this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/400.html" title="Last updated on Sep 10, 2026, 4:16 PM UTC (d34eee0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/400/48bbc1f...d34eee0.html" title="Last updated on Sep 10, 2026, 4:16 PM UTC (d34eee0)">Diff</a>