### PR TITLE
Link to 'active graph' defn

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -3184,8 +3184,9 @@ WHERE {
       <p>An RDF Dataset may contain zero named graphs; an RDF Dataset always contains one default
         graph. A query does not need to involve matching the default graph; the query can just involve
         matching named graphs.</p>
-      <p>The graph that is used for matching a basic graph pattern is the <i>active graph</i>. In the
-        previous sections, all queries have been shown executed against a single graph, the default
+      <p>The graph that is used for matching a basic graph pattern is the 
+        <a href="#defn_ActiveGraph">active graph</a>. 
+        In the previous sections, all queries have been shown executed against a single graph, the default
         graph of an RDF dataset as the active graph. The <code>GRAPH</code> keyword is used to make the
         active graph one of all of the named graphs in the dataset for part of the query.</p>
       <section id="exampleDatasets">


### PR DESCRIPTION
Change `<i>active graph</i>` to `<a href="#defn_ActiveGraph">active graph</a>`.

Rewrap.

No content changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/405.html" title="Last updated on Jul 5, 2026, 2:46 PM UTC (268ce5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/405/2b9c74e...268ce5c.html" title="Last updated on Jul 5, 2026, 2:46 PM UTC (268ce5c)">Diff</a>