### PR TITLE
Fix wording in SPARQL base direction explanation

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -704,7 +704,7 @@ PREFIX xsd:  &lt;http://www.w3.org/2001/XMLSchema#&gt;
           <p>
             SPARQL also supports matching a given
             <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.
-            Like Turtle, it is written following the language tag, for example,
+            As in Turtle, it is written following the language tag, for example,
             <code>@en--ltr</code>.
             The base direction is restricted to either `ltr` or `rtl`.
             Unlike a language tag, it is always lower case.


### PR DESCRIPTION
"Like Turtle" -> "As in Turtle"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/sparql-query/pull/401.html" title="Last updated on Jun 24, 2026, 7:26 PM UTC (0972350)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/401/da3537b...TallTed:0972350.html" title="Last updated on Jun 24, 2026, 7:26 PM UTC (0972350)">Diff</a>