### PR TITLE
Vocabulary: Remove `-distinct` variant of aggregation functions

### DIFF
--- a/sparql-ns.ttl
+++ b/sparql-ns.ttl
@@ -457,18 +457,8 @@ sparql:agg-count rdf:type sparql:Aggregate ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
     .
 
-sparql:agg-count-distinct rdf:type sparql:Aggregate ;
-    rdfs:comment "Aggregate function COUNT with DISTINCT" ;
-    rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
-    .
-
 sparql:agg-sum rdf:type sparql:Aggregate ;
     rdfs:comment "Aggregate function SUM" ;
-    rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
-    .
-
-sparql:agg-sum-distinct rdf:type sparql:Aggregate ;
-    rdfs:comment "Aggregate function SUM with DISTINCT" ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
     .
 
@@ -477,18 +467,8 @@ sparql:agg-min rdf:type sparql:Aggregate ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
     .
 
-sparql:agg-min-distinct rdf:type sparql:Aggregate ;
-    rdfs:comment "Aggregate function MIN with DISTINCT" ;
-    rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
-    .
-
 sparql:agg-max rdf:type sparql:Aggregate ;
     rdfs:comment "Aggregate function MAX" ;
-    rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
-    .
-
-sparql:agg-max-distinct rdf:type sparql:Aggregate ;
-    rdfs:comment "Aggregate function MAX with DISTINCT" ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
     .
 
@@ -497,28 +477,13 @@ sparql:agg-avg rdf:type sparql:Aggregate ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
     .
 
-sparql:agg-avg-distinct rdf:type sparql:Aggregate ;
-    rdfs:comment "Aggregate function AVG with DISTINCT" ;
-    rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
-    .
-
 sparql:agg-sample rdf:type sparql:Aggregate ;
     rdfs:comment "Aggregate function SAMPLE" ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
     .
 
-sparql:agg-sample-distinct rdf:type sparql:Aggregate ;
-    rdfs:comment "Aggregate function SAMPLE with DISTINCT" ;
-    rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
-    .
-
 sparql:agg-group-concat rdf:type sparql:Aggregate ;
     rdfs:comment "Aggregate function GROUP_CONCAT" ;
-    rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
-    .
-
-sparql:agg-group-concat-distinct rdf:type sparql:Aggregate ;
-    rdfs:comment "Aggregate function GROUP_CONCAT with DISTINCT" ;
     rdfs:isDefinedBy <http://www.w3.org/TR/sparql12-query/> ;
     .
 


### PR DESCRIPTION
Rational: DISTINCT is an operation done before invoking an aggregation function and is not part of it

Close #407 (see this issue for details)