### PR TITLE
Revise SPARQL 1.2 Query Language changes section

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -13060,112 +13060,130 @@ _:x rdf:type xsd:decimal .
     <section id="changes-1-1" class="appendix informative">
       <h2>Changes between SPARQL 1.1 Query Language and SPARQL 1.2 Query Language</h2>
       <ul>
-        <li>
-            Normative changes:
+        <li>Normative changes:
             <ul>
                 <li>Update grammar for triple terms, reifiers, reified triples, annotation syntax, and triple term functions
-                  in <a href="#sparqlGrammar" class="sectionRef"></a></li>
+                  in <a href="#sparqlGrammar" class="sectionRef"></a>.</li>
                 <li>Add functions related to <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> to
                   <a href="#func-triple-terms" class="sectionRef"></a>:
-                  `TRIPLE`, `isTRIPLE`, `SUBJECT`, `PREDICATE`, `OBJECT`</li>
-                <li>Update grammar for literal <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a> syntax</li>
-                <li>Update grammar for VERSION declaration and a <a href="#syntaxVersionAnnouncement" class="sectionRef">new section</a> to describe its usage</li>
+                  `TRIPLE`, `isTRIPLE`, `SUBJECT`, `PREDICATE`, `OBJECT`.</li>
+                <li>Update grammar for literal <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a> syntax.</li>
+                <li>Update grammar for `VERSION` declaration and a <a href="#syntaxVersionAnnouncement" class="sectionRef">new 
+                  section</a> to describe its use.</li>
                 <li>Add functions related to 
                   <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> and
                   <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>:
-                  `LANGDIR`, `hasLANG`, hasLANGDIR, and `STRLANGDIR`</li>
+                  `LANGDIR`, `hasLANG`, `hasLANGDIR`, and `STRLANGDIR`.</li>
                 <li>Define parser input as being an 
-                  <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a>. 
-                  Exclude Unicode surrogates from Unicode escape sequences</li>
-                <li>Remove concepts of plain and simple literals, in favor of explicit mentions of `xsd:string`</li>
+                  <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a>.</li>
+                <li>Exclude Unicode surrogates from Unicode escape sequences.</li>
+                <li>Remove concepts of plain and simple literals, in favor of explicit mentions of `xsd:string`.</li>
                 <li>Migrate XML Schema references to 1.1. 
-                Note that for datatypes involving years, the year 1 BCE is represented by `0000` and not as `-0001`.
-                See the note about the
-                <a data-cite="XMLSCHEMA11-2#dateTime-value-space">date/timeSevenPropertyModel</a>
-                for details.
-                </li>
-                <li>Update references to XPath from 2.0 to 3.1</li>
-                <li>Define `EBV` as a functional form</li>
-                <li>Forbid duplicated variables in `VALUES`</li>
-                <li>Add in-between term type ORDER BY support for triple terms in <a href="#modOrderBy" class="sectionRef"></a></li>
-                <li>Fixes the previously informal definition of `EXISTS` by adding a formal definition in <a href="#func-filter-exists" class="sectionRef"></a>, which includes extending the <a href="#defn_eval" class="evalFct">eval</a> function with a solution mapping <var>μ<sub>ctx</sub></var> as third argument</li>
+                  Note that for datatypes involving years, the year 1 BCE is represented by `0000` and not as `-0001`.
+                  See the note about the
+                  <a data-cite="XMLSCHEMA11-2#dateTime-value-space">date/timeSevenPropertyModel</a>
+                  for details.</li>
+                <li>Update references to XPath from 2.0 to 3.1.</li>
+                <li>Define `EBV` as a functional form.</li>
+                <li>Forbid duplicated variables in `VALUES`.</li>
+                <li>Add in-between term type `ORDER BY` support for triple terms in <a href="#modOrderBy" class="sectionRef"></a>.</li>
+                <li>Fix the previously informal definition of `EXISTS` by adding a formal definition in 
+                  <a href="#func-filter-exists" class="sectionRef"></a>, which includes extending the
+                  <a href="#defn_eval" class="evalFct">`eval`</a> function with a solution mapping <var>μ<sub>ctx</sub></var>
+                  as a third argument.</li>
                 <li>Rename function `RDFterm-equal` as <a href="#func-sameValue"></a> and
                   expand the definition to cover literal arguments of differing datatypes where the
-                  values are known to be equal or to be not equal</li>
-                <li>Expand the restriction on the use of `*` projection on queries that have implicit grouping</li>
-                <li>
-                  Escape sequence processing has been changed to be processed during parsing, not before. 
+                  values are known to be equal or not equal.</li>
+                <li>Expand the restriction on the use of `*` projection on queries that have implicit grouping.</li>
+                <li>Change escape sequence processing to be processed during parsing, not before. 
                   This aligns SPARQL with 
                   <a data-cite="RDF12-TURTLE#sec-escapes">escape sequences in Turtle</a>.
                 </li>
             </ul>
         </li>
-        <li>
-            Editorial changes:
+        <li>Editorial changes:
             <ul>
-                <li>Give an actual function signature to <a href="#func-sameValue" class="sectionRef"></a></li>
-                <li>Improve wording of blank nodes in <a href="#templatesWithBNodes" class="sectionRef"></a></li>
-                <li>Improve display on mobile</li>
-                <li>Move `sameValue` (was `RDFterm-equal`) and `sameTerm` to <a href="#func-rdfTerms" class="sectionRef"></a></li>
-                <li>Add note on deduplication of triples produced by CONSTRUCT to <a href="#construct" class="sectionRef"></a></li>
-                <li>Remove historical notes on rdf:langString datatype from <a href="#func-datatype" class="sectionRef"></a></li>
-                <li>Remove inconsistencies between the definitions of the set functions</li>
-                <li>Introduce a function called multiplicity to replace card[Ω](μ) in <a href="#BasicGraphPattern" class="sectionRef"></a></li>
-                <li>Update to Media Type language instead of MIME Type language</li>
-                <li>Clarify that aggregation returns a single partial function in <a href="#sparqlGroupAggregate" class="sectionRef"></a></li>
-                <li>Update Filter Evaluation language to reference more functional forms in <a href="#expression-evaluation" class="sectionRef"></a></li>
-                <li>Use PREFIX instead of @prefix</li>
-                <li>More accurate definition of the <a href="#defn_algSlice" class="algFct">Slice</a> algebra operator</li>
-                <li>Clarify definition of the Sum set function in <a href="#aggSum" class="sectionRef"></a></li>
-                <li>Improve definition of Group operator in <a href="#aggregateAlgebra" class="sectionRef"></a></li>
-                <li>Move definitions of Flatten and Card to <a href="#setFunctions" class="sectionRef"></a></li>
-                <li>Improve definitions in <a href="#initDefinitions" class="sectionRef"></a></li>
-                <li>Fix algorithm for translation SELECT expressions <a href="#sparqlSelectExpressions" class="sectionRef"></a></li>
-                <li>Clarify the use of ToList in algebra expressions in <a href="#translation" class="sectionRef"></a></li>
+                <li>Give an actual function signature to <a href="#func-sameValue" class="sectionRef"></a>.</li>
+                <li>Improve wording of blank nodes in <a href="#templatesWithBNodes" class="sectionRef"></a>.</li>
+                <li>Improve display on mobile.</li>
+                <li>Move `sameValue` (was `RDFterm-equal`) and `sameTerm` to <a href="#func-rdfTerms" class="sectionRef"></a>.</li>
+                <li>Add note on deduplication of triples produced by `CONSTRUCT` to <a href="#construct" class="sectionRef"></a>.</li>
+                <li>Remove historical notes on `rdf:langString` datatype from <a href="#func-datatype" class="sectionRef"></a>.</li>
+                <li>Remove inconsistencies among the definitions of the set functions.</li>
+                <li>Update to Media Type language instead of MIME Type language.</li>
+                <li>Introduce a function called `multiplicity` to replace `card[Ω](μ)` in <a href="#BasicGraphPattern" class="sectionRef"></a>.</li>
+                <li>Clarify that aggregation returns a single partial function in <a href="#sparqlGroupAggregate" class="sectionRef"></a>.</li>
+                <li>Update Filter Evaluation language to reference more functional forms in <a href="#expression-evaluation" class="sectionRef"></a>.</li>
+                <li>Use `PREFIX` instead of `@prefix`.</li>
+                <li>More accurate definition of the <a href="#defn_algSlice" class="algFct">Slice</a> algebra operator.</li>
+                <li>Clarify definition of the `Sum` set function in <a href="#aggSum" class="sectionRef"></a>.</li>
+                <li>Improve definition of `Group` operator in <a href="#aggregateAlgebra" class="sectionRef"></a>.</li>
+                <li>Move definitions of `Flatten` and `Card` to <a href="#setFunctions" class="sectionRef"></a>.</li>
+                <li>Improve definitions in <a href="#initDefinitions" class="sectionRef"></a>.</li>
+                <li>Fix algorithm for translation `SELECT` expressions <a href="#sparqlSelectExpressions" class="sectionRef"></a>.</li>
+                <li>Clarify the use of ToList in algebra expressions in <a href="#translation" class="sectionRef"></a>.</li>
                 <li>Add an explicit definition of the algebraic syntax
                   (<a href="#algebraicSyntax" class="sectionRef"></a>) into which the AST
                   expressions are translated according to <a href="#translation"
                   class="sectionRef"></a>, and mark up all mentions of symbols of this
                   syntax as links to their respective definition; similarly, mark up all
                   mentions of operators of the <a href="#sparqlAlgebra">SPARQL algebra</a>
-                  as links to their respective definition</li>
+                  as links to their respective definition.</li>
                 <li>Rename the function used to define the evaluation of property path expressions
                   in <a href="#PropertyPathPatterns" class="sectionRef"></a>
-                  from <i>eval</i> to <i>ppeval</i></li>
+                  from <i>eval</i> to <i>ppeval</i>.</li>
                 <li>Rename the function used within the definition of
                   the <a href="#defn_evalALP">ALP</a> function
-                  from <i>eval</i> to <i>reachableTerms</i></li>
-                <li>Add section <a href="#sparql-error" class="sectionRef"></a> about SPARQL expression evaluation errors</li>
-                <li>Rename section "Filter evaluation" as <a href="#expression-evaluation" class="sectionRef"></a></li>
+                  from <i>eval</i> to <i>reachableTerms</i>.</li>
+                <li>Add section <a href="#sparql-error" class="sectionRef"></a> about SPARQL expression evaluation errors.</li>
+                <li>Rename section "Filter evaluation" as <a href="#expression-evaluation" class="sectionRef"></a>.</li>
                 <li>Improve definitions of all algebra operators that involve expressions
                   (<a href="#defn_algFilter" class="algFct">Filter</a>, <a href="#defn_algDiff" class="algFct">Diff</a>,
-                  <a href="#defn_algLeftJoin" class="algFct">LeftJoin</a>, and <a href="#defn_algExtend" class="algFct">Extend</a>)</li>
+                  <a href="#defn_algLeftJoin" class="algFct">LeftJoin</a>, and <a href="#defn_algExtend" class="algFct">Extend</a>).</li>
             </ul>
         </li>
-        <li>
-            Errata:
+        <li>Errata:
             <ul>
-              <li><a href="https://www.w3.org/2013/sparql-errata#editorial-query-1">editorial-query-1</a>: Missing right parenthesis in <a href="#defn_evalGraph">Evaluation of Graph definition</a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#editorial-query-2">editorial-query-2</a>: Missing space in <a href="#defn_algJoin">Join definition</a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#editorial-query-3">editorial-query-3</a>: Incorrect link for DELETE DATA in <a href="#grammarBNodes" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-1">clarification-query-1</a>: Fix explanation of IN and NOT IN in <a href="#func-in" class="sectionRef"></a> and <a href="#func-not-in" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-2">clarification-query-2</a>: Remove unneeded reference to the semantics above in <a href="#operatorExtensibility"
-class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-3">clarification-query-3</a>: Rephrase equality definition in <a href="#func-sameValue" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-1">errata-query-1</a>: Let V be an empty set instead of empty multiset in <a href="#defn_evalALP">Function ALP definition</a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-2">errata-query-2</a>: Fix grammar of PropertyListPathNotEmpty in <a href="#grammar" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-4">errata-query-4</a>: Fix CONCAT definition for zero and one argument in <a href="#func-concat" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-5">errata-query-5</a>: Mention illegal nesting of aggregates in <a href="#sparqlGrammar" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-7">errata-query-7</a> and <a href="https://www.w3.org/2013/sparql-errata#errata-query-7a">errata-query-7a</a>: Remove incorrect full example <a href="#defn_algLeftJoin">LeftJoin definition</a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-9">errata-query-9</a>: Fix examples in <a href="#sparqlAlgebraExamples" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-11">errata-query-11</a>: Rename group variable in <a href="#sparqlGroupAggregate" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-12">errata-query-12</a>: Clarify definition of Diff in <a href="#sparqlAlgebra" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-13">errata-query-13</a>: Fix definition of Project cardinality in <a href="#sparqlAlgebra" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-18">errata-query-18</a>: Fix table in <a href="#sparqlTranslatePathPatterns" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-19">errata-query-19</a>: Fix translation in <a href="#sparqlTranslateGraphPatterns" class="sectionRef"></a></li>
-              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-23">errata-query-23</a>: Fix inconsistenties between <a href="#defn_aggMin">MIN</a> and <a
-href="#defn_aggMax">MAX</a></li>
-              <li>Grammar rule `UnaryExpression` to allow `!!`</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#editorial-query-1">editorial-query-1</a>:
+                Missing right parenthesis in <a href="#defn_evalGraph">Evaluation of Graph definition</a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#editorial-query-2">editorial-query-2</a>:
+                Missing space in <a href="#defn_algJoin">Join definition</a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#editorial-query-3">editorial-query-3</a>:
+                Incorrect link for `DELETE DATA` in <a href="#grammarBNodes" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-1">clarification-query-1</a>:
+                Fix explanation of `IN` and `NOT IN` in <a href="#func-in" class="sectionRef"></a> and
+                <a href="#func-not-in" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-2">clarification-query-2</a>:
+                Remove unneeded reference to the semantics above in
+                <a href="#operatorExtensibility" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#clarification-query-3">clarification-query-3</a>:
+                Rephrase equality definition in <a href="#func-sameValue" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-1">errata-query-1</a>:
+                Let V be an empty set instead of empty multiset in <a href="#defn_evalALP">Function ALP definition</a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-2">errata-query-2</a>:
+                Fix grammar of `PropertyListPathNotEmpty` in <a href="#grammar" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-4">errata-query-4</a>:
+                Fix `CONCAT` definition for zero and one argument in <a href="#func-concat" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-5">errata-query-5</a>:
+                Mention illegal nesting of aggregates in <a href="#sparqlGrammar" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-7">errata-query-7</a> and
+                <a href="https://www.w3.org/2013/sparql-errata#errata-query-7a">errata-query-7a</a>:
+                Remove incorrect full example <a href="#defn_algLeftJoin">LeftJoin definition</a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-9">errata-query-9</a>:
+                Fix examples in <a href="#sparqlAlgebraExamples" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-11">errata-query-11</a>:
+                Rename group variable in <a href="#sparqlGroupAggregate" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-12">errata-query-12</a>:
+                Clarify definition of Diff in <a href="#sparqlAlgebra" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-13">errata-query-13</a>:
+                Fix definition of Project cardinality in <a href="#sparqlAlgebra" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-18">errata-query-18</a>:
+                Fix table in <a href="#sparqlTranslatePathPatterns" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-19">errata-query-19</a>:
+                Fix translation in <a href="#sparqlTranslateGraphPatterns" class="sectionRef"></a>.</li>
+              <li><a href="https://www.w3.org/2013/sparql-errata#errata-query-23">errata-query-23</a>:
+                Fix inconsistencies between <a href="#defn_aggMin">`MIN`</a> and <a href="#defn_aggMax">`MAX`</a>.</li>
+              <li>Grammar rule `UnaryExpression` to allow `!!`.</li>
             </ul>
         </li>
       </ul>


### PR DESCRIPTION
Updated the SPARQL 1.2 Query Language changes section to improve clarity and correctness, including grammar updates and editorial changes.

(Replaces #387.)

(PR creation failed silently last week, when the commit was made. Intent is for this PR to include no tab indents, no CR nor CRLF EOLs, only space indents and LF EOLs.)