### PR TITLE
Vocabulary: classify logical-not and ebv as functions

### DIFF
--- a/sparql-ns.ttl
+++ b/sparql-ns.ttl
@@ -122,7 +122,7 @@ sparql:logical-not rdf:type sparql:Function ;
     .
 
 sparql:ebv rdf:type sparql:Function ;
-    rdfs:comment "This form computes the effective boolean value." ;
+    rdfs:comment "This function computes the effective boolean value." ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/#func-ebv> ;
     .
 

--- a/sparql-ns.ttl
+++ b/sparql-ns.ttl
@@ -117,7 +117,7 @@ sparql:logical-and rdf:type sparql:FunctionalForm ;
     .
 
 sparql:logical-not rdf:type sparql:Function ;
-    rdfs:comment "This form computes the logical NOT of a boolean expression." ;
+    rdfs:comment "This function computes the logical NOT of a boolean expression." ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/#func-logical-not> ;
     .
 

--- a/sparql-ns.ttl
+++ b/sparql-ns.ttl
@@ -116,12 +116,12 @@ sparql:logical-and rdf:type sparql:FunctionalForm ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/#func-logical-and> ;
     .
 
-sparql:logical-not rdf:type sparql:FunctionalForm ;
+sparql:logical-not rdf:type sparql:Function ;
     rdfs:comment "This form computes the logical NOT of a boolean expression." ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/#func-logical-not> ;
     .
 
-sparql:ebv rdf:type sparql:FunctionalForm ;
+sparql:ebv rdf:type sparql:Function ;
     rdfs:comment "This form computes the effective boolean value." ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/#func-ebv> ;
     .


### PR DESCRIPTION
They both take for input an RDF term and return an RDF term or an error. Errors from the argument are propagated, just like other functions