### PR TITLE
Document variable occurrence within nested triple patterns

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9091,6 +9091,8 @@ WHERE {
               </tr>
             </tbody>
           </table>
+          <p>Variable occurrence within BGPs and paths include occurrences within nested triple patterns.
+          </p>
           <p>The variable `v` must not be in-scope at the point of the
             `(expr AS v)` form. The scoping for `(expr AS v)`
             applies immediately in `SELECT` expressions.

--- a/spec/index.html
+++ b/spec/index.html
@@ -9091,7 +9091,7 @@ WHERE {
               </tr>
             </tbody>
           </table>
-          <p>Variable occurrence within BGPs and paths include occurrences within nested triple patterns.
+          <p>Variable occurrence within BGPs and paths includes variables that occur within nested triple patterns.
           </p>
           <p>The variable `v` must not be in-scope at the point of the
             `(expr AS v)` form. The scoping for `(expr AS v)`


### PR DESCRIPTION
This explicitly mentions that variable scoping in BGPs and paths includes triple patterns.

I initially tried to add the text within the table itself, but this made the table (which was very compact at the moment) quite wide. So I added a new line below it instead.

Required for #53


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/pull/416.html" title="Last updated on Aug 26, 2026, 7:53 AM UTC (98fe963)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-query/416/50868ca...98fe963.html" title="Last updated on Aug 26, 2026, 7:53 AM UTC (98fe963)">Diff</a>